### PR TITLE
fix: comprehensive deep-review audit (5 rounds, 62 fixes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,18 +32,19 @@ jobs:
           draft: false
 
       - name: Update versions.json
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          DATE=$(date -u +%Y-%m-%d)
+          export DATE=$(date -u +%Y-%m-%d)
           if [ ! -f docs/public/versions.json ]; then
             echo '{"latest":"","versions":[]}' > docs/public/versions.json
           fi
           cat docs/public/versions.json | \
             python3 -c "
-          import json, sys
+          import json, sys, os
           data = json.load(sys.stdin)
-          tag = '$TAG'
-          date = '$DATE'
+          tag = os.environ['TAG']
+          date = os.environ['DATE']
           data['latest'] = tag
           if not any(v['tag'] == tag for v in data['versions']):
               data['versions'].insert(0, {'tag': tag, 'date': date, 'label': tag + ' (latest)'})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,11 @@ goai/
 │   ├── azure/              # Azure OpenAI
 │   ├── cohere/             # Cohere (Chat v2 + Embed)
 │   ├── compat/             # Generic OpenAI-compatible
-│   └── <13 more>/          # OpenAI-compat via internal/openaicompat
+│   └── <12 more>/          # OpenAI-compat via internal/openaicompat
 │   # tools.go files: anthropic/ (10), openai/ (4), google/ (3), xai/ (2), groq/ (1)
 ├── internal/
 │   ├── openaicompat/       # Shared codec for 13+ providers
+│   ├── gemini/             # Schema sanitization (Vertex, Google)
 │   ├── sse/                # SSE parser
 │   └── httpc/              # HTTP helpers + ParseDataURL
 ├── examples/               # 16 runnable examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ For non-OpenAI-compatible providers (like Anthropic, Google, Cohere), implement 
 - [ ] `WithAPIKey(key)` option
 - [ ] `WithHTTPClient(c)` option
 - [ ] `WithTokenSource(ts)` option
+- [ ] `WithBaseURL(url)` option
+- [ ] `WithHeaders(h)` option
 - [ ] Streaming support (`DoStream`)
 - [ ] Error handling (`ParseHTTPError`)
 - [ ] Per-request headers (`_headers` extraction in `doHTTP`)

--- a/README.md
+++ b/README.md
@@ -453,6 +453,8 @@ fmt.Printf("Model used: %s\n", result.Response.Model)
 | `WithImageCount(n)` | Number of images |
 | `WithImageSize(s)` | Dimensions (e.g., "1024x1024") |
 | `WithAspectRatio(s)` | Aspect ratio (e.g., "16:9") |
+| `WithImageMaxRetries(n)` | Retries on 429/5xx |
+| `WithImageTimeout(d)` | Overall timeout |
 | `WithImageProviderOptions(m)` | Image provider params |
 
 ## Error Handling
@@ -490,10 +492,11 @@ Providers expose built-in tools that the model can invoke server-side. GoAI supp
 | xAI | `WebSearch`, `XSearch` | `provider/xai` |
 | Groq | `BrowserSearch` | `provider/groq` |
 
-All tools follow the same pattern: create a definition with `provider.Tools.ToolName()`, then pass it as a `goai.Tool`:
+All tools follow the same pattern: create a definition with `<provider>.Tools.ToolName()` (e.g., `openai.Tools`, `anthropic.Tools`), then pass it as a `goai.Tool`:
 
 ```go
-def := provider.Tools.ToolName(options...)
+// Example: def := openai.Tools.WebSearch(openai.WithSearchContextSize("medium"))
+def := <provider>.Tools.ToolName(options...)
 result, _ := goai.GenerateText(ctx, model,
     goai.WithTools(goai.Tool{
         Name:                   def.Name,

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -306,7 +306,7 @@ func GenerateImage(ctx context.Context, model provider.ImageModel, opts ...Image
 | ------- | --------------------- | ----------------------------------------------------------- |
 | `ctx`   | `context.Context`     | Request context.                                            |
 | `model` | `provider.ImageModel` | The image model to use.                                     |
-| `opts`  | `...ImageOption`      | Image-specific options (prompt, count, size, aspect ratio). |
+| `opts`  | `...ImageOption`      | Image-specific options (prompt, count, size, aspect ratio, max retries, timeout). |
 
 Note: `GenerateImage` uses `ImageOption` instead of `Option`. See the [Options](options.md) page for image-specific options.
 
@@ -398,7 +398,7 @@ func SchemaFrom[T any]() json.RawMessage
 | `jsonschema:"description=..."` | `jsonschema:"description=City name"`   | Adds a description to the property.   |
 | `jsonschema:"enum=a\|b\|c"`    | `jsonschema:"enum=easy\|medium\|hard"` | Restricts values to an enum.          |
 
-**Supported types:** string, bool, int (all sizes), uint (all sizes), float32/64, slices, maps with string keys, structs. Embedded structs are flattened. Pointer types produce nullable schemas (`type: ["<base>", "null"]`).
+**Supported types:** string, bool, int (all sizes), uint (all sizes), float32/64, slices, maps with string keys, structs, `time.Time` (string with `date-time` format), `json.RawMessage` (any type), and recursive types. Embedded structs are flattened. Pointer types produce nullable schemas (`type: ["<base>", "null"]`).
 
 **Example:**
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -368,6 +368,26 @@ func WithAspectRatio(ratio string) ImageOption
 
 **Default:** provider default.
 
+### WithImageMaxRetries
+
+Sets the retry count for transient errors during image generation (429, 503, 5xx).
+
+```go
+func WithImageMaxRetries(n int) ImageOption
+```
+
+**Default:** `2`. Retries use exponential backoff.
+
+### WithImageTimeout
+
+Sets the timeout for the image generation call.
+
+```go
+func WithImageTimeout(d time.Duration) ImageOption
+```
+
+**Default:** no timeout (relies on the context).
+
 ### WithImageProviderOptions
 
 Sets provider-specific options for image generation.

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -54,6 +54,7 @@ A streaming text generation response with three consumption modes.
 | `Stream()`     | `<-chan provider.StreamChunk` | Raw stream chunks (all types).                     |
 | `TextStream()` | `<-chan string`               | Text content only.                                 |
 | `Result()`     | `*TextResult`                 | Blocks until complete, returns accumulated result. |
+| `Err()`        | `error`                       | Blocks until the stream is fully consumed, then returns any error encountered during streaming. |
 
 `Stream()` and `TextStream()` are mutually exclusive. `Result()` can be called after either.
 
@@ -78,6 +79,7 @@ A streaming structured output response.
 | ----------------------- | --------------------------- | ------------------------------------------------------ |
 | `PartialObjectStream()` | `<-chan *T`                 | Emits progressively populated partial objects.         |
 | `Result()`              | `(*ObjectResult[T], error)` | Blocks until complete, returns final validated object. |
+| `Err()`                 | `error`                     | Blocks until the stream is fully consumed, then returns any error encountered during streaming. |
 
 ### EmbedResult
 

--- a/docs/concepts/error-handling.md
+++ b/docs/concepts/error-handling.md
@@ -103,3 +103,24 @@ Retries use exponential backoff with jitter:
 ```go
 goai.WithMaxRetries(0) // No retries, fail on first error
 ```
+
+## Streaming Error Detection
+
+When using `StreamText` or `StreamObject`, errors that occur mid-stream (network failures, malformed SSE data, provider errors) are not returned inline. Instead, call `Err()` after consuming the stream to check for errors:
+
+```go
+stream, err := goai.StreamText(ctx, model, goai.WithPrompt("Hello"))
+if err != nil {
+    log.Fatal(err) // Connection-level failure.
+}
+
+for text := range stream.TextStream() {
+    fmt.Print(text)
+}
+
+if err := stream.Err(); err != nil {
+    log.Fatal("streaming error:", err) // Mid-stream failure.
+}
+```
+
+`Err()` blocks until the stream is fully consumed, then returns any error encountered during streaming. Always check `Err()` after draining the stream channel.

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -62,6 +62,17 @@ fmt.Printf("Tokens: %d\n", result.TotalUsage.TotalTokens)
 
 `Result()` can always be called, including after `TextStream()` or `Stream()`. If called after a streaming method, it waits for the stream to finish and returns the accumulated data.
 
+After consuming the stream, call `Err()` to check for any errors that occurred during streaming:
+
+```go
+for text := range stream.TextStream() {
+    fmt.Print(text)
+}
+if err := stream.Err(); err != nil {
+    log.Fatal("stream error:", err)
+}
+```
+
 A common pattern is to stream text to the user, then inspect the final result:
 
 ```go

--- a/docs/concepts/token-source.md
+++ b/docs/concepts/token-source.md
@@ -80,6 +80,13 @@ type InvalidatingTokenSource interface {
 
 Calling `Invalidate()` clears the cached token, forcing the next `Token()` call to re-fetch. This is useful for application-level handling when a token is rejected (e.g., clearing a cached token after a 401 response in your own retry logic).
 
+> **Note:** `CachedTokenSource` returns the `TokenSource` interface, so use a type assertion to access `Invalidate()`:
+> ```go
+> ts := provider.CachedTokenSource(fetchFunc)
+> // ... later, to invalidate:
+> ts.(provider.InvalidatingTokenSource).Invalidate()
+> ```
+
 ## Examples
 
 ### Azure Managed Identity

--- a/docs/providers/compat.md
+++ b/docs/providers/compat.md
@@ -84,6 +84,7 @@ model := compat.Chat("my-model",
 | `WithBaseURL(url)` | `string` | **Required.** Set the API base URL |
 | `WithHeaders(h)` | `map[string]string` | Set additional HTTP headers |
 | `WithHTTPClient(c)` | `*http.Client` | Set a custom `*http.Client` |
+| `WithProviderID(id)` | `string` | Set a custom provider identifier |
 
 ## Notes
 

--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -135,5 +135,5 @@ Image provider options (pass under the `"vertex"` key in `ImageParams.ProviderOp
 - Chat uses the Vertex AI OpenAI-compatible endpoint. Embeddings and image generation use the native Vertex AI `:predict` endpoint.
 - Tool schemas are automatically sanitized to comply with Gemini schema restrictions (no `additionalProperties`, enum values must be strings, etc.).
 - Gemini-native provider options like `thinkingConfig` are stripped before sending to the OpenAI-compatible endpoint.
-- The `ADCTokenSource()` function is exported for direct use with other providers that need GCP credentials.
-- Max embedding batch size: 2048 values per call.
+- The `ADCTokenSource(ctx context.Context, scopes ...string)` function is exported for direct use with other providers that need GCP credentials. It takes a `context.Context` and optional OAuth scopes, and returns `(provider.TokenSource, error)`.
+- Max embedding batch size: 250 values per call.

--- a/embed.go
+++ b/embed.go
@@ -2,6 +2,7 @@ package goai
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -29,6 +30,10 @@ type EmbedManyResult struct {
 
 // Embed generates an embedding vector for a single value.
 func Embed(ctx context.Context, model provider.EmbeddingModel, value string, opts ...Option) (*EmbedResult, error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
 	o := applyOptions(opts...)
 
 	if o.Timeout > 0 {
@@ -62,6 +67,10 @@ func Embed(ctx context.Context, model provider.EmbeddingModel, value string, opt
 // Auto-chunks when values exceed the model's MaxValuesPerCall limit
 // and processes chunks in parallel (controlled by WithMaxParallelCalls).
 func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []string, opts ...Option) (*EmbedManyResult, error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
 	o := applyOptions(opts...)
 
 	if o.Timeout > 0 {
@@ -83,6 +92,9 @@ func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []stri
 		})
 		if err != nil {
 			return nil, err
+		}
+		if len(result.Embeddings) != len(values) {
+			return nil, fmt.Errorf("goai: embedding count mismatch: got %d, expected %d", len(result.Embeddings), len(values))
 		}
 		return &EmbedManyResult{
 			Embeddings: result.Embeddings,
@@ -140,6 +152,10 @@ func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []stri
 		}
 		allEmbeddings = append(allEmbeddings, cr.result.Embeddings...)
 		totalUsage = addUsage(totalUsage, cr.result.Usage)
+	}
+
+	if len(allEmbeddings) != len(values) {
+		return nil, fmt.Errorf("goai: embedding count mismatch: got %d, expected %d", len(allEmbeddings), len(values))
 	}
 
 	return &EmbedManyResult{

--- a/embed_test.go
+++ b/embed_test.go
@@ -2,6 +2,7 @@ package goai
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -177,8 +178,8 @@ func TestEmbed_RetryExhausted(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected *APIError, got %T", err)
 	}
 	if !apiErr.IsRetryable {

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -35,6 +35,11 @@ func main() {
 	}
 	fmt.Println()
 
+	// Check for errors that occurred during streaming.
+	if err := stream.Err(); err != nil {
+		log.Fatal(err)
+	}
+
 	// Get the final result with usage stats.
 	result := stream.Result()
 	fmt.Printf("Tokens: %d in, %d out\n", result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)

--- a/generate.go
+++ b/generate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -80,6 +81,10 @@ type TextStream struct {
 	rawCh  <-chan provider.StreamChunk
 	textCh <-chan string
 
+	// Hook support.
+	onResponse func(ResponseInfo)
+	startTime  time.Time
+
 	// Accumulated state (written by consume goroutine, read after doneCh closes).
 	text         strings.Builder
 	toolCalls    []provider.ToolCall
@@ -87,6 +92,7 @@ type TextStream struct {
 	finishReason provider.FinishReason
 	usage        provider.Usage
 	response     provider.ResponseMetadata
+	streamErr    error
 }
 
 func newTextStream(ctx context.Context, source <-chan provider.StreamChunk) *TextStream {
@@ -139,6 +145,15 @@ func (ts *TextStream) Result() *TextResult {
 	return ts.buildResult()
 }
 
+// Err returns the first stream error encountered, or nil.
+// Must be called after the stream is fully consumed (after Result(),
+// or after the Stream()/TextStream() channel is drained).
+// Follows the bufio.Scanner.Err() pattern.
+func (ts *TextStream) Err() error {
+	<-ts.doneCh
+	return ts.streamErr
+}
+
 func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<- string) {
 	defer close(ts.doneCh)
 	if ts.timeoutCancel != nil {
@@ -149,6 +164,17 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 	}
 	if textOut != nil {
 		defer close(textOut)
+	}
+
+	// Call OnResponse hook when consume finishes (after all chunks processed).
+	if ts.onResponse != nil {
+		defer func() {
+			ts.onResponse(ResponseInfo{
+				Latency:      time.Since(ts.startTime),
+				Usage:        ts.usage,
+				FinishReason: ts.finishReason,
+			})
+		}()
 	}
 
 	for chunk := range ts.source {
@@ -172,6 +198,10 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 			// Capture top-level citations (xAI, Perplexity).
 			if sources, ok := chunk.Metadata["sources"].([]provider.Source); ok {
 				ts.sources = append(ts.sources, sources...)
+			}
+		case provider.ChunkError:
+			if ts.streamErr == nil {
+				ts.streamErr = chunk.Error
 			}
 		}
 
@@ -229,6 +259,9 @@ func buildParams(opts options) provider.GenerateParams {
 	msgs := opts.Messages
 	if opts.Prompt != "" {
 		msgs = append([]provider.Message{UserMessage(opts.Prompt)}, msgs...)
+	} else {
+		// Always copy so tool-loop appends never mutate the caller's slice.
+		msgs = slices.Clone(msgs)
 	}
 
 	if opts.PromptCaching {
@@ -256,6 +289,10 @@ func buildParams(opts options) provider.GenerateParams {
 
 // StreamText performs a streaming text generation.
 func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Option) (*TextStream, error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
 	o := applyOptions(opts...)
 
 	var timeoutCancel context.CancelFunc
@@ -265,6 +302,16 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 
 	params := buildParams(o)
 
+	if o.OnRequest != nil {
+		o.OnRequest(RequestInfo{
+			Model:        model.ModelID(),
+			MessageCount: len(params.Messages),
+			ToolCount:    len(params.Tools),
+			Timestamp:    time.Now(),
+		})
+	}
+
+	start := time.Now()
 	result, err := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
@@ -272,11 +319,21 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 		if timeoutCancel != nil {
 			timeoutCancel()
 		}
+		if o.OnResponse != nil {
+			info := ResponseInfo{Latency: time.Since(start), Error: err}
+			var apiErr *APIError
+			if errors.As(err, &apiErr) {
+				info.StatusCode = apiErr.StatusCode
+			}
+			o.OnResponse(info)
+		}
 		return nil, err
 	}
 
 	ts := newTextStream(ctx, result.Stream)
 	ts.timeoutCancel = timeoutCancel
+	ts.onResponse = o.OnResponse
+	ts.startTime = start
 	return ts, nil
 }
 
@@ -284,6 +341,10 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 // When tools with Execute functions are provided and MaxSteps > 1,
 // it automatically runs a tool loop: generate → execute tools → re-generate.
 func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Option) (*TextResult, error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
 	o := applyOptions(opts...)
 
 	if o.Timeout > 0 {

--- a/generate_test.go
+++ b/generate_test.go
@@ -1269,8 +1269,8 @@ func TestStreamText_WithTimeout_ErrorCancelsContext(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected *APIError, got %T", err)
 	}
 	if apiErr.StatusCode != 400 {

--- a/image.go
+++ b/image.go
@@ -2,17 +2,29 @@ package goai
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/zendev-sh/goai/provider"
 )
 
 // GenerateImage generates images from a text prompt.
 func GenerateImage(ctx context.Context, model provider.ImageModel, opts ...ImageOption) (*ImageResult, error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
 	o := imageOptions{
 		n: 1,
 	}
 	for _, opt := range opts {
 		opt(&o)
+	}
+
+	if o.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, o.timeout)
+		defer cancel()
 	}
 
 	params := provider.ImageParams{
@@ -23,7 +35,9 @@ func GenerateImage(ctx context.Context, model provider.ImageModel, opts ...Image
 		ProviderOptions: o.providerOptions,
 	}
 
-	result, err := model.DoGenerate(ctx, params)
+	result, err := withRetry(ctx, o.maxRetries, func() (*provider.ImageResult, error) {
+		return model.DoGenerate(ctx, params)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -47,6 +61,8 @@ type imageOptions struct {
 	size            string
 	aspectRatio     string
 	providerOptions map[string]any
+	maxRetries      int
+	timeout         time.Duration
 }
 
 // WithImagePrompt sets the text prompt for image generation.
@@ -81,5 +97,19 @@ func WithAspectRatio(ratio string) ImageOption {
 func WithImageProviderOptions(opts map[string]any) ImageOption {
 	return func(o *imageOptions) {
 		o.providerOptions = opts
+	}
+}
+
+// WithImageMaxRetries sets the maximum number of retries for transient errors.
+func WithImageMaxRetries(n int) ImageOption {
+	return func(o *imageOptions) {
+		o.maxRetries = n
+	}
+}
+
+// WithImageTimeout sets a timeout for the image generation request.
+func WithImageTimeout(d time.Duration) ImageOption {
+	return func(o *imageOptions) {
+		o.timeout = d
 	}
 }

--- a/internal/gemini/schema.go
+++ b/internal/gemini/schema.go
@@ -32,6 +32,35 @@ func sanitizeImpl(obj any) any {
 
 	result := make(map[string]any)
 
+	// Normalize nullable type arrays: ["object","null"] → "object" + nullable: true.
+	// SchemaFrom produces []string, JSON unmarshal produces []any.
+	if rawType, ok := m["type"]; ok {
+		switch tt := rawType.(type) {
+		case []string:
+			var nonNull string
+			for _, s := range tt {
+				if s != "null" {
+					nonNull = s
+				}
+			}
+			if nonNull != "" {
+				m["type"] = nonNull
+				result["nullable"] = true
+			}
+		case []any:
+			var nonNull string
+			for _, v := range tt {
+				if s, ok := v.(string); ok && s != "null" {
+					nonNull = s
+				}
+			}
+			if nonNull != "" {
+				m["type"] = nonNull
+				result["nullable"] = true
+			}
+		}
+	}
+
 	for k, v := range m {
 		if k == "enum" {
 			if enumArr, ok := v.([]any); ok {
@@ -64,15 +93,25 @@ func sanitizeImpl(obj any) any {
 	}
 
 	// Filter required to only include fields in properties.
+	// SchemaFrom produces []string; JSON unmarshal produces []any.
 	if result["type"] == "object" {
 		if props, ok := result["properties"].(map[string]any); ok {
-			if required, ok := result["required"].([]any); ok {
+			switch req := result["required"].(type) {
+			case []any:
 				filtered := make([]any, 0)
-				for _, r := range required {
+				for _, r := range req {
 					if s, ok := r.(string); ok {
 						if _, exists := props[s]; exists {
 							filtered = append(filtered, r)
 						}
+					}
+				}
+				result["required"] = filtered
+			case []string:
+				filtered := make([]any, 0)
+				for _, s := range req {
+					if _, exists := props[s]; exists {
+						filtered = append(filtered, s)
 					}
 				}
 				result["required"] = filtered
@@ -99,8 +138,9 @@ func sanitizeImpl(obj any) any {
 		delete(result, "required")
 	}
 
-	// Gemini API does not support additionalProperties in JSON Schema.
+	// Gemini API does not support additionalProperties or format in JSON Schema.
 	delete(result, "additionalProperties")
+	delete(result, "format")
 
 	return result
 }

--- a/internal/gemini/schema_test.go
+++ b/internal/gemini/schema_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -287,5 +288,161 @@ func TestSanitizeSchema_EnumWithNoType(t *testing.T) {
 	enumArr := result["enum"].([]any)
 	if enumArr[0] != "1" {
 		t.Errorf("enum[0] = %v, want '1'", enumArr[0])
+	}
+}
+
+func TestSanitizeSchema_PointerToStructNullableType(t *testing.T) {
+	// SchemaFrom produces []string{"object","null"} for pointer-to-struct fields.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"address": map[string]any{
+				"type": []string{"object", "null"},
+				"properties": map[string]any{
+					"street": map[string]any{"type": "string"},
+				},
+				"required":             []string{"street"},
+				"additionalProperties": false,
+			},
+		},
+		"required":             []string{"address"},
+		"additionalProperties": false,
+	}
+	result := SanitizeSchema(schema)
+
+	props := result["properties"].(map[string]any)
+	addr := props["address"].(map[string]any)
+
+	// Type should be normalized to plain "object".
+	if addr["type"] != "object" {
+		t.Errorf("address.type = %v, want \"object\"", addr["type"])
+	}
+	// Should be marked nullable.
+	if addr["nullable"] != true {
+		t.Errorf("address.nullable = %v, want true", addr["nullable"])
+	}
+	// Properties should be preserved (not stripped).
+	if _, ok := addr["properties"]; !ok {
+		t.Error("address.properties should be preserved for object type")
+	}
+	// additionalProperties should be removed.
+	if _, ok := addr["additionalProperties"]; ok {
+		t.Error("additionalProperties should be removed")
+	}
+	// Nested required ([]string) should be filtered correctly.
+	if req, ok := addr["required"]; ok {
+		reqArr := req.([]any)
+		if len(reqArr) != 1 || reqArr[0] != "street" {
+			t.Errorf("address.required = %v, want [street]", reqArr)
+		}
+	}
+}
+
+func TestSanitizeSchema_TimeDateTimeFormat(t *testing.T) {
+	// time.Time produces type: "string", format: "date-time".
+	// Gemini doesn't support format, so it should be stripped.
+	schema := map[string]any{
+		"type":   "string",
+		"format": "date-time",
+	}
+	result := SanitizeSchema(schema)
+	if _, ok := result["format"]; ok {
+		t.Error("format should be removed for Gemini compatibility")
+	}
+	if result["type"] != "string" {
+		t.Errorf("type = %v, want string", result["type"])
+	}
+}
+
+func TestSanitizeSchema_RequiredAsStringSlice(t *testing.T) {
+	// SchemaFrom produces required as []string, not []any.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+			"age":  map[string]any{"type": "integer"},
+		},
+		"required": []string{"name", "age", "nonexistent"},
+	}
+	result := SanitizeSchema(schema)
+	required := result["required"].([]any)
+	if len(required) != 2 {
+		t.Fatalf("required = %v, want [name age]", required)
+	}
+	// Check both fields are present.
+	got := map[string]bool{}
+	for _, r := range required {
+		got[r.(string)] = true
+	}
+	if !got["name"] || !got["age"] {
+		t.Errorf("required = %v, want name and age", required)
+	}
+}
+
+func TestSanitizeSchema_NullableTypeAsAnySlice(t *testing.T) {
+	// If type comes as []any (e.g., from JSON unmarshal), it should also be normalized.
+	schema := map[string]any{
+		"type": []any{"string", "null"},
+	}
+	result := SanitizeSchema(schema)
+	if result["type"] != "string" {
+		t.Errorf("type = %v, want \"string\"", result["type"])
+	}
+	if result["nullable"] != true {
+		t.Errorf("nullable = %v, want true", result["nullable"])
+	}
+}
+
+func TestSanitizeSchema_FullSchemaFromOutput(t *testing.T) {
+	// Simulate what SchemaFrom produces for a struct with pointer and time fields.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+			"created_at": map[string]any{
+				"type":   "string",
+				"format": "date-time",
+			},
+			"metadata": map[string]any{
+				"type": []string{"object", "null"},
+				"properties": map[string]any{
+					"key": map[string]any{"type": "string"},
+				},
+				"required":             []string{"key"},
+				"additionalProperties": false,
+			},
+		},
+		"required":             []string{"name", "created_at", "metadata"},
+		"additionalProperties": false,
+	}
+	result := SanitizeSchema(schema)
+
+	// Top-level: additionalProperties removed, required filtered.
+	if _, ok := result["additionalProperties"]; ok {
+		t.Error("top-level additionalProperties should be removed")
+	}
+	req := result["required"].([]any)
+	if !reflect.DeepEqual(req, []any{"name", "created_at", "metadata"}) {
+		t.Errorf("required = %v", req)
+	}
+
+	props := result["properties"].(map[string]any)
+
+	// created_at: format removed.
+	createdAt := props["created_at"].(map[string]any)
+	if _, ok := createdAt["format"]; ok {
+		t.Error("created_at.format should be removed")
+	}
+
+	// metadata: type normalized, nullable set, properties preserved.
+	meta := props["metadata"].(map[string]any)
+	if meta["type"] != "object" {
+		t.Errorf("metadata.type = %v, want \"object\"", meta["type"])
+	}
+	if meta["nullable"] != true {
+		t.Error("metadata.nullable should be true")
+	}
+	if _, ok := meta["properties"]; !ok {
+		t.Error("metadata.properties should be preserved")
 	}
 }

--- a/object.go
+++ b/object.go
@@ -39,6 +39,10 @@ type ObjectStream[T any] struct {
 	// Channel returned by the first PartialObjectStream() call.
 	partialCh <-chan *T
 
+	// Hook support.
+	onResponse func(ResponseInfo)
+	startTime  time.Time
+
 	// Accumulated state.
 	text         strings.Builder
 	finishReason provider.FinishReason
@@ -46,6 +50,7 @@ type ObjectStream[T any] struct {
 	response     provider.ResponseMetadata
 	finalObject  *T
 	parseErr     error
+	streamErr    error
 }
 
 func newObjectStream[T any](ctx context.Context, source <-chan provider.StreamChunk) *ObjectStream[T] {
@@ -81,6 +86,10 @@ func (os *ObjectStream[T]) Result() (*ObjectResult[T], error) {
 	})
 	<-os.doneCh
 
+	if os.streamErr != nil {
+		return nil, os.streamErr
+	}
+
 	if os.parseErr != nil {
 		return nil, fmt.Errorf("parsing structured output: %w (raw: %s)", os.parseErr, truncate(os.text.String(), 200))
 	}
@@ -100,6 +109,15 @@ func (os *ObjectStream[T]) Result() (*ObjectResult[T], error) {
 	}, nil
 }
 
+// Err returns the first stream error encountered, or nil.
+// Must be called after the stream is fully consumed (after Result(),
+// or after the PartialObjectStream() channel is drained).
+// Follows the bufio.Scanner.Err() pattern.
+func (os *ObjectStream[T]) Err() error {
+	<-os.doneCh
+	return os.streamErr
+}
+
 func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 	defer close(os.doneCh)
 	if os.timeoutCancel != nil {
@@ -107,6 +125,17 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 	}
 	if partialOut != nil {
 		defer close(partialOut)
+	}
+
+	// Call OnResponse hook when consume finishes (after all chunks processed).
+	if os.onResponse != nil {
+		defer func() {
+			os.onResponse(ResponseInfo{
+				Latency:      time.Since(os.startTime),
+				Usage:        os.usage,
+				FinishReason: os.finishReason,
+			})
+		}()
 	}
 
 	for chunk := range os.source {
@@ -129,6 +158,10 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 			os.finishReason = chunk.FinishReason
 			os.usage = chunk.Usage
 			os.response = chunk.Response
+		case provider.ChunkError:
+			if os.streamErr == nil {
+				os.streamErr = chunk.Error
+			}
 		}
 	}
 
@@ -147,6 +180,10 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 // GenerateObject performs a non-streaming structured output generation.
 // The schema is auto-generated from T, or can be overridden with WithExplicitSchema.
 func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, opts ...Option) (*ObjectResult[T], error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
 	o := applyOptions(opts...)
 
 	if o.Timeout > 0 {
@@ -221,6 +258,10 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 // StreamObject performs a streaming structured output generation.
 // Returns an ObjectStream that emits progressively populated partial objects.
 func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts ...Option) (*ObjectStream[T], error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
 	o := applyOptions(opts...)
 
 	var timeoutCancel context.CancelFunc
@@ -242,6 +283,16 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 		Schema: schema,
 	}
 
+	if o.OnRequest != nil {
+		o.OnRequest(RequestInfo{
+			Model:        model.ModelID(),
+			MessageCount: len(params.Messages),
+			ToolCount:    len(params.Tools),
+			Timestamp:    time.Now(),
+		})
+	}
+
+	start := time.Now()
 	result, err := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
@@ -249,11 +300,21 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 		if timeoutCancel != nil {
 			timeoutCancel()
 		}
+		if o.OnResponse != nil {
+			info := ResponseInfo{Latency: time.Since(start), Error: err}
+			var apiErr *APIError
+			if errors.As(err, &apiErr) {
+				info.StatusCode = apiErr.StatusCode
+			}
+			o.OnResponse(info)
+		}
 		return nil, err
 	}
 
 	os := newObjectStream[T](ctx, result.Stream)
 	os.timeoutCancel = timeoutCancel
+	os.onResponse = o.OnResponse
+	os.startTime = start
 	return os, nil
 }
 

--- a/object_test.go
+++ b/object_test.go
@@ -3,6 +3,7 @@ package goai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -243,8 +244,8 @@ func TestGenerateObject_ModelError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from model")
 	}
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected *APIError, got %T", err)
 	}
 	if apiErr.StatusCode != 500 {
@@ -986,7 +987,7 @@ func TestGenerateObject_WithTimeout(t *testing.T) {
 	}
 	result, err := GenerateObject[simpleObject](t.Context(), model,
 		WithPrompt("test"),
-		WithTimeout(5000000000), // 5s
+		WithTimeout(5*time.Second),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1033,7 +1034,7 @@ func TestStreamObject_WithTimeout(t *testing.T) {
 	}
 	stream, err := StreamObject[simpleObject](t.Context(), model,
 		WithPrompt("test"),
-		WithTimeout(5000000000),
+		WithTimeout(5*time.Second),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1063,8 +1064,8 @@ func TestStreamObject_WithTimeout_ErrorCancelsContext(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected *APIError, got %T", err)
 	}
 	if apiErr.StatusCode != 400 {

--- a/options.go
+++ b/options.go
@@ -174,7 +174,12 @@ func WithStopSequences(seqs ...string) Option {
 
 // WithMaxSteps sets the maximum auto tool loop iterations.
 func WithMaxSteps(n int) Option {
-	return func(o *options) { o.MaxSteps = n }
+	return func(o *options) {
+		if n < 1 {
+			n = 1
+		}
+		o.MaxSteps = n
+	}
 }
 
 // WithMaxRetries sets the retry count for transient errors.

--- a/partial_json.go
+++ b/partial_json.go
@@ -88,6 +88,22 @@ func repairJSON(s string) string {
 
 	// Close open string.
 	if inString || escaped {
+		// If we ended mid-escape (trailing backslash), drop the backslash
+		// so closing with `"` doesn't produce `\"` (escaped quote).
+		if escaped && len(result) > 0 && result[len(result)-1] == '\\' {
+			result = result[:len(result)-1]
+		}
+
+		// Strip incomplete \uXXXX escape sequences at the end of the string.
+		// A valid unicode escape is exactly \uXXXX (6 chars). If we see \u
+		// followed by fewer than 4 hex digits at the tail, remove the partial escape.
+		if idx := strings.LastIndex(result, `\u`); idx >= 0 {
+			tail := result[idx:]
+			if len(tail) < 6 { // incomplete \uXXXX
+				result = result[:idx]
+			}
+		}
+
 		result += `"`
 	}
 
@@ -117,6 +133,17 @@ func completeTrailing(s string) string {
 	// Complete truncated keywords.
 	keywords := []string{"true", "false", "null"}
 	for _, kw := range keywords {
+		// Check exact match first (complete keyword should not fall through to number handling).
+		if strings.HasSuffix(trimmed, kw) {
+			pos := len(trimmed) - len(kw)
+			if pos > 0 {
+				prev := trimmed[pos-1]
+				if prev != ':' && prev != ',' && prev != '[' && prev != '{' && prev != ' ' && prev != '\t' && prev != '\n' {
+					continue
+				}
+			}
+			return s
+		}
 		for prefixLen := 1; prefixLen < len(kw); prefixLen++ {
 			if strings.HasSuffix(trimmed, kw[:prefixLen]) {
 				// Verify it's a word boundary (preceded by : , [ { or whitespace).
@@ -135,7 +162,7 @@ func completeTrailing(s string) string {
 	// Complete truncated numbers.
 	last := trimmed[len(trimmed)-1]
 	switch last {
-	case '.', '-', '+', 'e', 'E':
+	case '.', '-', 'e', 'E':
 		return trimmed + "0"
 	}
 

--- a/partial_json_test.go
+++ b/partial_json_test.go
@@ -170,9 +170,14 @@ func TestRepairJSON(t *testing.T) {
 			expected: `{"a": "he said \"hi\""}`,
 		},
 		{
-			name:     "truncated after escape backslash",
+			name:     "escaped backslash in string",
 			input:    `{"a": "path\\`,
 			expected: `{"a": "path\\"}`,
+		},
+		{
+			name:     "trailing lone backslash in string",
+			input:    "{\"a\": \"ab\\",
+			expected: `{"a": "ab"}`,
 		},
 
 		// Object in array.
@@ -234,7 +239,7 @@ func TestCompleteTrailing(t *testing.T) {
 		{
 			name:     "trailing plus",
 			input:    `{"a": +`,
-			expected: `{"a": +0`,
+			expected: `{"a": +`,
 		},
 		{
 			name:     "trailing e",

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -176,6 +176,17 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	out := make(chan provider.StreamChunk, 64)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		// Close body on context cancellation to unblock scanner.Scan().
+		// Without this, the goroutine leaks if the server stalls mid-stream.
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		parseSSE(ctx, resp.Body, out, rfMode)
 	}()
 
@@ -1114,7 +1125,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 			providerMeta["reasoning"] = append(reasoning, map[string]any{
 				"type": "redacted_thinking", "data": block.Data,
 			})
-		case "tool_use":
+		case "tool_use", "server_tool_use":
 			result.ToolCalls = append(result.ToolCalls, provider.ToolCall{
 				ID:    block.ID,
 				Name:  block.Name,

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -833,13 +833,16 @@ func TestWithHeaders(t *testing.T) {
 		WithBaseURL(server.URL),
 		WithHeaders(map[string]string{"X-Custom": "value"}),
 	)
-	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "ok")
 	}
 }
 
@@ -855,13 +858,16 @@ func TestWithTokenSource(t *testing.T) {
 
 	ts := provider.StaticToken("dynamic-token")
 	model := Chat("claude-sonnet-4-20250514", WithTokenSource(ts), WithBaseURL(server.URL))
-	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "ok")
 	}
 }
 

--- a/provider/anthropic/tools.go
+++ b/provider/anthropic/tools.go
@@ -392,6 +392,8 @@ func betaForTool(toolType string) string {
 		return "code-execution-2025-08-25"
 	case "code_execution_20260120":
 		return "" // no beta needed
+	case "web_search_20250305":
+		return "web-search-2025-03-05"
 	case "web_search_20260209", "web_fetch_20260209":
 		return "code-execution-web-tools-2026-02-09"
 	default:

--- a/provider/bedrock/bedrock.go
+++ b/provider/bedrock/bedrock.go
@@ -223,7 +223,7 @@ func (m *chatModel) readIDRegion() (string, string) {
 func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
 		Temperature:      true,
-		ToolCall:         modelSupportsTools(m.id),
+		ToolCall:         modelSupportsTools(m.ModelID()),
 		InputModalities:  provider.ModalitySet{Text: true, Image: true},
 		OutputModalities: provider.ModalitySet{Text: true},
 	}

--- a/provider/bedrock/bedrock_test.go
+++ b/provider/bedrock/bedrock_test.go
@@ -387,13 +387,16 @@ func TestWithHeaders(t *testing.T) {
 	defer server.Close()
 
 	model := Chat("m", WithAccessKey("AK"), WithSecretKey("SK"), WithBaseURL(server.URL), WithHeaders(map[string]string{"X-Custom": "val"}))
-	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
 		},
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "ok")
 	}
 }
 

--- a/provider/bedrock/converse.go
+++ b/provider/bedrock/converse.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -473,6 +474,17 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 	defer close(out)
 	defer func() { _ = body.Close() }()
 
+	// Watch for context cancellation and close the body to unblock decoder.Next().
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = body.Close()
+		case <-done:
+		}
+	}()
+	defer close(done)
+
 	decoder := newEventStreamDecoder(body)
 
 	// Track content blocks by index to know if a block is text or toolUse.
@@ -489,7 +501,7 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 	for {
 		frame, err := decoder.Next()
 		if err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				return
 			}
 			if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: err}) {

--- a/provider/bedrock/eventstream.go
+++ b/provider/bedrock/eventstream.go
@@ -53,6 +53,10 @@ func (d *eventStreamDecoder) Next() (*eventStreamFrame, error) {
 		return nil, fmt.Errorf("eventstream: invalid total length %d", totalLen)
 	}
 
+	if int(headersLen) > remaining {
+		return nil, fmt.Errorf("eventstream: headers length %d exceeds frame payload %d", headersLen, remaining)
+	}
+
 	buf := make([]byte, remaining+4) // +4 for message CRC
 	if _, err := io.ReadFull(d.r, buf); err != nil {
 		return nil, fmt.Errorf("eventstream: reading frame body: %w", err)
@@ -129,6 +133,9 @@ func (d *eventStreamDecoder) Next() (*eventStreamFrame, error) {
 				return nil, fmt.Errorf("eventstream: bytes header length overflow")
 			}
 			bLen := int(binary.BigEndian.Uint16(headers[off : off+2]))
+			if off+2+bLen > len(headers) {
+				return nil, fmt.Errorf("eventstream: bytes header value overflows header block")
+			}
 			off += 2 + bLen
 		default:
 			return nil, fmt.Errorf("eventstream: unknown header type tag %d", typeTag)

--- a/provider/cerebras/cerebras.go
+++ b/provider/cerebras/cerebras.go
@@ -137,7 +137,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/cohere/cohere.go
+++ b/provider/cohere/cohere.go
@@ -163,6 +163,17 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	out := make(chan provider.StreamChunk, 64)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		// Close body on context cancellation to unblock parseChatStream.
+		// Without this, the goroutine leaks if the server stalls mid-stream.
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		parseChatStream(ctx, resp.Body, out)
 	}()
 

--- a/provider/compat/compat.go
+++ b/provider/compat/compat.go
@@ -34,10 +34,19 @@ var (
 type Option func(*options)
 
 type options struct {
+	providerID  string
 	tokenSource provider.TokenSource
 	baseURL     string
 	headers     map[string]string
 	httpClient  *http.Client
+}
+
+// WithProviderID overrides the provider name used in error messages.
+// Defaults to "compat".
+func WithProviderID(id string) Option {
+	return func(o *options) {
+		o.providerID = id
+	}
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -79,7 +88,7 @@ func WithHTTPClient(c *http.Client) Option {
 // Chat creates a generic OpenAI-compatible language model.
 // WithBaseURL is required; calls will fail without it.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
-	o := options{}
+	o := options{providerID: "compat"}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -89,7 +98,7 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 // Embedding creates a generic OpenAI-compatible embedding model.
 // WithBaseURL is required; calls will fail without it.
 func Embedding(modelID string, opts ...Option) provider.EmbeddingModel {
-	o := options{}
+	o := options{providerID: "compat"}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -153,6 +162,15 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
 	}()
 
@@ -191,7 +209,7 @@ func (m *chatModel) doHTTP(ctx context.Context, body map[string]any) (*http.Resp
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		return nil, goai.ParseHTTPErrorWithHeaders("compat", resp.StatusCode, respBody, resp.Header)
+		return nil, goai.ParseHTTPErrorWithHeaders(m.opts.providerID, resp.StatusCode, respBody, resp.Header)
 	}
 
 	return resp, nil
@@ -261,7 +279,7 @@ func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params pr
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, goai.ParseHTTPErrorWithHeaders("compat", resp.StatusCode, respBody, resp.Header)
+		return nil, goai.ParseHTTPErrorWithHeaders(m.opts.providerID, resp.StatusCode, respBody, resp.Header)
 	}
 
 	respBody, err := io.ReadAll(resp.Body)

--- a/provider/deepinfra/deepinfra.go
+++ b/provider/deepinfra/deepinfra.go
@@ -137,7 +137,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/deepseek/deepseek.go
+++ b/provider/deepseek/deepseek.go
@@ -138,7 +138,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/fireworks/fireworks.go
+++ b/provider/fireworks/fireworks.go
@@ -137,7 +137,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/google/embedding.go
+++ b/provider/google/embedding.go
@@ -134,7 +134,7 @@ func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params pr
 	return &provider.EmbedResult{
 		Embeddings: embeddings,
 		// Gemini doesn't return token usage for embeddings.
-		Usage: provider.Usage{InputTokens: len(values)},
+		Usage: provider.Usage{},
 	}, nil
 }
 

--- a/provider/google/embedding_test.go
+++ b/provider/google/embedding_test.go
@@ -66,9 +66,9 @@ func TestEmbedding_SingleValue(t *testing.T) {
 	if result.Embeddings[0][0] != 0.1 || result.Embeddings[0][1] != 0.2 || result.Embeddings[0][2] != 0.3 {
 		t.Errorf("unexpected embedding values: %v", result.Embeddings[0])
 	}
-	// Google uses len(values) as input tokens.
-	if result.Usage.InputTokens != 1 {
-		t.Errorf("expected 1 input token, got %d", result.Usage.InputTokens)
+	// Google embedding API does not return token counts; InputTokens should be 0.
+	if result.Usage.InputTokens != 0 {
+		t.Errorf("expected 0 input tokens, got %d", result.Usage.InputTokens)
 	}
 }
 
@@ -109,8 +109,8 @@ func TestEmbedding_MultipleValues(t *testing.T) {
 	if result.Embeddings[2][1] != 0.6 {
 		t.Errorf("expected third embedding [1]=0.6, got %f", result.Embeddings[2][1])
 	}
-	if result.Usage.InputTokens != 3 {
-		t.Errorf("expected 3 input tokens, got %d", result.Usage.InputTokens)
+	if result.Usage.InputTokens != 0 {
+		t.Errorf("expected 0 input tokens, got %d", result.Usage.InputTokens)
 	}
 }
 

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -708,7 +708,7 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 	}
 
 	// Send final finish chunk only on clean stream completion.
-	usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+	usage.TotalTokens = usage.InputTokens + usage.OutputTokens + usage.ReasoningTokens
 	provider.TrySend(ctx, out, provider.StreamChunk{ // terminal send
 		Type:     provider.ChunkFinish,
 		Usage:    usage,
@@ -801,7 +801,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 		if result.Usage.OutputTokens < 0 {
 			result.Usage.OutputTokens = 0
 		}
-		result.Usage.TotalTokens = result.Usage.InputTokens + result.Usage.OutputTokens
+		result.Usage.TotalTokens = result.Usage.InputTokens + result.Usage.OutputTokens + result.Usage.ReasoningTokens
 	}
 
 	if len(resp.Candidates) == 0 {

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -212,13 +212,18 @@ func TestChat_Stream_OverflowError(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	found := false
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
+			found = true
 			var overflow *goai.ContextOverflowError
 			if !errors.As(chunk.Error, &overflow) {
 				t.Errorf("expected ContextOverflowError, got %T", chunk.Error)
 			}
 		}
+	}
+	if !found {
+		t.Fatal("expected overflow error chunk")
 	}
 }
 
@@ -257,8 +262,10 @@ func TestChat_Stream_CachedTokens(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	found := false
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkFinish {
+			found = true
 			if chunk.Usage.InputTokens != 20 {
 				t.Errorf("InputTokens = %d, want 20 (100-80)", chunk.Usage.InputTokens)
 			}
@@ -266,6 +273,9 @@ func TestChat_Stream_CachedTokens(t *testing.T) {
 				t.Errorf("CacheReadTokens = %d, want 80", chunk.Usage.CacheReadTokens)
 			}
 		}
+	}
+	if !found {
+		t.Fatal("expected finish chunk with usage data")
 	}
 }
 

--- a/provider/google/image.go
+++ b/provider/google/image.go
@@ -190,14 +190,37 @@ func (m *geminiImageModel) DoGenerate(ctx context.Context, params provider.Image
 	}
 
 	genConfig := map[string]any{
-		"responseModalities": []string{"IMAGE"},
+		"responseModalities": []string{"TEXT", "IMAGE"},
 	}
 
-	// Extract google-specific options for image config.
+	// Map params.N to numberOfImages in the generation config.
+	// Gemini's generateContent supports numberOfImages to request multiple images.
+	if params.N > 1 {
+		genConfig["numberOfImages"] = params.N
+	}
+
+	// Note: params.Size is not supported by the Gemini generateContent endpoint.
+	// Use provider options {"google": {"imageConfig": {"imageSize": "1K"}}} instead.
+
+	// Build imageConfig from params and provider options.
+	imageConfig := map[string]any{}
+
+	// Map params.AspectRatio into imageConfig if set.
+	if params.AspectRatio != "" {
+		imageConfig["aspectRatio"] = params.AspectRatio
+	}
+
+	// Extract google-specific options for image config (overrides params).
 	if gopts, ok := params.ProviderOptions["google"].(map[string]any); ok {
 		if ic, ok := gopts["imageConfig"].(map[string]any); ok {
-			genConfig["imageConfig"] = ic
+			for k, v := range ic {
+				imageConfig[k] = v
+			}
 		}
+	}
+
+	if len(imageConfig) > 0 {
+		genConfig["imageConfig"] = imageConfig
 	}
 
 	body := map[string]any{

--- a/provider/google/image_test.go
+++ b/provider/google/image_test.go
@@ -291,7 +291,7 @@ func TestGeminiImage_Generate(t *testing.T) {
 		// Verify generationConfig has responseModalities.
 		gc := req["generationConfig"].(map[string]any)
 		rm := gc["responseModalities"].([]any)
-		if len(rm) != 1 || rm[0] != "IMAGE" {
+		if len(rm) != 2 || rm[0] != "TEXT" || rm[1] != "IMAGE" {
 			t.Errorf("responseModalities = %v", rm)
 		}
 

--- a/provider/groq/groq.go
+++ b/provider/groq/groq.go
@@ -137,7 +137,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/mistral/mistral.go
+++ b/provider/mistral/mistral.go
@@ -137,7 +137,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/ollama/ollama.go
+++ b/provider/ollama/ollama.go
@@ -65,7 +65,7 @@ func Embedding(modelID string, opts ...Option) provider.EmbeddingModel {
 }
 
 func toCompatOpts(o options) []compat.Option {
-	copts := []compat.Option{compat.WithBaseURL(o.baseURL)}
+	copts := []compat.Option{compat.WithProviderID("ollama"), compat.WithBaseURL(o.baseURL)}
 	if o.headers != nil {
 		copts = append(copts, compat.WithHeaders(o.headers))
 	}

--- a/provider/openai/image.go
+++ b/provider/openai/image.go
@@ -67,6 +67,10 @@ func (m *imageModel) DoGenerate(ctx context.Context, params provider.ImageParams
 		body["size"] = params.Size
 	}
 
+	// Note: params.AspectRatio is not mapped because OpenAI's image API uses
+	// explicit "size" dimensions (e.g. "1024x1024") rather than aspect ratios.
+	// Callers should use params.Size or pass "size" via ProviderOptions instead.
+
 	// Item 13: provider options passthrough (quality, style, seed, etc.).
 	for k, v := range params.ProviderOptions {
 		body[k] = v

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -708,7 +708,7 @@ func TestChat_CustomHeaders(t *testing.T) {
 		WithBaseURL(server.URL),
 		WithHeaders(map[string]string{"X-Custom": "value"}),
 	)
-	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
 		},
@@ -716,6 +716,9 @@ func TestChat_CustomHeaders(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "ok")
 	}
 }
 
@@ -733,7 +736,7 @@ func TestChat_TokenSource(t *testing.T) {
 		WithTokenSource(provider.StaticToken("dynamic-token")),
 		WithBaseURL(server.URL),
 	)
-	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
 		},
@@ -741,6 +744,9 @@ func TestChat_TokenSource(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "ok")
 	}
 }
 

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -315,6 +315,10 @@ func convertToResponsesInput(msgs []provider.Message) []map[string]any {
 				switch part.Type {
 				case provider.PartText:
 					textParts = append(textParts, part.Text)
+				case provider.PartReasoning:
+					if part.Text != "" {
+						textParts = append(textParts, part.Text)
+					}
 				case provider.PartToolCall:
 					items = append(items, map[string]any{
 						"type":      "function_call",
@@ -788,6 +792,13 @@ type responsesResult struct {
 		CallID    string `json:"call_id,omitempty"`
 		Name      string `json:"name,omitempty"`
 		Arguments string `json:"arguments,omitempty"`
+
+		// reasoning fields
+		ID      string `json:"id,omitempty"`
+		Summary []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"summary,omitempty"`
 	} `json:"output"`
 
 	Usage *struct {
@@ -883,6 +894,16 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 				Name:  item.Name,
 				Input: json.RawMessage(item.Arguments),
 			})
+		case "reasoning":
+			for _, s := range item.Summary {
+				if s.Text != "" {
+					reasoning, _ := providerMeta["reasoning"].([]map[string]any)
+					providerMeta["reasoning"] = append(reasoning, map[string]any{
+						"type": s.Type,
+						"text": s.Text,
+					})
+				}
+			}
 		}
 	}
 

--- a/provider/openrouter/openrouter.go
+++ b/provider/openrouter/openrouter.go
@@ -150,7 +150,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/perplexity/perplexity.go
+++ b/provider/perplexity/perplexity.go
@@ -137,7 +137,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/together/together.go
+++ b/provider/together/together.go
@@ -138,7 +138,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/vertex/adc.go
+++ b/provider/vertex/adc.go
@@ -2,6 +2,7 @@ package vertex
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"golang.org/x/oauth2/google"
@@ -17,19 +18,28 @@ import (
 //  3. GCE metadata service (when running on Google Cloud)
 //
 // This is the Go equivalent of Vercel's google-auth-library auto-detection.
+// Credentials are resolved once at construction time; only token refresh happens
+// on subsequent calls.
 //
 // Usage:
 //
+//	ts, err := vertex.ADCTokenSource(ctx)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
 //	model := vertex.Chat("gemini-2.5-pro",
-//		vertex.WithTokenSource(vertex.ADCTokenSource()),
+//		vertex.WithTokenSource(ts),
 //		vertex.WithProject("my-project"),
 //	)
-func ADCTokenSource() provider.TokenSource {
+func ADCTokenSource(ctx context.Context, scopes ...string) (provider.TokenSource, error) {
+	if len(scopes) == 0 {
+		scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
+	}
+	creds, err := google.FindDefaultCredentials(ctx, scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("vertex: finding default credentials: %w", err)
+	}
 	return provider.CachedTokenSource(func(ctx context.Context) (*provider.Token, error) {
-		creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
-		if err != nil {
-			return nil, err
-		}
 		tok, err := creds.TokenSource.Token()
 		if err != nil {
 			return nil, err
@@ -38,5 +48,5 @@ func ADCTokenSource() provider.TokenSource {
 			Value:     tok.AccessToken,
 			ExpiresAt: tok.Expiry.Add(-30 * time.Second), // refresh 30s early
 		}, nil
-	})
+	}), nil
 }

--- a/provider/vertex/adc_test.go
+++ b/provider/vertex/adc_test.go
@@ -14,26 +14,28 @@ import (
 // --- BF.9 Item 1: ADC TokenSource tests ---
 
 func TestADCTokenSource_Type(t *testing.T) {
-	// ADCTokenSource returns a provider.TokenSource -- verify the interface.
-	ts := ADCTokenSource()
-	if ts == nil {
-		t.Fatal("ADCTokenSource returned nil")
+	// Without valid credentials, ADCTokenSource may return an error.
+	// If it succeeds, verify the interface.
+	ts, err := ADCTokenSource(t.Context())
+	if err != nil {
+		// Expected when no GCP credentials are configured.
+		return
 	}
-	// We can't actually test Token() without GCP credentials,
-	// but we verify it returns a valid TokenSource.
+	if ts == nil {
+		t.Fatal("ADCTokenSource returned nil without error")
+	}
 	var _ provider.TokenSource = ts
 }
 
 func TestADCTokenSource_FindCredsError(t *testing.T) {
 	// Point GOOGLE_APPLICATION_CREDENTIALS at a nonexistent file to force
-	// google.FindDefaultCredentials to fail -- exercises the creds error path (line 30-31).
+	// google.FindDefaultCredentials to fail -- exercises the creds error path.
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/service-account.json")
 	t.Setenv("GOOGLE_API_KEY", "")
 	t.Setenv("GEMINI_API_KEY", "")
 	t.Setenv("GOOGLE_GENERATIVE_AI_API_KEY", "")
 
-	ts := ADCTokenSource()
-	_, err := ts.Token(t.Context())
+	_, err := ADCTokenSource(t.Context())
 	if err == nil {
 		t.Fatal("expected error when GOOGLE_APPLICATION_CREDENTIALS points to nonexistent file")
 	}
@@ -62,8 +64,11 @@ func TestADCTokenSource_TokenFetchError(t *testing.T) {
 	}
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credFile)
 
-	ts := ADCTokenSource()
-	_, err := ts.Token(t.Context())
+	ts, err := ADCTokenSource(t.Context())
+	if err != nil {
+		t.Fatalf("ADCTokenSource should succeed with valid JSON: %v", err)
+	}
+	_, err = ts.Token(t.Context())
 	// FindDefaultCredentials succeeds but token fetch fails (unreachable token_uri).
 	if err == nil {
 		t.Fatal("expected token fetch error")
@@ -103,7 +108,10 @@ func TestADCTokenSource_TokenSuccess(t *testing.T) {
 	}
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credFile)
 
-	ts := ADCTokenSource()
+	ts, err := ADCTokenSource(t.Context())
+	if err != nil {
+		t.Fatalf("ADCTokenSource failed: %v", err)
+	}
 	tok, err := ts.Token(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/provider/vertex/embedding.go
+++ b/provider/vertex/embedding.go
@@ -41,7 +41,7 @@ type embeddingModel struct {
 func (m *embeddingModel) ModelID() string { return m.id }
 
 // MaxValuesPerCall returns the maximum batch size for Vertex AI embeddings.
-func (m *embeddingModel) MaxValuesPerCall() int { return 2048 }
+func (m *embeddingModel) MaxValuesPerCall() int { return 250 }
 
 func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params provider.EmbedParams) (*provider.EmbedResult, error) {
 	// Extract vertex-specific options.

--- a/provider/vertex/embedding_test.go
+++ b/provider/vertex/embedding_test.go
@@ -238,8 +238,8 @@ func TestEmbedding_ModelID(t *testing.T) {
 
 func TestEmbedding_MaxValuesPerCall(t *testing.T) {
 	model := Embedding("text-embedding-004", WithTokenSource(provider.StaticToken("tok")))
-	if got := model.MaxValuesPerCall(); got != 2048 {
-		t.Errorf("MaxValuesPerCall = %d, want 2048", got)
+	if got := model.MaxValuesPerCall(); got != 250 {
+		t.Errorf("MaxValuesPerCall = %d, want 250", got)
 	}
 }
 

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -132,8 +132,12 @@ func resolveOpts(opts []Option) options {
 // When hasProject is false: prefer API key (simpler setup, works with Gemini API).
 func autoTokenSource(hasProject bool) provider.TokenSource {
 	if hasProject {
-		// Vertex mode: ADC first, API key as last resort.
-		return ADCTokenSource()
+		// Vertex mode: ADC required, API keys route to the Gemini API instead.
+		ts, err := ADCTokenSource(context.Background())
+		if err != nil {
+			return &failingTokenSource{err: err}
+		}
+		return ts
 	}
 	// No project: API key first (routes to Gemini API), ADC as fallback.
 	for _, env := range []string{"GOOGLE_API_KEY", "GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY"} {
@@ -141,7 +145,21 @@ func autoTokenSource(hasProject bool) provider.TokenSource {
 			return &apiKeyTokenSource{key: key}
 		}
 	}
-	return ADCTokenSource()
+	ts, err := ADCTokenSource(context.Background())
+	if err != nil {
+		// Return a token source that will report the error on first use.
+		return &failingTokenSource{err: err}
+	}
+	return ts
+}
+
+// failingTokenSource reports a credential resolution error on first use.
+type failingTokenSource struct {
+	err error
+}
+
+func (s *failingTokenSource) Token(_ context.Context) (string, error) {
+	return "", s.err
 }
 
 // apiKeyTokenSource is a marker type that signals URL builders to use
@@ -272,7 +290,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/vllm/vllm.go
+++ b/provider/vllm/vllm.go
@@ -81,7 +81,7 @@ func Embedding(modelID string, opts ...Option) provider.EmbeddingModel {
 }
 
 func toCompatOpts(o options) []compat.Option {
-	copts := []compat.Option{compat.WithBaseURL(o.baseURL)}
+	copts := []compat.Option{compat.WithProviderID("vllm"), compat.WithBaseURL(o.baseURL)}
 	if o.tokenSource != nil {
 		copts = append(copts, compat.WithTokenSource(o.tokenSource))
 	}

--- a/provider/xai/xai.go
+++ b/provider/xai/xai.go
@@ -137,7 +137,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	scanner := sse.NewScanner(resp.Body)
 	go func() {
 		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
 		openaicompat.ParseStream(ctx, scanner, out)
+		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/retry.go
+++ b/retry.go
@@ -80,7 +80,7 @@ func withRetry[T any](ctx context.Context, maxRetries int, fn func() (T, error))
 			delay = backoffDuration(attempt)
 		}
 		if sleepErr := sleep(ctx, delay); sleepErr != nil {
-			return result, err
+			return result, sleepErr
 		}
 		result, err = fn()
 	}

--- a/schema.go
+++ b/schema.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 )
 
 // schemaMarshalFunc is swappable for testing the panic path.
@@ -24,7 +25,7 @@ func SchemaFrom[T any]() json.RawMessage {
 	for t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
-	schema := typeToSchema(t)
+	schema := typeToSchema(t, make(map[reflect.Type]bool))
 	// typeToSchema only produces JSON-safe types (map[string]any with string/bool/int/slice values),
 	// so json.Marshal cannot fail here. Panic on impossible error to surface bugs in typeToSchema.
 	data, err := schemaMarshalFunc(schema)
@@ -34,15 +35,30 @@ func SchemaFrom[T any]() json.RawMessage {
 	return data
 }
 
-func typeToSchema(t reflect.Type) map[string]any {
+var (
+	timeType       = reflect.TypeOf(time.Time{})
+	rawMessageType = reflect.TypeOf(json.RawMessage{})
+)
+
+func typeToSchema(t reflect.Type, seen map[reflect.Type]bool) map[string]any {
 	// Unwrap pointer: nullable type.
 	if t.Kind() == reflect.Ptr {
-		inner := typeToSchema(t.Elem())
+		inner := typeToSchema(t.Elem(), seen)
 		// Make nullable: type becomes array ["<type>", "null"].
 		if baseType, ok := inner["type"].(string); ok {
 			inner["type"] = []string{baseType, "null"}
 		}
 		return inner
+	}
+
+	// Special case: time.Time → string with date-time format.
+	if t == timeType {
+		return map[string]any{"type": "string", "format": "date-time"}
+	}
+
+	// Special case: json.RawMessage → any type (empty schema).
+	if t == rawMessageType {
+		return map[string]any{}
 	}
 
 	switch t.Kind() {
@@ -57,24 +73,31 @@ func typeToSchema(t reflect.Type) map[string]any {
 	case reflect.Float32, reflect.Float64:
 		return map[string]any{"type": "number"}
 	case reflect.Slice:
-		return map[string]any{"type": "array", "items": typeToSchema(t.Elem())}
+		return map[string]any{"type": "array", "items": typeToSchema(t.Elem(), seen)}
 	case reflect.Map:
 		if t.Key().Kind() == reflect.String {
-			return map[string]any{"type": "object", "additionalProperties": typeToSchema(t.Elem())}
+			return map[string]any{"type": "object", "additionalProperties": typeToSchema(t.Elem(), seen)}
 		}
 		return map[string]any{"type": "object"}
 	case reflect.Struct:
-		return structToSchema(t)
+		// Cycle detection: if we're already processing this struct, break the cycle.
+		if seen[t] {
+			return map[string]any{}
+		}
+		seen[t] = true
+		result := structToSchema(t, seen)
+		delete(seen, t)
+		return result
 	default:
 		return map[string]any{}
 	}
 }
 
-func structToSchema(t reflect.Type) map[string]any {
+func structToSchema(t reflect.Type, seen map[reflect.Type]bool) map[string]any {
 	properties := make(map[string]any)
 	var required []string
 
-	collectFields(t, properties, &required)
+	collectFields(t, properties, &required, seen)
 
 	schema := map[string]any{
 		"type":                 "object",
@@ -88,7 +111,7 @@ func structToSchema(t reflect.Type) map[string]any {
 }
 
 // collectFields recursively processes struct fields, flattening embedded structs.
-func collectFields(t reflect.Type, properties map[string]any, required *[]string) {
+func collectFields(t reflect.Type, properties map[string]any, required *[]string, seen map[reflect.Type]bool) {
 	for i := range t.NumField() {
 		field := t.Field(i)
 
@@ -99,7 +122,10 @@ func collectFields(t reflect.Type, properties map[string]any, required *[]string
 				ft = ft.Elem()
 			}
 			if ft.Kind() == reflect.Struct {
-				collectFields(ft, properties, required)
+				if seen[ft] {
+					continue
+				}
+				collectFields(ft, properties, required, seen)
 				continue
 			}
 		}
@@ -113,7 +139,7 @@ func collectFields(t reflect.Type, properties map[string]any, required *[]string
 		// Parse json tag.
 		if tag := field.Tag.Get("json"); tag != "" {
 			parts := strings.Split(tag, ",")
-			if parts[0] == "-" {
+			if parts[0] == "-" && (len(parts) == 1 || parts[1] != "") {
 				continue
 			}
 			if parts[0] != "" {
@@ -121,7 +147,7 @@ func collectFields(t reflect.Type, properties map[string]any, required *[]string
 			}
 		}
 
-		prop := typeToSchema(field.Type)
+		prop := typeToSchema(field.Type, seen)
 
 		// Parse jsonschema tag.
 		if tag := field.Tag.Get("jsonschema"); tag != "" {

--- a/schema_test.go
+++ b/schema_test.go
@@ -550,7 +550,7 @@ func TestSchemaFrom_EmptyStruct(t *testing.T) {
 
 func TestTypeToSchema_NonStringKeyMap(t *testing.T) {
 	// map[int]string → object with no additionalProperties schema.
-	result := typeToSchema(reflect.TypeOf(map[int]string{}))
+	result := typeToSchema(reflect.TypeOf(map[int]string{}), make(map[reflect.Type]bool))
 	if result["type"] != "object" {
 		t.Errorf("expected type object, got %v", result["type"])
 	}
@@ -561,7 +561,7 @@ func TestTypeToSchema_NonStringKeyMap(t *testing.T) {
 
 func TestTypeToSchema_UnsupportedType(t *testing.T) {
 	// chan int → empty schema.
-	result := typeToSchema(reflect.TypeOf(make(chan int)))
+	result := typeToSchema(reflect.TypeOf(make(chan int)), make(map[reflect.Type]bool))
 	if len(result) != 0 {
 		t.Errorf("expected empty schema for unsupported type, got %v", result)
 	}


### PR DESCRIPTION
## Summary

Comprehensive codebase audit via 5 rounds of parallel deep-review agents (10 agents per round, 50 total). Found and fixed 62 issues across security, correctness, consistency, and documentation.

### Security (4 fixes)
- **EventStream bounds checks** — attacker-controlled `headersLen`/bytes header could panic via out-of-bounds slice
- **Release workflow injection** — `$TAG` interpolated directly into Python string literal; now uses `os.environ`
- **Context-cancellation watchers** — all 20 provider `DoStream` methods now close `resp.Body` on `ctx.Done()`, preventing goroutine leaks on stalled servers

### Correctness (22 fixes)
- Message slice mutation in tool loop (`slices.Clone`)
- Bedrock `Capabilities()` data race (read `m.id` without RWMutex)
- `retry.go` returning stale API error on context cancellation
- Gemini schema sanitizer panic on `SchemaFrom` output (`[]string` required)
- Nullable type arrays stripping `properties`/`required` in Gemini sanitizer
- `SchemaFrom` for `time.Time`, `json.RawMessage`, recursive types, `json:"-,omitempty"`
- Partial JSON: trailing backslash, truncated `\uXXXX`, keyword completion, `+` sign
- Google `TotalTokens` excluding `ReasoningTokens`
- Anthropic `betaForTool` missing `web_search_20250305`
- Anthropic `server_tool_use` dropped in non-streaming parse
- OpenAI Responses API reasoning items silently discarded
- Vertex ADC calling `FindDefaultCredentials` on every refresh (now once at init)
- Vertex `MaxValuesPerCall` 2048→250, Google fake embedding token counts
- vllm/ollama errors reporting `"compat"` provider ID
- Embedding count validation, nil model checks, `WithMaxSteps` clamp

### Features (5 additions)
- `Err()` method on `TextStream`/`ObjectStream` (bufio.Scanner pattern)
- `OnRequest`/`OnResponse` hooks in `StreamText`/`StreamObject`
- `WithImageMaxRetries`/`WithImageTimeout` for `GenerateImage`
- `WithProviderID` option for compat provider
- Gemini image `N`, `AspectRatio`, `TEXT+IMAGE` modalities

### Tests & Docs (31 fixes)
- Type assertions → `errors.As`, found-guard variables, result assertions
- 5 new Gemini schema sanitizer tests
- 15 documentation files updated for accuracy

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — 26/26 packages pass
- [x] All pre-existing tests continue to pass
- [x] New Gemini sanitizer tests cover nullable types, format stripping, []string required