### PR TITLE
fix(vertex): clear GOOGLE_VERTEX_* env vars in tests

### DIFF
--- a/provider/vertex/vertex_test.go
+++ b/provider/vertex/vertex_test.go
@@ -72,8 +72,10 @@ func TestChat_Generate(t *testing.T) {
 }
 
 func TestNoProject(t *testing.T) {
+	t.Setenv("GOOGLE_VERTEX_PROJECT", "")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
 	t.Setenv("GCLOUD_PROJECT", "")
+	t.Setenv("GOOGLE_VERTEX_LOCATION", "")
 	model := Chat("model", WithTokenSource(provider.StaticToken("tok")))
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
@@ -107,6 +109,7 @@ func TestChat_HTTPError(t *testing.T) {
 }
 
 func TestDefaultLocation(t *testing.T) {
+	t.Setenv("GOOGLE_VERTEX_LOCATION", "")
 	t.Setenv("GOOGLE_CLOUD_LOCATION", "")
 	model := Chat("m", WithTokenSource(provider.StaticToken("tok")), WithProject("proj"))
 	cm := model.(*chatModel)
@@ -244,8 +247,10 @@ func TestDefaultURLWithProject(t *testing.T) {
 	defer server.Close()
 
 	// Use baseURL to point at test server, but verify project/location env fallbacks work.
+	t.Setenv("GOOGLE_VERTEX_PROJECT", "")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
 	t.Setenv("GCLOUD_PROJECT", "my-project")
+	t.Setenv("GOOGLE_VERTEX_LOCATION", "")
 	t.Setenv("GOOGLE_CLOUD_LOCATION", "europe-west4")
 	model := Chat("m", WithTokenSource(provider.StaticToken("tok")), WithBaseURL(server.URL))
 	cm := model.(*chatModel)


### PR DESCRIPTION
Tests for env var fallback chains (`TestNoProject`, `TestDefaultLocation`, `TestDefaultURLWithProject`) only cleared `GOOGLE_CLOUD_*` and `GCLOUD_*` env vars but not the higher-priority `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION` vars.

This causes failures on machines where those vars are set because `resolveOpts` checks `GOOGLE_VERTEX_*` first per the priority chain:

```go
o.project = cmp.Or(o.project, os.Getenv("GOOGLE_VERTEX_PROJECT"), os.Getenv("GOOGLE_CLOUD_PROJECT"), os.Getenv("GCLOUD_PROJECT"))
o.location = cmp.Or(o.location, os.Getenv("GOOGLE_VERTEX_LOCATION"), os.Getenv("GOOGLE_CLOUD_LOCATION"), "us-central1")
```

Fix: add `t.Setenv` for `GOOGLE_VERTEX_*` in all 3 tests to make them hermetic.