### PR TITLE
fix(bedrock): per-model ToolCall capability + orphan toolConfig handling

### DIFF
--- a/provider/bedrock/bedrock.go
+++ b/provider/bedrock/bedrock.go
@@ -223,10 +223,26 @@ func (m *chatModel) readIDRegion() (string, string) {
 func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
 		Temperature:      true,
-		ToolCall:         true,
+		ToolCall:         modelSupportsTools(m.id),
 		InputModalities:  provider.ModalitySet{Text: true, Image: true},
 		OutputModalities: provider.ModalitySet{Text: true},
 	}
+}
+
+// modelSupportsTools returns whether a Bedrock model supports tool_use.
+// DeepSeek R1 and Titan Text Lite/Express do not support tool calling.
+func modelSupportsTools(modelID string) bool {
+	lower := strings.ToLower(modelID)
+	// DeepSeek R1 (reasoning model) does not support tool_use on Bedrock.
+	// DeepSeek V3 DOES support tool_use.
+	if strings.Contains(lower, "deepseek") && strings.Contains(lower, "r1") {
+		return false
+	}
+	// Amazon Titan Text Lite and Express do not support tool_use.
+	if strings.Contains(lower, "titan-text-lite") || strings.Contains(lower, "titan-text-express") {
+		return false
+	}
+	return true
 }
 
 const responseFormatToolName = "__json_response"
@@ -429,6 +445,12 @@ func (m *chatModel) buildAndSend(ctx context.Context, params provider.GeneratePa
 	m.applyBedrockOptions(body, params.Tools, params.ProviderOptions)
 	if len(params.Tools) == 0 {
 		delete(body, "toolConfig")
+		// Bedrock Converse API requires toolConfig whenever messages contain
+		// toolUse or toolResult content blocks. This happens after Esc interrupt:
+		// conversation history retains tool blocks from the aborted turn, but
+		// the new request may not include tools (e.g., compaction agent).
+		// Scan messages and synthesize a minimal toolConfig from referenced tools.
+		ensureToolConfigForHistory(body, params.Messages)
 	}
 	return m.doHTTP(ctx, body, streaming)
 }

--- a/provider/bedrock/bedrock_test.go
+++ b/provider/bedrock/bedrock_test.go
@@ -4119,3 +4119,104 @@ func TestDoStream_ToolStreamingRetry_DrainCtxDone(t *testing.T) {
 	for range result.Stream {
 	}
 }
+
+func TestModelSupportsTools(t *testing.T) {
+	tests := []struct {
+		modelID string
+		want    bool
+	}{
+		{"anthropic.claude-sonnet-4-20250514-v1:0", true},
+		{"anthropic.claude-3-5-haiku-20241022-v1:0", true},
+		{"deepseek.r1-v1:0", false},
+		{"deepseek.v3-v1:0", true},
+		{"deepseek.v3.2", true},
+		{"amazon.titan-text-lite-v1", false},
+		{"amazon.titan-text-express-v1", false},
+		{"amazon.nova-pro-v1:0", true},
+		{"meta.llama3-2-90b-instruct-v1:0", true},
+		{"us.deepseek.r1-v1:0", false},
+		{"us.deepseek.v3-v1:0", true},
+	}
+	for _, tt := range tests {
+		got := modelSupportsTools(tt.modelID)
+		if got != tt.want {
+			t.Errorf("modelSupportsTools(%q) = %v, want %v", tt.modelID, got, tt.want)
+		}
+	}
+}
+
+func TestCapabilities_PerModel(t *testing.T) {
+	m := Chat("deepseek.r1-v1:0").(*chatModel)
+	caps := m.Capabilities()
+	if caps.ToolCall {
+		t.Error("deepseek.r1-v1:0 should have ToolCall=false")
+	}
+	m2 := Chat("deepseek.v3-v1:0").(*chatModel)
+	caps2 := m2.Capabilities()
+	if !caps2.ToolCall {
+		t.Error("deepseek.v3-v1:0 should have ToolCall=true")
+	}
+}
+
+func TestEnsureToolConfigForHistory_NoToolBlocks(t *testing.T) {
+	body := map[string]any{}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hello"}}},
+	}
+	ensureToolConfigForHistory(body, msgs)
+	if _, ok := body["toolConfig"]; ok {
+		t.Error("should not add toolConfig when no tool blocks")
+	}
+}
+
+func TestEnsureToolConfigForHistory_WithToolBlocks(t *testing.T) {
+	body := map[string]any{}
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, Content: []provider.Part{
+			{Type: provider.PartToolCall, ToolName: "bash", ToolCallID: "1"},
+		}},
+	}
+	ensureToolConfigForHistory(body, msgs)
+	tc, ok := body["toolConfig"]
+	if !ok {
+		t.Fatal("should add toolConfig when tool blocks present")
+	}
+	tools := tc.(map[string]any)["tools"].([]map[string]any)
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	spec := tools[0]["toolSpec"].(map[string]any)
+	if spec["name"] != "bash" {
+		t.Errorf("expected tool name 'bash', got %v", spec["name"])
+	}
+}
+
+func TestEnsureToolConfigForHistory_SkipsIfExists(t *testing.T) {
+	body := map[string]any{"toolConfig": map[string]any{"tools": []any{}}}
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, Content: []provider.Part{
+			{Type: provider.PartToolCall, ToolName: "bash", ToolCallID: "1"},
+		}},
+	}
+	ensureToolConfigForHistory(body, msgs)
+	tools := body["toolConfig"].(map[string]any)["tools"].([]any)
+	if len(tools) != 0 {
+		t.Error("should not modify existing toolConfig")
+	}
+}
+
+func TestEnsureToolConfigForHistory_MultipleTools(t *testing.T) {
+	body := map[string]any{}
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, Content: []provider.Part{
+			{Type: provider.PartToolCall, ToolName: "bash", ToolCallID: "1"},
+			{Type: provider.PartToolCall, ToolName: "read", ToolCallID: "2"},
+			{Type: provider.PartToolCall, ToolName: "bash", ToolCallID: "3"},
+		}},
+	}
+	ensureToolConfigForHistory(body, msgs)
+	tools := body["toolConfig"].(map[string]any)["tools"].([]map[string]any)
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 unique tools, got %d", len(tools))
+	}
+}

--- a/provider/bedrock/converse.go
+++ b/provider/bedrock/converse.go
@@ -155,6 +155,51 @@ func buildConverseRequest(params provider.GenerateParams, modelID string) map[st
 	return body
 }
 
+// ensureToolConfigForHistory scans provider messages for toolUse/toolResult
+// references and synthesizes a minimal toolConfig in the request body.
+// This is required because Bedrock Converse API returns an error when messages
+// contain toolUse or toolResult content blocks but toolConfig is absent.
+//
+// This scenario occurs after an Esc interrupt: the conversation history
+// retains tool blocks from the aborted turn, and if the subsequent request
+// has no tools (e.g., compaction agent, or a retry without tools), Bedrock
+// rejects it. The fix creates placeholder tool definitions from the tool
+// names found in the message history.
+func ensureToolConfigForHistory(body map[string]any, msgs []provider.Message) {
+	// Already has toolConfig - nothing to do.
+	if _, ok := body["toolConfig"]; ok {
+		return
+	}
+
+	// Scan messages for tool-call parts to extract tool names.
+	toolNames := make(map[string]bool)
+	for _, msg := range msgs {
+		for _, p := range msg.Content {
+			if p.Type == provider.PartToolCall && p.ToolName != "" {
+				toolNames[p.ToolName] = true
+			}
+		}
+	}
+
+	if len(toolNames) == 0 {
+		return
+	}
+
+	// Build minimal toolConfig with placeholder tool definitions.
+	// Bedrock requires name + description + inputSchema for each tool.
+	tools := make([]map[string]any, 0, len(toolNames))
+	for name := range toolNames {
+		tools = append(tools, map[string]any{
+			"toolSpec": map[string]any{
+				"name":        name,
+				"description": name,
+				"inputSchema": map[string]any{"json": map[string]any{"type": "object"}},
+			},
+		})
+	}
+	body["toolConfig"] = map[string]any{"tools": tools}
+}
+
 // convertMessages maps provider.Message slice to Bedrock Converse format.
 // Tool-role messages are merged into user role per Bedrock convention.
 func convertMessages(msgs []provider.Message) []map[string]any {


### PR DESCRIPTION
## Summary
- `modelSupportsTools()` returns per-model ToolCall capability instead of hardcoded `true`. DeepSeek R1 and Titan Text Lite/Express return `false`.
- `ensureToolConfigForHistory()` synthesizes minimal toolConfig when conversation history contains orphan tool blocks (e.g., after user interrupts agent mid-tool-use). Bedrock Converse API requires toolConfig whenever toolUse/toolResult blocks appear in messages.

## Test plan
- [x] `TestModelSupportsTools` — 11 model IDs verified
- [x] `TestCapabilities_PerModel` — R1=false, V3=true
- [x] `TestEnsureToolConfigForHistory_*` — 4 test cases (no blocks, with blocks, skip existing, dedup)
- [x] All existing bedrock tests pass