### PR TITLE
fix(bedrock): 3 Converse API streaming bugs

### DIFF
--- a/provider/bedrock/bedrock_test.go
+++ b/provider/bedrock/bedrock_test.go
@@ -1379,7 +1379,7 @@ func TestConvertParts_ImageDataURL(t *testing.T) {
 	parts := []provider.Part{
 		{Type: provider.PartImage, URL: "data:image/jpeg;base64,/9j/abc123"},
 	}
-	blocks := convertParts(parts)
+	blocks := convertParts(parts, make(map[string]int))
 	if len(blocks) != 1 {
 		t.Fatalf("blocks = %d, want 1", len(blocks))
 	}
@@ -1400,7 +1400,7 @@ func TestConvertParts_ImageWithMediaType(t *testing.T) {
 	parts := []provider.Part{
 		{Type: provider.PartImage, URL: "data:image/png;base64,iVBOR", MediaType: "image/webp"},
 	}
-	blocks := convertParts(parts)
+	blocks := convertParts(parts, make(map[string]int))
 	img, _ := blocks[0]["image"].(map[string]any)
 	// MediaType should take precedence over data URL format.
 	if img["format"] != "webp" {
@@ -1416,7 +1416,7 @@ func TestConvertParts_Document(t *testing.T) {
 	parts := []provider.Part{
 		{Type: provider.PartFile, URL: "base64data", MediaType: "application/pdf", Filename: "report.pdf"},
 	}
-	blocks := convertParts(parts)
+	blocks := convertParts(parts, make(map[string]int))
 	if len(blocks) != 1 {
 		t.Fatalf("blocks = %d, want 1", len(blocks))
 	}
@@ -2327,7 +2327,7 @@ func TestConvertParts_ReasoningWithSignature(t *testing.T) {
 				"signature": "sig123",
 			},
 		},
-	})
+	}, make(map[string]int))
 	if len(parts) != 1 {
 		t.Fatalf("parts = %d, want 1", len(parts))
 	}
@@ -2350,7 +2350,7 @@ func TestConvertParts_ReasoningRedacted(t *testing.T) {
 				"redactedData": "encrypted123",
 			},
 		},
-	})
+	}, make(map[string]int))
 	if len(parts) != 1 {
 		t.Fatalf("parts = %d, want 1", len(parts))
 	}
@@ -2369,7 +2369,7 @@ func TestConvertParts_ToolCall(t *testing.T) {
 			ToolName:   "search",
 			ToolInput:  []byte(`{"q":"test"}`),
 		},
-	})
+	}, make(map[string]int))
 	if len(parts) != 1 {
 		t.Fatalf("parts = %d", len(parts))
 	}
@@ -2389,7 +2389,7 @@ func TestConvertParts_ToolResult(t *testing.T) {
 			ToolCallID: "tc1",
 			ToolOutput: "result text",
 		},
-	})
+	}, make(map[string]int))
 	if len(parts) != 1 {
 		t.Fatalf("parts = %d", len(parts))
 	}
@@ -2407,7 +2407,7 @@ func TestConvertParts_File(t *testing.T) {
 			MediaType: "text/csv",
 			Filename:  "data.csv",
 		},
-	})
+	}, make(map[string]int))
 	if len(parts) != 1 {
 		t.Fatalf("parts = %d", len(parts))
 	}
@@ -2424,7 +2424,7 @@ func TestConvertParts_FileNoFilename(t *testing.T) {
 			URL:       "base64data",
 			MediaType: "application/pdf",
 		},
-	})
+	}, make(map[string]int))
 	doc := parts[0]["document"].(map[string]any)
 	name := doc["name"].(string)
 	if !strings.HasPrefix(name, "document-") {
@@ -2492,7 +2492,7 @@ func TestConvertParts_CacheControl(t *testing.T) {
 			Text:         "cached text",
 			CacheControl: "ephemeral",
 		},
-	})
+	}, make(map[string]int))
 	if len(parts) != 2 {
 		t.Fatalf("parts = %d, want 2 (text + cachePoint)", len(parts))
 	}
@@ -3190,7 +3190,7 @@ func TestConvertParts_ToolCallNilInput(t *testing.T) {
 			ToolName:   "test",
 			ToolInput:  nil, // nil input
 		},
-	})
+	}, make(map[string]int))
 	tu := parts[0]["toolUse"].(map[string]any)
 	input, ok := tu["input"].(map[string]any)
 	if !ok {

--- a/provider/bedrock/converse.go
+++ b/provider/bedrock/converse.go
@@ -159,10 +159,13 @@ func buildConverseRequest(params provider.GenerateParams, modelID string) map[st
 // Tool-role messages are merged into user role per Bedrock convention.
 func convertMessages(msgs []provider.Message) []map[string]any {
 	var result []map[string]any
+	// Track document names across the conversation for uniqueness.
+	// Bedrock rejects duplicate names; append "-N" suffix when needed.
+	docNames := make(map[string]int)
 
 	for _, msg := range msgs {
 		role := string(msg.Role)
-		content := convertParts(msg.Content)
+		content := convertParts(msg.Content, docNames)
 
 		if len(content) == 0 {
 			continue
@@ -193,7 +196,8 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 }
 
 // convertParts maps provider.Part slice to Bedrock content blocks.
-func convertParts(parts []provider.Part) []map[string]any {
+// docNames tracks document names across the conversation for uniqueness.
+func convertParts(parts []provider.Part, docNames map[string]int) []map[string]any {
 	var blocks []map[string]any
 
 	for _, p := range parts {
@@ -276,8 +280,18 @@ func convertParts(parts []provider.Part) []map[string]any {
 		case provider.PartFile:
 			format := bedrockDocumentFormat(p.MediaType)
 			name := sanitizeDocumentName(p.Filename)
-			// Data may be base64 string or raw bytes depending on caller.
-			data := p.URL // URL field holds the data for file parts.
+			// Bedrock requires unique document names across the conversation.
+			// Append "-N" suffix for duplicates.
+			docNames[name]++
+			if docNames[name] > 1 {
+				name = fmt.Sprintf("%s-%d", name, docNames[name])
+			}
+			// p.URL may be a data URL ("data:mime;base64,...") or raw base64.
+			// Bedrock Converse API expects raw base64 in source.bytes.
+			data := p.URL
+			if idx := strings.Index(data, ";base64,"); idx >= 0 && strings.HasPrefix(data, "data:") {
+				data = data[idx+8:]
+			}
 			blocks = append(blocks, map[string]any{
 				"document": map[string]any{
 					"format": format,
@@ -411,10 +425,13 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 	decoder := newEventStreamDecoder(body)
 
 	// Track content blocks by index to know if a block is text or toolUse.
+	// For tool blocks, accumulate input deltas so the final ChunkToolCall
+	// includes the full tool input (matches openaicompat accumulation pattern).
 	type blockInfo struct {
 		isToolUse  bool
 		toolUseID  string
 		toolName   string
+		inputBuf   strings.Builder // accumulated tool input JSON fragments
 	}
 	blocks := make(map[int]*blockInfo)
 
@@ -484,9 +501,13 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 				}
 				if tu, ok := delta["toolUse"].(map[string]any); ok {
 					bi := blocks[idx]
+					inputFrag := strVal(tu, "input")
+					if bi != nil {
+						bi.inputBuf.WriteString(inputFrag)
+					}
 					chunk := provider.StreamChunk{
 						Type:      provider.ChunkToolCallDelta,
-						ToolInput: strVal(tu, "input"),
+						ToolInput: inputFrag,
 					}
 					if bi != nil {
 						chunk.ToolCallID = bi.toolUseID
@@ -542,6 +563,7 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 					Type:       provider.ChunkToolCall,
 					ToolCallID: bi.toolUseID,
 					ToolName:   bi.toolName,
+					ToolInput:  bi.inputBuf.String(),
 				}) {
 					return
 				}


### PR DESCRIPTION
## Summary
- Document `source.bytes` strip data URL prefix (raw base64 expected)
- Streaming `ChunkToolCall` accumulate tool input deltas (was empty)
- Document name dedup across conversation (append `-N` suffix)

## Test plan
- [x] `go test ./provider/bedrock/` passes
- [x] E2E: TUI with PDF attachment + thinking + tool calls on `bedrock/anthropic.claude-sonnet-4-6`