### PR TITLE
docs: fix stale content across documentation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -74,7 +74,7 @@ Providers auto-read API keys from env vars. No explicit config needed:
 | --------- | ------------------------------------------------------------ |
 | OpenAI    | `OPENAI_API_KEY`                                             |
 | Anthropic | `ANTHROPIC_API_KEY`                                          |
-| Google    | `GOOGLE_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY`           |
+| Google    | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY`           |
 | Bedrock   | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION` |
 | Azure     | `AZURE_OPENAI_API_KEY`                                       |
 | Vertex AI | Application Default Credentials (ADC)                        |

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -21,11 +21,11 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 
 **Parameters:**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `ctx` | `context.Context` | Request context for cancellation and deadlines. |
-| `model` | `provider.LanguageModel` | The language model to use. |
-| `opts` | `...Option` | Configuration options (system prompt, messages, tools, etc.). |
+| Name    | Type                     | Description                                                   |
+| ------- | ------------------------ | ------------------------------------------------------------- |
+| `ctx`   | `context.Context`        | Request context for cancellation and deadlines.               |
+| `model` | `provider.LanguageModel` | The language model to use.                                    |
+| `opts`  | `...Option`              | Configuration options (system prompt, messages, tools, etc.). |
 
 **Returns:** `*TextResult` containing generated text, tool calls, step history, and usage. Returns an error on API failure or context cancellation.
 
@@ -232,12 +232,12 @@ func Embed(ctx context.Context, model provider.EmbeddingModel, value string, opt
 
 **Parameters:**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `ctx` | `context.Context` | Request context. |
-| `model` | `provider.EmbeddingModel` | The embedding model to use. |
-| `value` | `string` | The text to embed. |
-| `opts` | `...Option` | Options (`WithTimeout`, `WithMaxRetries`, `WithEmbeddingProviderOptions`). |
+| Name    | Type                      | Description                                                                |
+| ------- | ------------------------- | -------------------------------------------------------------------------- |
+| `ctx`   | `context.Context`         | Request context.                                                           |
+| `model` | `provider.EmbeddingModel` | The embedding model to use.                                                |
+| `value` | `string`                  | The text to embed.                                                         |
+| `opts`  | `...Option`               | Options (`WithTimeout`, `WithMaxRetries`, `WithEmbeddingProviderOptions`). |
 
 **Returns:** `*EmbedResult` containing the embedding vector and usage.
 
@@ -265,12 +265,12 @@ func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []stri
 
 **Parameters:**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `ctx` | `context.Context` | Request context. |
-| `model` | `provider.EmbeddingModel` | The embedding model to use. |
-| `values` | `[]string` | The texts to embed. |
-| `opts` | `...Option` | Options (`WithMaxParallelCalls`, `WithTimeout`, `WithMaxRetries`, `WithEmbeddingProviderOptions`). |
+| Name     | Type                      | Description                                                                                        |
+| -------- | ------------------------- | -------------------------------------------------------------------------------------------------- |
+| `ctx`    | `context.Context`         | Request context.                                                                                   |
+| `model`  | `provider.EmbeddingModel` | The embedding model to use.                                                                        |
+| `values` | `[]string`                | The texts to embed.                                                                                |
+| `opts`   | `...Option`               | Options (`WithMaxParallelCalls`, `WithTimeout`, `WithMaxRetries`, `WithEmbeddingProviderOptions`). |
 
 **Returns:** `*EmbedManyResult` containing one embedding vector per input value and aggregated usage.
 
@@ -302,11 +302,11 @@ func GenerateImage(ctx context.Context, model provider.ImageModel, opts ...Image
 
 **Parameters:**
 
-| Name | Type | Description |
-|------|------|-------------|
-| `ctx` | `context.Context` | Request context. |
-| `model` | `provider.ImageModel` | The image model to use. |
-| `opts` | `...ImageOption` | Image-specific options (prompt, count, size, aspect ratio). |
+| Name    | Type                  | Description                                                 |
+| ------- | --------------------- | ----------------------------------------------------------- |
+| `ctx`   | `context.Context`     | Request context.                                            |
+| `model` | `provider.ImageModel` | The image model to use.                                     |
+| `opts`  | `...ImageOption`      | Image-specific options (prompt, count, size, aspect ratio). |
 
 Note: `GenerateImage` uses `ImageOption` instead of `Option`. See the [Options](options.md) page for image-specific options.
 
@@ -391,12 +391,12 @@ func SchemaFrom[T any]() json.RawMessage
 
 **Supported struct tags:**
 
-| Tag | Example | Description |
-|-----|---------|-------------|
-| `json:"name"` | `json:"city"` | Sets the property name in the schema. |
-| `json:"-"` | `json:"-"` | Excludes the field from the schema. |
-| `jsonschema:"description=..."` | `jsonschema:"description=City name"` | Adds a description to the property. |
-| `jsonschema:"enum=a\|b\|c"` | `jsonschema:"enum=easy\|medium\|hard"` | Restricts values to an enum. |
+| Tag                            | Example                                | Description                           |
+| ------------------------------ | -------------------------------------- | ------------------------------------- |
+| `json:"name"`                  | `json:"city"`                          | Sets the property name in the schema. |
+| `json:"-"`                     | `json:"-"`                             | Excludes the field from the schema.   |
+| `jsonschema:"description=..."` | `jsonschema:"description=City name"`   | Adds a description to the property.   |
+| `jsonschema:"enum=a\|b\|c"`    | `jsonschema:"enum=easy\|medium\|hard"` | Restricts values to an enum.          |
 
 **Supported types:** string, bool, int (all sizes), uint (all sizes), float32/64, slices, maps with string keys, structs. Embedded structs are flattened. Pointer types produce nullable schemas (`type: ["<base>", "null"]`).
 
@@ -420,4 +420,4 @@ schema := goai.SchemaFrom[City]()
 
 ## Error Utility Functions
 
-See [Errors](errors.md) for `IsOverflow`, `ParseHTTPError`, `ParseStreamError`, and error type documentation.
+See [Errors](errors.md) for `IsOverflow`, `ParseHTTPError`, `ParseHTTPErrorWithHeaders`, `ParseStreamError`, `ClassifyStreamError`, `ErrUnknownTool`, and error type documentation.

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -31,12 +31,12 @@ type APIError struct {
 
 The following HTTP status codes produce retryable errors:
 
-| Status Code | Meaning |
-|-------------|---------|
-| 429 | Too Many Requests (rate limited) |
-| 503 | Service Unavailable |
-| 500+ | Any server error |
-| 404 (OpenAI only) | Intermittent model availability |
+| Status Code       | Meaning                          |
+| ----------------- | -------------------------------- |
+| 429               | Too Many Requests (rate limited) |
+| 503               | Service Unavailable              |
+| 500+              | Any server error                 |
+| 404 (OpenAI only) | Intermittent model availability  |
 
 GoAI's built-in retry logic (controlled by `WithMaxRetries`, default 2) automatically retries these errors with exponential backoff. Non-retryable errors are returned immediately.
 
@@ -85,17 +85,26 @@ func ParseHTTPError(providerID string, statusCode int, body []byte) error
 
 **Parameters:**
 
-| Name | Type | Description |
-|------|------|-------------|
+| Name         | Type     | Description                                                   |
+| ------------ | -------- | ------------------------------------------------------------- |
 | `providerID` | `string` | Provider identifier (e.g., "openai"). Affects retry behavior. |
-| `statusCode` | `int` | HTTP status code from the response. |
-| `body` | `[]byte` | Raw response body. |
+| `statusCode` | `int`    | HTTP status code from the response.                           |
+| `body`       | `[]byte` | Raw response body.                                            |
 
 **Returns:** `*ContextOverflowError` if the error message matches an overflow pattern, otherwise `*APIError`.
 
 The function extracts human-readable error messages from two common API formats:
+
 - Chat Completions format: `{"error": {"message": "..."}}`
 - Responses API format: `{"message": "...", "code": "...", "type": "..."}`
+
+## ParseHTTPErrorWithHeaders
+
+Like `ParseHTTPError` but preserves retry-related response headers (`Retry-After`, `Retry-After-ms`) on the returned `*APIError`. Used by providers to support header-based backoff.
+
+```go
+func ParseHTTPErrorWithHeaders(providerID string, statusCode int, body []byte, headers http.Header) error
+```
 
 ---
 
@@ -110,22 +119,49 @@ func ParseStreamError(body []byte) *ParsedStreamError
 Returns `nil` if the body does not contain a recognized error event. When non-nil, the `ParsedStreamError` contains:
 
 ```go
+type StreamErrorType string
+
+const (
+    StreamErrorContextOverflow StreamErrorType = "context_overflow"
+    StreamErrorAPI             StreamErrorType = "api_error"
+)
+
 type ParsedStreamError struct {
-    Type         string // "context_overflow" or "api_error".
-    Message      string // Human-readable error message.
-    IsRetryable  bool   // Whether this error can be retried.
-    ResponseBody string // Raw event body.
+    Type         StreamErrorType // "context_overflow" or "api_error".
+    Message      string          // Human-readable error message.
+    IsRetryable  bool            // Whether this error can be retried.
+    ResponseBody string          // Raw event body.
 }
 ```
 
 Recognized stream error codes:
 
-| Code | Type | Retryable |
-|------|------|-----------|
-| `context_length_exceeded` | `context_overflow` | No |
-| `insufficient_quota` | `api_error` | No |
-| `usage_not_included` | `api_error` | No |
-| `invalid_prompt` | `api_error` | No |
+| Code                      | Type               | Retryable |
+| ------------------------- | ------------------ | --------- |
+| `context_length_exceeded` | `context_overflow` | No        |
+| `insufficient_quota`      | `api_error`        | No        |
+| `usage_not_included`      | `api_error`        | No        |
+| `invalid_prompt`          | `api_error`        | No        |
+
+---
+
+## ClassifyStreamError
+
+Higher-level variant of `ParseStreamError` that returns typed errors directly. Returns `*ContextOverflowError` or `*APIError`, or `nil` if the data is not a recognized error event.
+
+```go
+func ClassifyStreamError(body []byte) error
+```
+
+---
+
+## ErrUnknownTool
+
+Sentinel error set on `ToolCallInfo.Error` when a tool call references a tool not in the tool map during auto tool loop execution.
+
+```go
+var ErrUnknownTool = errors.New("goai: unknown tool")
+```
 
 ---
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -91,12 +91,12 @@ func WithToolChoice(tc string) Option
 
 **Values:**
 
-| Value | Behavior |
-|-------|----------|
-| `"auto"` | Model decides whether to use tools (default when tools are present). |
-| `"none"` | Model does not use tools. |
-| `"required"` | Model must use at least one tool. |
-| `"<tool_name>"` | Model must use the specified tool. |
+| Value           | Behavior                                                             |
+| --------------- | -------------------------------------------------------------------- |
+| `"auto"`        | Model decides whether to use tools (default when tools are present). |
+| `"none"`        | Model does not use tools.                                            |
+| `"required"`    | Model must use at least one tool.                                    |
+| `"<tool_name>"` | Model must use the specified tool.                                   |
 
 **Default:** provider-dependent (typically `"auto"` when tools are present).
 
@@ -130,6 +130,46 @@ Controls nucleus sampling. Only tokens with cumulative probability up to `p` are
 
 ```go
 func WithTopP(p float64) Option
+```
+
+**Default:** `nil` (provider default).
+
+### WithTopK
+
+Limits sampling to the top K tokens. Only available with some providers (e.g., Google, Anthropic).
+
+```go
+func WithTopK(k int) Option
+```
+
+**Default:** `nil` (provider default).
+
+### WithFrequencyPenalty
+
+Penalizes tokens based on how frequently they appear in the text so far.
+
+```go
+func WithFrequencyPenalty(p float64) Option
+```
+
+**Default:** `nil` (provider default).
+
+### WithPresencePenalty
+
+Penalizes tokens that have already appeared in the text so far.
+
+```go
+func WithPresencePenalty(p float64) Option
+```
+
+**Default:** `nil` (provider default).
+
+### WithSeed
+
+Sets the seed for deterministic generation. Not all providers support this.
+
+```go
+func WithSeed(s int) Option
 ```
 
 **Default:** `nil` (provider default).

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -49,11 +49,11 @@ type StepResult struct {
 
 A streaming text generation response with three consumption modes.
 
-| Method | Return Type | Description |
-|--------|-------------|-------------|
-| `Stream()` | `<-chan provider.StreamChunk` | Raw stream chunks (all types). |
-| `TextStream()` | `<-chan string` | Text content only. |
-| `Result()` | `*TextResult` | Blocks until complete, returns accumulated result. |
+| Method         | Return Type                   | Description                                        |
+| -------------- | ----------------------------- | -------------------------------------------------- |
+| `Stream()`     | `<-chan provider.StreamChunk` | Raw stream chunks (all types).                     |
+| `TextStream()` | `<-chan string`               | Text content only.                                 |
+| `Result()`     | `*TextResult`                 | Blocks until complete, returns accumulated result. |
 
 `Stream()` and `TextStream()` are mutually exclusive. `Result()` can be called after either.
 
@@ -74,10 +74,10 @@ type ObjectResult[T any] struct {
 
 A streaming structured output response.
 
-| Method | Return Type | Description |
-|--------|-------------|-------------|
-| `PartialObjectStream()` | `<-chan *T` | Emits progressively populated partial objects. |
-| `Result()` | `(*ObjectResult[T], error)` | Blocks until complete, returns final validated object. |
+| Method                  | Return Type                 | Description                                            |
+| ----------------------- | --------------------------- | ------------------------------------------------------ |
+| `PartialObjectStream()` | `<-chan *T`                 | Emits progressively populated partial objects.         |
+| `Result()`              | `(*ObjectResult[T], error)` | Blocks until complete, returns final validated object. |
 
 ### EmbedResult
 
@@ -152,7 +152,6 @@ Passed to the `OnRequest` hook before a generation call.
 
 ```go
 type RequestInfo struct {
-    Provider     string    // Provider identifier (e.g. "openai", "anthropic").
     Model        string    // Model ID.
     MessageCount int       // Number of messages in the request.
     ToolCount    int       // Number of tools available.
@@ -210,8 +209,25 @@ type LanguageModel interface {
     ModelID() string
     DoGenerate(ctx context.Context, params GenerateParams) (*GenerateResult, error)
     DoStream(ctx context.Context, params GenerateParams) (*StreamResult, error)
+}
+```
+
+### CapableModel
+
+Optional interface that `LanguageModel` implementations can satisfy to declare capabilities. Use `ModelCapabilitiesOf` to query safely.
+
+```go
+type CapableModel interface {
     Capabilities() ModelCapabilities
 }
+```
+
+### ModelCapabilitiesOf
+
+Returns the model's capabilities if it implements `CapableModel`, or a zero-value `ModelCapabilities` otherwise.
+
+```go
+func ModelCapabilitiesOf(m LanguageModel) ModelCapabilities
 ```
 
 ### EmbeddingModel
@@ -245,18 +261,22 @@ All parameters for a generation request. Constructed internally by GoAI from opt
 
 ```go
 type GenerateParams struct {
-    Messages        []Message          // Conversation history.
-    System          string             // System prompt.
-    Tools           []ToolDefinition   // Available tools.
-    MaxOutputTokens int                // Response length limit (0 = provider default).
-    Temperature     *float64           // Randomness control (nil = provider default).
-    TopP            *float64           // Nucleus sampling (nil = provider default).
-    StopSequences   []string           // Stop generation when encountered.
-    Headers         map[string]string  // Additional HTTP headers.
-    ProviderOptions map[string]any     // Provider-specific parameters.
-    PromptCaching   bool               // Enable prompt caching.
-    ToolChoice      string             // Tool selection: "auto", "none", "required", or tool name.
-    ResponseFormat  *ResponseFormat    // Structured JSON output schema.
+    Messages         []Message          // Conversation history.
+    System           string             // System prompt.
+    Tools            []ToolDefinition   // Available tools.
+    MaxOutputTokens  int                // Response length limit (0 = provider default).
+    Temperature      *float64           // Randomness control (nil = provider default).
+    TopP             *float64           // Nucleus sampling (nil = provider default).
+    TopK             *int               // Top-K sampling (nil = provider default).
+    FrequencyPenalty *float64           // Frequency penalty (nil = provider default).
+    PresencePenalty  *float64           // Presence penalty (nil = provider default).
+    Seed             *int               // Deterministic generation (nil = provider default).
+    StopSequences    []string           // Stop generation when encountered.
+    Headers          map[string]string  // Additional HTTP headers.
+    ProviderOptions  map[string]any     // Provider-specific parameters.
+    PromptCaching    bool               // Enable prompt caching.
+    ToolChoice       string             // Tool selection: "auto", "none", "required", or tool name.
+    ResponseFormat   *ResponseFormat    // Structured JSON output schema.
 }
 ```
 
@@ -432,9 +452,9 @@ type FinishReason string
 
 const (
     FinishStop          FinishReason = "stop"           // Normal completion.
-    FinishToolCalls     FinishReason = "tool_calls"     // Model wants to call tools.
+    FinishToolCalls     FinishReason = "tool-calls"     // Model wants to call tools.
     FinishLength        FinishReason = "length"         // Hit max output tokens.
-    FinishContentFilter FinishReason = "content_filter" // Content policy triggered.
+    FinishContentFilter FinishReason = "content-filter" // Content policy triggered.
     FinishError         FinishReason = "error"          // Generation error.
     FinishOther         FinishReason = "other"          // Provider-specific reason.
 )
@@ -616,4 +636,12 @@ func CachedTokenSource(fetchFn TokenFetchFunc) TokenSource
 
 ```go
 type TokenFetchFunc func(ctx context.Context) (*Token, error)
+```
+
+### TrySend
+
+Utility for provider implementors. Sends a chunk to a stream channel, returning `false` if the context is cancelled. Prevents goroutine leaks when the consumer stops reading.
+
+```go
+func TrySend(ctx context.Context, out chan<- StreamChunk, chunk StreamChunk) bool
 ```

--- a/docs/concepts/error-handling.md
+++ b/docs/concepts/error-handling.md
@@ -93,8 +93,9 @@ These errors are never retried:
 
 Retries use exponential backoff with jitter:
 
-- Base delay: 1s, 2s, 4s, 8s, ... capped at 30s
+- Base delay: 2s, 4s, 8s, 16s, ... capped at 60s
 - Jitter: 0.5x to 1.5x of the base delay
+- Respects `Retry-After` / `Retry-After-ms` headers when present
 - Respects context cancellation during the wait
 
 ### Disabling retries

--- a/docs/concepts/provider-tools.md
+++ b/docs/concepts/provider-tools.md
@@ -56,18 +56,18 @@ result, err := goai.GenerateText(ctx, model,
 
 Import: `github.com/zendev-sh/goai/provider/anthropic`
 
-| Factory | Description |
-|---------|-------------|
-| `anthropic.Tools.Computer(opts)` | Computer use - screenshot, mouse, keyboard (v20250124) |
-| `anthropic.Tools.Computer_20251124(opts)` | Computer use with zoom support (Opus 4.5+) |
-| `anthropic.Tools.Bash()` | Bash shell execution (v20250124) |
-| `anthropic.Tools.TextEditor()` | Text editor - view, create, replace (v20250429) |
-| `anthropic.Tools.TextEditor_20250728(opts...)` | Text editor with optional maxCharacters (Sonnet 4+) |
-| `anthropic.Tools.WebSearch(opts...)` | Web search via Brave Search (v20250305) |
-| `anthropic.Tools.WebSearch_20260209(opts...)` | Web search (v20260209, requires beta header) |
-| `anthropic.Tools.WebFetch(opts...)` | Fetch web content by URL (v20260209) |
-| `anthropic.Tools.CodeExecution()` | Python code execution in sandbox (v20260120) |
-| `anthropic.Tools.CodeExecution_20250825()` | Code execution (v20250825, requires beta header) |
+| Factory                                        | Description                                            |
+| ---------------------------------------------- | ------------------------------------------------------ |
+| `anthropic.Tools.Computer(opts)`               | Computer use - screenshot, mouse, keyboard (v20250124) |
+| `anthropic.Tools.Computer_20251124(opts)`      | Computer use with zoom support (Opus 4.5+)             |
+| `anthropic.Tools.Bash()`                       | Bash shell execution (v20250124)                       |
+| `anthropic.Tools.TextEditor()`                 | Text editor - view, create, replace (v20250429)        |
+| `anthropic.Tools.TextEditor_20250728(opts...)` | Text editor with optional maxCharacters (Sonnet 4+)    |
+| `anthropic.Tools.WebSearch(opts...)`           | Web search via Brave Search (v20250305)                |
+| `anthropic.Tools.WebSearch_20260209(opts...)`  | Web search (v20260209, requires beta header)           |
+| `anthropic.Tools.WebFetch(opts...)`            | Fetch web content by URL (v20260209)                   |
+| `anthropic.Tools.CodeExecution()`              | Python code execution in sandbox (v20260120)           |
+| `anthropic.Tools.CodeExecution_20250825()`     | Code execution (v20250825, requires beta header)       |
 
 ```go
 // Each factory returns a provider.ToolDefinition. Wrap with goai.Tool{} before passing to WithTools.
@@ -92,11 +92,11 @@ td := anthropic.Tools.CodeExecution()
 
 Import: `github.com/zendev-sh/goai/provider/openai`
 
-| Factory | Description |
-|---------|-------------|
-| `openai.Tools.WebSearch(opts...)` | Web search via Responses API |
-| `openai.Tools.CodeInterpreter(opts...)` | Python code execution in sandbox |
-| `openai.Tools.FileSearch(opts...)` | Semantic search over uploaded files |
+| Factory                                 | Description                           |
+| --------------------------------------- | ------------------------------------- |
+| `openai.Tools.WebSearch(opts...)`       | Web search via Responses API          |
+| `openai.Tools.CodeInterpreter(opts...)` | Python code execution in sandbox      |
+| `openai.Tools.FileSearch(opts...)`      | Semantic search over uploaded files   |
 | `openai.Tools.ImageGeneration(opts...)` | Generate images within a conversation |
 
 ```go
@@ -114,7 +114,7 @@ td := openai.Tools.WebSearch(
 
 // Code interpreter with container
 td := openai.Tools.CodeInterpreter(
-    openai.WithContainer("container-id"),
+    openai.WithContainerID("container-id"),
 )
 
 // File search with vector stores
@@ -134,11 +134,11 @@ td := openai.Tools.ImageGeneration(
 
 Import: `github.com/zendev-sh/goai/provider/google`
 
-| Factory | Description |
-|---------|-------------|
-| `google.Tools.GoogleSearch(opts...)` | Grounding with Google Search |
-| `google.Tools.URLContext()` | Fetch and process web content from URLs |
-| `google.Tools.CodeExecution()` | Python code execution in sandbox |
+| Factory                              | Description                             |
+| ------------------------------------ | --------------------------------------- |
+| `google.Tools.GoogleSearch(opts...)` | Grounding with Google Search            |
+| `google.Tools.URLContext()`          | Fetch and process web content from URLs |
+| `google.Tools.CodeExecution()`       | Python code execution in sandbox        |
 
 ```go
 // Each factory returns a provider.ToolDefinition. Wrap with goai.Tool{} before passing to WithTools.
@@ -159,10 +159,10 @@ td := google.Tools.CodeExecution()
 
 Import: `github.com/zendev-sh/goai/provider/xai`
 
-| Factory | Description |
-|---------|-------------|
-| `xai.Tools.WebSearch(opts...)` | Web search |
-| `xai.Tools.XSearch(opts...)` | Search posts on X (Twitter) |
+| Factory                        | Description                 |
+| ------------------------------ | --------------------------- |
+| `xai.Tools.WebSearch(opts...)` | Web search                  |
+| `xai.Tools.XSearch(opts...)`   | Search posts on X (Twitter) |
 
 ```go
 // Each factory returns a provider.ToolDefinition. Wrap with goai.Tool{} before passing to WithTools.
@@ -183,8 +183,8 @@ td := xai.Tools.XSearch(
 
 Import: `github.com/zendev-sh/goai/provider/groq`
 
-| Factory | Description |
-|---------|-------------|
+| Factory                      | Description                |
+| ---------------------------- | -------------------------- |
 | `groq.Tools.BrowserSearch()` | Interactive browser search |
 
 ```go

--- a/docs/concepts/providers-and-models.md
+++ b/docs/concepts/providers-and-models.md
@@ -36,11 +36,12 @@ type LanguageModel interface {
     ModelID() string
     DoGenerate(ctx context.Context, params GenerateParams) (*GenerateResult, error)
     DoStream(ctx context.Context, params GenerateParams) (*StreamResult, error)
-    Capabilities() ModelCapabilities
 }
 ```
 
 Used with `GenerateText`, `StreamText`, `GenerateObject`, and `StreamObject`.
+
+Models may also implement the optional `CapableModel` interface to declare capabilities. Use `provider.ModelCapabilitiesOf(model)` to query safely.
 
 ### EmbeddingModel
 
@@ -71,10 +72,10 @@ Used with `GenerateImage`.
 
 ## Capabilities
 
-Every `LanguageModel` exposes a `Capabilities()` method that describes what the model supports:
+Models that implement the optional `CapableModel` interface expose their capabilities. Use `provider.ModelCapabilitiesOf` to query safely (returns zero-value if not implemented):
 
 ```go
-caps := model.Capabilities()
+caps := provider.ModelCapabilitiesOf(model)
 if caps.ToolCall {
     // safe to pass tools
 }
@@ -85,14 +86,14 @@ if caps.Reasoning {
 
 The `ModelCapabilities` struct includes:
 
-| Field              | Type         | Description                                |
-|--------------------|-------------|---------------------------------------------|
-| `Temperature`      | `bool`       | Accepts temperature parameter               |
-| `Reasoning`        | `bool`       | Extended thinking / chain-of-thought        |
-| `Attachment`       | `bool`       | File attachment support                     |
-| `ToolCall`         | `bool`       | Tool / function calling                     |
-| `InputModalities`  | `ModalitySet`| Supported input types (text, image, etc.)   |
-| `OutputModalities` | `ModalitySet`| Supported output types                      |
+| Field              | Type          | Description                               |
+| ------------------ | ------------- | ----------------------------------------- |
+| `Temperature`      | `bool`        | Accepts temperature parameter             |
+| `Reasoning`        | `bool`        | Extended thinking / chain-of-thought      |
+| `Attachment`       | `bool`        | File attachment support                   |
+| `ToolCall`         | `bool`        | Tool / function calling                   |
+| `InputModalities`  | `ModalitySet` | Supported input types (text, image, etc.) |
+| `OutputModalities` | `ModalitySet` | Supported output types                    |
 
 ## Provider Configuration
 
@@ -113,28 +114,28 @@ If no API key or token source is provided, providers read from environment varia
 
 ## Provider List
 
-| Provider    | Import Path                                          | Factory Functions             |
-|-------------|------------------------------------------------------|-------------------------------|
-| OpenAI      | `github.com/zendev-sh/goai/provider/openai`          | `Chat`, `Embedding`, `Image`  |
-| Anthropic   | `github.com/zendev-sh/goai/provider/anthropic`        | `Chat`                        |
-| Google      | `github.com/zendev-sh/goai/provider/google`           | `Chat`, `Embedding`, `Image`  |
-| Azure       | `github.com/zendev-sh/goai/provider/azure`            | `Chat`, `Image`               |
-| Vertex AI   | `github.com/zendev-sh/goai/provider/vertex`           | `Chat`, `Embedding`, `Image`  |
-| Bedrock     | `github.com/zendev-sh/goai/provider/bedrock`          | `Chat`                        |
-| Mistral     | `github.com/zendev-sh/goai/provider/mistral`          | `Chat`                        |
-| xAI         | `github.com/zendev-sh/goai/provider/xai`              | `Chat`                        |
-| Groq        | `github.com/zendev-sh/goai/provider/groq`             | `Chat`                        |
-| DeepInfra   | `github.com/zendev-sh/goai/provider/deepinfra`        | `Chat`                        |
-| OpenRouter  | `github.com/zendev-sh/goai/provider/openrouter`       | `Chat`                        |
-| DeepSeek    | `github.com/zendev-sh/goai/provider/deepseek`         | `Chat`                        |
-| Fireworks   | `github.com/zendev-sh/goai/provider/fireworks`        | `Chat`                        |
-| Together    | `github.com/zendev-sh/goai/provider/together`         | `Chat`                        |
-| Cohere      | `github.com/zendev-sh/goai/provider/cohere`           | `Chat`, `Embedding`           |
-| Cerebras    | `github.com/zendev-sh/goai/provider/cerebras`         | `Chat`                        |
-| Perplexity  | `github.com/zendev-sh/goai/provider/perplexity`       | `Chat`                        |
-| Ollama      | `github.com/zendev-sh/goai/provider/ollama`           | `Chat`, `Embedding`           |
-| vLLM        | `github.com/zendev-sh/goai/provider/vllm`             | `Chat`, `Embedding`           |
-| Compat      | `github.com/zendev-sh/goai/provider/compat`           | `Chat`, `Embedding`           |
+| Provider   | Import Path                                     | Factory Functions            |
+| ---------- | ----------------------------------------------- | ---------------------------- |
+| OpenAI     | `github.com/zendev-sh/goai/provider/openai`     | `Chat`, `Embedding`, `Image` |
+| Anthropic  | `github.com/zendev-sh/goai/provider/anthropic`  | `Chat`                       |
+| Google     | `github.com/zendev-sh/goai/provider/google`     | `Chat`, `Embedding`, `Image` |
+| Azure      | `github.com/zendev-sh/goai/provider/azure`      | `Chat`, `Image`              |
+| Vertex AI  | `github.com/zendev-sh/goai/provider/vertex`     | `Chat`, `Embedding`, `Image` |
+| Bedrock    | `github.com/zendev-sh/goai/provider/bedrock`    | `Chat`                       |
+| Mistral    | `github.com/zendev-sh/goai/provider/mistral`    | `Chat`                       |
+| xAI        | `github.com/zendev-sh/goai/provider/xai`        | `Chat`                       |
+| Groq       | `github.com/zendev-sh/goai/provider/groq`       | `Chat`                       |
+| DeepInfra  | `github.com/zendev-sh/goai/provider/deepinfra`  | `Chat`                       |
+| OpenRouter | `github.com/zendev-sh/goai/provider/openrouter` | `Chat`                       |
+| DeepSeek   | `github.com/zendev-sh/goai/provider/deepseek`   | `Chat`                       |
+| Fireworks  | `github.com/zendev-sh/goai/provider/fireworks`  | `Chat`                       |
+| Together   | `github.com/zendev-sh/goai/provider/together`   | `Chat`                       |
+| Cohere     | `github.com/zendev-sh/goai/provider/cohere`     | `Chat`, `Embedding`          |
+| Cerebras   | `github.com/zendev-sh/goai/provider/cerebras`   | `Chat`                       |
+| Perplexity | `github.com/zendev-sh/goai/provider/perplexity` | `Chat`                       |
+| Ollama     | `github.com/zendev-sh/goai/provider/ollama`     | `Chat`, `Embedding`          |
+| vLLM       | `github.com/zendev-sh/goai/provider/vllm`       | `Chat`, `Embedding`          |
+| Compat     | `github.com/zendev-sh/goai/provider/compat`     | `Chat`, `Embedding`          |
 
 The `compat` provider works with any OpenAI-compatible API. Pass a custom base URL:
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -13,45 +13,45 @@ All 7 core functions — `GenerateText`, `StreamText`, `GenerateObject[T]`, `Str
 
 Dedicated implementations with extended API support.
 
-| Provider | Chat | Embed | Image | Provider Tools | Auth Env Var |
-|----------|------|-------|-------|---------------|--------------|
-| [OpenAI](openai.md) | ✅ `gpt-4o`, `o3` | ✅ `text-embedding-3-*` | ✅ `gpt-image-1` | 4 tools | `OPENAI_API_KEY` |
-| [Anthropic](anthropic.md) | ✅ `claude-*` | — | — | 10 tools | `ANTHROPIC_API_KEY` |
-| [Google](google.md) | ✅ `gemini-*` | ✅ `text-embedding-004` | ✅ `imagen-*` | 3 tools | `GOOGLE_API_KEY` |
-| [Bedrock](bedrock.md) | ✅ `anthropic.*`, `meta.*` | — | — | — | `AWS_ACCESS_KEY_ID` |
-| [Azure](azure.md) | ✅ `gpt-4o`, `claude-*` | ✅ | ✅ | — | `AZURE_OPENAI_API_KEY` |
-| [Vertex AI](vertex.md) | ✅ `gemini-*` | ✅ | ✅ | — | ADC (Application Default Credentials) |
+| Provider                  | Chat                       | Embed                   | Image            | Provider Tools | Auth Env Var                          |
+| ------------------------- | -------------------------- | ----------------------- | ---------------- | -------------- | ------------------------------------- |
+| [OpenAI](openai.md)       | ✅ `gpt-4o`, `o3`          | ✅ `text-embedding-3-*` | ✅ `gpt-image-1` | 4 tools        | `OPENAI_API_KEY`                      |
+| [Anthropic](anthropic.md) | ✅ `claude-*`              | —                       | —                | 10 tools       | `ANTHROPIC_API_KEY`                   |
+| [Google](google.md)       | ✅ `gemini-*`              | ✅ `text-embedding-004` | ✅ `imagen-*`    | 3 tools        | `GOOGLE_GENERATIVE_AI_API_KEY`        |
+| [Bedrock](bedrock.md)     | ✅ `anthropic.*`, `meta.*` | —                       | —                | —              | `AWS_ACCESS_KEY_ID`                   |
+| [Azure](azure.md)         | ✅ `gpt-4o`, `claude-*`    | —                       | ✅               | —              | `AZURE_OPENAI_API_KEY`                |
+| [Vertex AI](vertex.md)    | ✅ `gemini-*`              | ✅                      | ✅               | —              | ADC (Application Default Credentials) |
 
 ## Tier 2
 
-| Provider | Chat | Embed | Image | Provider Tools | Auth Env Var |
-|----------|------|-------|-------|---------------|--------------|
-| [Cohere](cohere.md) | ✅ `command-r-*` | ✅ `embed-*` | — | — | `COHERE_API_KEY` |
-| [Mistral](mistral.md) | ✅ `mistral-large`, `magistral-*` | — | — | — | `MISTRAL_API_KEY` |
-| [xAI (Grok)](xai.md) | ✅ `grok-*` | — | — | 2 tools | `XAI_API_KEY` |
-| [Groq](groq.md) | ✅ `llama-*`, `mixtral-*` | — | — | 1 tool | `GROQ_API_KEY` |
-| [DeepSeek](deepseek.md) | ✅ `deepseek-chat`, `deepseek-reasoner` | — | — | — | `DEEPSEEK_API_KEY` |
+| Provider                | Chat                                    | Embed        | Image | Provider Tools | Auth Env Var       |
+| ----------------------- | --------------------------------------- | ------------ | ----- | -------------- | ------------------ |
+| [Cohere](cohere.md)     | ✅ `command-r-*`                        | ✅ `embed-*` | —     | —              | `COHERE_API_KEY`   |
+| [Mistral](mistral.md)   | ✅ `mistral-large`, `magistral-*`       | —            | —     | —              | `MISTRAL_API_KEY`  |
+| [xAI (Grok)](xai.md)    | ✅ `grok-*`                             | —            | —     | 2 tools        | `XAI_API_KEY`      |
+| [Groq](groq.md)         | ✅ `llama-*`, `mixtral-*`               | —            | —     | 1 tool         | `GROQ_API_KEY`     |
+| [DeepSeek](deepseek.md) | ✅ `deepseek-chat`, `deepseek-reasoner` | —            | —     | —              | `DEEPSEEK_API_KEY` |
 
 ## Tier 3
 
 All use the shared `internal/openaicompat` codec.
 
-| Provider | Endpoint | Auth Env Var |
-|----------|----------|--------------|
-| [Fireworks](fireworks.md) | `api.fireworks.ai` | `FIREWORKS_API_KEY` |
-| [Together](together.md) | `api.together.xyz` | `TOGETHER_AI_API_KEY` |
-| [DeepInfra](deepinfra.md) | `api.deepinfra.com` | `DEEPINFRA_API_KEY` |
-| [OpenRouter](openrouter.md) | `openrouter.ai` | `OPENROUTER_API_KEY` |
-| [Perplexity](perplexity.md) | `api.perplexity.ai` | `PERPLEXITY_API_KEY` |
-| [Cerebras](cerebras.md) | `api.cerebras.ai` | `CEREBRAS_API_KEY` |
+| Provider                    | Endpoint            | Auth Env Var          |
+| --------------------------- | ------------------- | --------------------- |
+| [Fireworks](fireworks.md)   | `api.fireworks.ai`  | `FIREWORKS_API_KEY`   |
+| [Together](together.md)     | `api.together.xyz`  | `TOGETHER_AI_API_KEY` |
+| [DeepInfra](deepinfra.md)   | `api.deepinfra.com` | `DEEPINFRA_API_KEY`   |
+| [OpenRouter](openrouter.md) | `openrouter.ai`     | `OPENROUTER_API_KEY`  |
+| [Perplexity](perplexity.md) | `api.perplexity.ai` | `PERPLEXITY_API_KEY`  |
+| [Cerebras](cerebras.md)     | `api.cerebras.ai`   | `CEREBRAS_API_KEY`    |
 
 ## Local / Custom
 
-| Provider | Default Endpoint | Auth | Features |
-|----------|-----------------|------|----------|
-| [Ollama](ollama.md) | `localhost:11434` | None required | Embedding support |
-| [vLLM](vllm.md) | `localhost:8000` | Optional | Embedding support |
-| [Generic Compatible](compat.md) | (required) | Configurable | Any OpenAI-compatible endpoint |
+| Provider                        | Default Endpoint  | Auth          | Features                       |
+| ------------------------------- | ----------------- | ------------- | ------------------------------ |
+| [Ollama](ollama.md)             | `localhost:11434` | None required | Embedding support              |
+| [vLLM](vllm.md)                 | `localhost:8000`  | Optional      | Embedding support              |
+| [Generic Compatible](compat.md) | (required)        | Configurable  | Any OpenAI-compatible endpoint |
 
 ## Common Options
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -291,7 +291,7 @@ All providers auto-resolve credentials from environment variables.
 |----------|--------|------|-------|-------|----------------|--------------|
 | OpenAI | `provider/openai` | ✅ gpt-4o, o3 | ✅ text-embedding-3-* | ✅ gpt-image-1 | 4 (web search, code interpreter, image gen, file search) | `OPENAI_API_KEY` |
 | Anthropic | `provider/anthropic` | ✅ claude-* | — | — | 10 (web search, web fetch, computer use, bash, text editor, code execution) | `ANTHROPIC_API_KEY` |
-| Google | `provider/google` | ✅ gemini-* | ✅ text-embedding-004 | ✅ imagen-* | 3 (google search, URL context, code execution) | `GOOGLE_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY` |
+| Google | `provider/google` | ✅ gemini-* | ✅ text-embedding-004 | ✅ imagen-* | 3 (google search, URL context, code execution) | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` |
 | Bedrock | `provider/bedrock` | ✅ anthropic.*, meta.* | — | — | — | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
 | Azure | `provider/azure` | ✅ gpt-4o, claude-* | ✅ | ✅ | — | `AZURE_OPENAI_API_KEY` |
 | Vertex AI | `provider/vertex` | ✅ gemini-* | ✅ | ✅ | — | ADC (Application Default Credentials) |

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -50,7 +50,7 @@ Requires Go 1.25+. Zero external dependencies (stdlib only, except golang.org/x/
 ### Tier 1 (dedicated implementations)
 - OpenAI (`OPENAI_API_KEY`) — Chat, Embed, Image, 4 provider tools
 - Anthropic (`ANTHROPIC_API_KEY`) — Chat, 10 provider tools
-- Google Gemini (`GOOGLE_API_KEY`) - Chat, Embed, Image, 3 provider tools (google search, URL context, code execution)
+- Google Gemini (`GOOGLE_GENERATIVE_AI_API_KEY`) - Chat, Embed, Image, 3 provider tools (google search, URL context, code execution)
 - AWS Bedrock (`AWS_ACCESS_KEY_ID`) — Chat
 - Azure OpenAI (`AZURE_OPENAI_API_KEY`) — Chat, Embed, Image
 - Vertex AI (ADC) — Chat, Embed, Image


### PR DESCRIPTION
Comprehensive docs audit found 18 issues (6 critical, 7 significant, 5 minor). All fixed.

## Critical fixes (code from docs would break)
- **LanguageModel interface** included `Capabilities()` - it belongs to separate `CapableModel` interface (types.md, providers-and-models.md)
- **FinishReason values** used underscores (`tool_calls`, `content_filter`) - actual code uses dashes (`tool-calls`, `content-filter`)
- **RequestInfo** had phantom `Provider string` field that doesn't exist
- **Retry backoff** documented as 1s/2s/4s capped at 30s - actual is 2s/4s/8s capped at 60s

## Missing documentation added
- 4 options: `WithTopK`, `WithFrequencyPenalty`, `WithPresencePenalty`, `WithSeed`
- 4 GenerateParams fields: `TopK`, `FrequencyPenalty`, `PresencePenalty`, `Seed`
- `CapableModel` interface + `ModelCapabilitiesOf` function
- `ParseHTTPErrorWithHeaders`, `ClassifyStreamError`, `ErrUnknownTool`
- `StreamErrorType` named type with constants
- `TrySend` utility

## Other fixes
- `openai.WithContainer` -> `openai.WithContainerID` in provider-tools.md
- Google env var: `GOOGLE_API_KEY` -> `GOOGLE_GENERATIVE_AI_API_KEY` (in index.md, llms.txt, llms-full.txt, SKILL.md)
- Azure: removed Embed checkmark (no `azure.Embedding()` exists)
- Retry-After header support documented

## Files changed (11)
```
SKILL.md, docs/api/{core-functions,errors,options,types}.md,
docs/concepts/{error-handling,provider-tools,providers-and-models}.md,
docs/providers/index.md, docs/public/{llms,llms-full}.txt
```

**Examples: all 16 verified clean - no changes needed.**