### PR TITLE
fix: versioned docs routing to Cloudflare branch deploys

### DIFF
--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -2,7 +2,7 @@ name: Docs (versioned)
 
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -27,7 +27,6 @@ jobs:
       - name: Build versioned docs
         run: npm run build
         env:
-          VITEPRESS_BASE: /${{ steps.version.outputs.tag }}/
           VITE_GOAI_THEME: dev
 
       - name: Deploy versioned docs

--- a/docs/.vitepress/theme/VersionSwitcher.vue
+++ b/docs/.vitepress/theme/VersionSwitcher.vue
@@ -1,54 +1,76 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted } from "vue";
 
 interface Version {
-  tag: string
-  date: string
-  label: string
+  tag: string;
+  date: string;
+  label: string;
 }
 
-const versions = ref<Version[]>([])
-const current = ref('latest')
-const latestTag = ref('')
+const versions = ref<Version[]>([]);
+const current = ref("latest");
+const latestTag = ref("");
+const branchBaseURL = ref("");
 
 onMounted(async () => {
   try {
-    const base = import.meta.env.BASE_URL || '/'
-    const res = await fetch(`${base}versions.json`)
+    const base = import.meta.env.BASE_URL || "/";
+    const res = await fetch(`${base}versions.json`);
     if (res.ok) {
-      const data = await res.json()
-      versions.value = data.versions || []
-      latestTag.value = data.latest || ''
+      const data = await res.json();
+      versions.value = data.versions || [];
+      latestTag.value = data.latest || "";
+      branchBaseURL.value = data.branchBaseURL || "";
 
       // Detect current version from URL path (e.g. /v0.4.0/getting-started/)
-      const path = window.location.pathname
-      const match = path.match(/^\/(v[\d.]+)\//)
+      const path = window.location.pathname;
+      const match = path.match(/^\/(v[\d.]+)\//);
       if (match) {
-        current.value = match[1]
+        current.value = match[1];
       }
     }
   } catch {
     // versions.json not available
   }
-})
+});
 
 function navigate(tag: string) {
-  const path = window.location.pathname
+  const path = window.location.pathname;
   // Strip current version prefix from path
-  const stripped = path.replace(/^\/(v[\d.]+)\//, '/')
-  if (tag === 'latest') {
-    window.location.href = stripped
+  const stripped = path.replace(/^\/(v[\d.]+)\//, "/");
+  if (tag === "latest") {
+    if (branchBaseURL.value) {
+      // On a branch deploy, go back to main site
+      window.location.href = "https://goai.sh" + stripped;
+    } else {
+      window.location.href = stripped;
+    }
   } else {
-    window.location.href = `/${tag}${stripped}`
+    // Navigate to versioned branch deploy
+    // CF Pages branch names use dashes: v0.4.2 → v0-4-2
+    const branch = tag.replace(/\./g, "-");
+    if (branchBaseURL.value) {
+      const url = branchBaseURL.value.replace("{branch}", branch);
+      window.location.href = url + stripped;
+    } else {
+      window.location.href = "/" + tag + stripped;
+    }
   }
 }
 </script>
 
 <template>
   <div v-if="versions.length > 1" class="version-switcher">
-    <select :value="current" @change="navigate(($event.target as HTMLSelectElement).value)">
-      <option value="latest">latest{{ latestTag ? ` (${latestTag})` : '' }}</option>
-      <option v-for="v in versions" :key="v.tag" :value="v.tag">{{ v.tag }}</option>
+    <select
+      :value="current"
+      @change="navigate(($event.target as HTMLSelectElement).value)"
+    >
+      <option value="latest">
+        latest{{ latestTag ? ` (${latestTag})` : "" }}
+      </option>
+      <option v-for="v in versions" :key="v.tag" :value="v.tag">
+        {{ v.tag }}
+      </option>
     </select>
   </div>
 </template>

--- a/docs/public/versions.json
+++ b/docs/public/versions.json
@@ -1,5 +1,6 @@
 {
   "latest": "v0.4.2",
+  "branchBaseURL": "https://{branch}.goai-2lz.pages.dev",
   "versions": [
     {
       "tag": "v0.4.2",


### PR DESCRIPTION
## Problem

Version switcher on the docsite was 404ing when selecting older versions (v0.4.0, v0.4.1). 

**Root cause:** Versioned docs are deployed as Cloudflare Pages **branch deploys** (e.g. `v0-4-2.goai-2lz.pages.dev`), but the VersionSwitcher was navigating to `goai.sh/v0.4.x/...` which doesn't exist on the main deployment.

Additionally, versioned builds were setting `VITEPRESS_BASE: /v0.4.x/` but branch deploys serve from `/`, causing asset 404s even on the branch URL.

## Fix

1. **Remove `VITEPRESS_BASE`** from `docs-version.yml` — branch deploys serve from root
2. **Update `VersionSwitcher`** — navigate to CF Pages branch subdomain URLs instead of path-based routing
3. **Add `branchBaseURL`** to `versions.json` — configurable pattern for branch deploy URLs
4. **Handle return to latest** — when on a branch deploy, selecting 'latest' navigates back to `goai.sh`

## Note

Existing versioned deploys (v0.4.0, v0.4.1, v0.4.2) were built with the old `VITEPRESS_BASE` and will need to be re-triggered to work correctly. This can be done by re-pushing the tags or using workflow_dispatch.