### PR TITLE
fix: comprehensive red-team audit (7 rounds, 60+ fixes)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 
 **Go version**: (output of `go version`)
 
-**GoAI version**: (e.g., v0.4.0)
+**GoAI version**: (e.g., v0.4.3)
 
 **Description**
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 - **Structured output**: `GenerateObject[T]` auto-generates JSON Schema from Go types via reflection
 - **Streaming**: Real-time text and partial object streaming via channels
 - **Dynamic auth**: `TokenSource` interface for OAuth, rotating keys, cloud IAM, with `CachedTokenSource` for TTL-based caching
-- **Prompt caching**: Automatic cache control for supported providers (Anthropic, OpenAI)
+- **Prompt caching**: Automatic cache control for supported providers (Anthropic, Bedrock)
 - **Citations/sources**: Grounding and inline citations from xAI, Perplexity, Google, OpenAI
 - **Web search**: Built-in web search tools for OpenAI, Anthropic, Google, Groq. Model decides when to search
 - **Code execution**: Server-side Python sandboxes via OpenAI, Anthropic, Google. No local setup

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # GoAI Roadmap
 
-> Last updated: 2026-03-16
+> Last updated: 2026-03-25
 
-## v0.4.0 - Current release
+## v0.4.3 - Current release
 
 ### Core functions
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -268,7 +268,7 @@ result, err := goai.GenerateImage(ctx, openai.Image("gpt-image-1"),
 // result.Images[0].Data = raw bytes, result.Images[0].MediaType = "image/png"
 ```
 
-**Note**: `GenerateImage` uses `ImageOption` (not `Option`): `WithImagePrompt`, `WithImageCount`, `WithImageSize`, `WithAspectRatio`, `WithImageProviderOptions`.
+**Note**: `GenerateImage` uses `ImageOption` (not `Option`): `WithImagePrompt`, `WithImageCount`, `WithImageSize`, `WithAspectRatio`, `WithImageMaxRetries`, `WithImageTimeout`, `WithImageProviderOptions`.
 
 ### 9. Provider-Defined Tools (Server-Side)
 
@@ -379,6 +379,8 @@ goai.WithImagePrompt(prompt string)                // text prompt
 goai.WithImageCount(n int)                         // number of images (default: 1)
 goai.WithImageSize(size string)                    // e.g. "1024x1024"
 goai.WithAspectRatio(ratio string)                 // e.g. "16:9"
+goai.WithImageMaxRetries(n int)                   // retries on 429/5xx
+goai.WithImageTimeout(d time.Duration)            // overall timeout
 goai.WithImageProviderOptions(opts map[string]any) // provider-specific params
 ```
 

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -121,6 +121,14 @@ func (ts *TextStream) Result() *TextResult
 
 Can be called after `Stream()` or `TextStream()` to get usage, finish reason, and the complete text. Can also be called without any streaming method to silently consume the stream and return the result.
 
+#### TextStream.Err
+
+Returns the first error encountered during streaming, or nil if the stream completed successfully. Follows the `bufio.Scanner.Err()` pattern: must be called after the stream is fully consumed (after `Result()`, or after the `Stream()`/`TextStream()` channel is drained). Blocks until the stream is done.
+
+```go
+func (ts *TextStream) Err() error
+```
+
 ---
 
 ## GenerateObject
@@ -195,6 +203,14 @@ func (os *ObjectStream[T]) Result() (*ObjectResult[T], error)
 ```
 
 Returns an error if JSON parsing of the accumulated text fails.
+
+### ObjectStream.Err
+
+Returns the first error encountered during streaming, or nil if the stream completed successfully. Follows the `bufio.Scanner.Err()` pattern: must be called after the stream is fully consumed (after `Result()`, or after the `PartialObjectStream()` channel is drained). Blocks until the stream is done.
+
+```go
+func (os *ObjectStream[T]) Err() error
+```
 
 **Example:**
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -27,17 +27,17 @@ The provider also reads `OPENAI_BASE_URL` from the environment when no explicit 
 
 | Model ID | Type | Notes |
 |----------|------|-------|
-| `gpt-4o` | Chat | Uses Responses API by default |
-| `gpt-4o-mini` | Chat | Uses Responses API by default |
-| `gpt-5` | Chat | Reasoning model, Responses API |
-| `gpt-5-mini` | Chat | Reasoning model, Responses API |
-| `o3` | Chat | Reasoning model, Responses API |
-| `o4-mini` | Chat | Reasoning model, Responses API |
-| `codex-*` | Chat | Reasoning model, Responses API |
+| `gpt-4o` | Chat | Responses API by default |
+| `gpt-4o-mini` | Chat | Responses API by default |
+| `gpt-5` | Chat | Reasoning model, Responses API by default |
+| `gpt-5-mini` | Chat | Reasoning model, Responses API by default |
+| `o3` | Chat | Reasoning model, Responses API by default |
+| `o4-mini` | Chat | Reasoning model, Responses API by default |
+| `codex-*` | Chat | Reasoning model, Responses API by default |
 | `text-embedding-3-small` | Embedding | 1536 dimensions |
 | `text-embedding-3-large` | Embedding | 3072 dimensions |
 | `text-embedding-ada-002` | Embedding | Legacy |
-| `dall-e-3` | Image | Requires explicit `response_format` |
+| `dall-e-3` | Image | Legacy image generation |
 | `gpt-image-1` | Image | Defaults to b64_json |
 
 ## Tested Models
@@ -313,6 +313,6 @@ This pattern supports Copilot (URL rewrite + OAuth token swap) and Codex (URL re
 ## Notes
 
 - The embedding model supports up to 2048 values per batch call via `MaxValuesPerCall()`. `goai.EmbedMany` auto-chunks larger batches.
-- Image models `gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5` default to `b64_json` response format and reject an explicit `response_format` parameter. Older models like `dall-e-3` require it explicitly.
+- Image models `gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5` default to `b64_json` response format and reject an explicit `response_format` parameter. For older models like `dall-e-3`, the provider automatically sets `response_format` to `b64_json`.
 - Structured output uses `response_format` with `json_schema` for both APIs. The Responses API places it under `text.format`.
 - Per-request headers can be injected via `goai.WithHeaders(map[string]string{...})` for features like Codex session tracking.

--- a/docs/providers/vertex.md
+++ b/docs/providers/vertex.md
@@ -132,7 +132,7 @@ Image provider options (pass under the `"vertex"` key in `ImageParams.ProviderOp
 ## Notes
 
 - For direct API key access without GCP, see the [Google provider](google.md).
-- Chat uses the Vertex AI OpenAI-compatible endpoint. Embeddings and image generation use the native Vertex AI `:predict` endpoint.
+- With ADC or an explicit token source, chat uses the Vertex AI OpenAI-compatible endpoint (`{region}-aiplatform.googleapis.com`). When using an API key instead (no GCP project configured), chat routes to the Gemini API endpoint (`generativelanguage.googleapis.com`). Embeddings and image generation use the native Vertex AI `:predict` endpoint (or the Gemini API equivalent when using an API key).
 - Tool schemas are automatically sanitized to comply with Gemini schema restrictions (no `additionalProperties`, enum values must be strings, etc.).
 - Gemini-native provider options like `thinkingConfig` are stripped before sending to the OpenAI-compatible endpoint.
 - The `ADCTokenSource(ctx context.Context, scopes ...string)` function is exported for direct use with other providers that need GCP credentials. It takes a `context.Context` and optional OAuth scopes, and returns `(provider.TokenSource, error)`.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -144,7 +144,7 @@ Image generation from text prompt.
 func GenerateImage(ctx context.Context, model provider.ImageModel, opts ...ImageOption) (*ImageResult, error)
 ```
 
-Uses `ImageOption` (not `Option`): `WithImagePrompt`, `WithImageCount`, `WithImageSize`, `WithAspectRatio`, `WithImageProviderOptions`.
+Uses `ImageOption` (not `Option`): `WithImagePrompt`, `WithImageCount`, `WithImageSize`, `WithAspectRatio`, `WithImageProviderOptions`, `WithImageMaxRetries`, `WithImageTimeout`.
 
 ### Message Builders
 
@@ -224,6 +224,8 @@ All options use the functional options pattern: `goai.With*(...)`.
 - `WithImageSize(size string)` — dimensions (e.g., "1024x1024")
 - `WithAspectRatio(ratio string)` — aspect ratio (e.g., "16:9")
 - `WithImageProviderOptions(opts map[string]any)` — provider-specific image params
+- `WithImageMaxRetries(n int)` - max retries for image generation (default: 2)
+- `WithImageTimeout(d time.Duration)` - per-attempt timeout for image generation
 
 ---
 
@@ -319,11 +321,12 @@ Fireworks (`FIREWORKS_API_KEY`), Together (`TOGETHER_AI_API_KEY`), DeepInfra (`D
 ### Common Provider Options
 
 ```go
-provider.WithAPIKey(key)        // static API key
-provider.WithTokenSource(ts)    // dynamic auth (OAuth, service accounts)
-provider.WithBaseURL(url)       // override endpoint
-provider.WithHeaders(h)         // custom HTTP headers
-provider.WithHTTPClient(c)      // custom HTTP transport
+// Each provider exports its own With* options:
+openai.WithAPIKey(key)        // static API key
+openai.WithTokenSource(ts)    // dynamic auth (OAuth, service accounts)
+openai.WithBaseURL(url)       // override endpoint
+openai.WithHeaders(h)         // custom HTTP headers
+openai.WithHTTPClient(c)      // custom HTTP transport
 ```
 
 ---

--- a/generate.go
+++ b/generate.go
@@ -173,6 +173,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				Latency:      time.Since(ts.startTime),
 				Usage:        ts.usage,
 				FinishReason: ts.finishReason,
+				Error:        ts.streamErr,
 			})
 		}()
 	}
@@ -216,6 +217,11 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 			select {
 			case textOut <- chunk.Text:
 			case <-ts.ctx.Done():
+				return
+			}
+		}
+		if rawOut == nil && textOut == nil {
+			if ts.ctx.Err() != nil {
 				return
 			}
 		}
@@ -446,6 +452,9 @@ func buildToolMap(tools []Tool) map[string]Tool {
 func executeTools(ctx context.Context, calls []provider.ToolCall, toolMap map[string]Tool, onToolCall func(ToolCallInfo)) []provider.Message {
 	var msgs []provider.Message
 	for _, tc := range calls {
+		if ctx.Err() != nil {
+			return msgs
+		}
 		tool, ok := toolMap[tc.Name]
 		if !ok {
 			if onToolCall != nil {

--- a/generate_test.go
+++ b/generate_test.go
@@ -286,6 +286,13 @@ func TestStreamText_ErrorFromProvider(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 429 {
+		t.Errorf("status = %d, want 429", apiErr.StatusCode)
+	}
 }
 
 func TestStreamText_ErrorChunk(t *testing.T) {
@@ -1685,5 +1692,48 @@ func TestStreamText_TextStream_CtxCancelStopsConsume(t *testing.T) {
 	// If ctx.Done select works on textOut, we should get far fewer than 500 chunks.
 	if drained >= 450 {
 		t.Errorf("drained %d text chunks - ctx.Done select on textOut did not trigger", drained)
+	}
+}
+
+func TestStreamText_ErrNilOnSuccess(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hello"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+	stream, err := StreamText(context.Background(), model, WithPrompt("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = stream.Result()
+	if stream.Err() != nil {
+		t.Errorf("expected nil Err(), got %v", stream.Err())
+	}
+}
+
+func TestStreamText_ErrReturnsStreamError(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "partial"},
+				provider.StreamChunk{Type: provider.ChunkError, Error: errors.New("stream broke")},
+			), nil
+		},
+	}
+	stream, err := StreamText(context.Background(), model, WithPrompt("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = stream.Result()
+	if stream.Err() == nil {
+		t.Fatal("expected non-nil Err()")
+	}
+	if stream.Err().Error() != "stream broke" {
+		t.Errorf("unexpected error: %v", stream.Err())
 	}
 }

--- a/image.go
+++ b/image.go
@@ -15,7 +15,8 @@ func GenerateImage(ctx context.Context, model provider.ImageModel, opts ...Image
 	}
 
 	o := imageOptions{
-		n: 1,
+		n:          1,
+		maxRetries: 2,
 	}
 	for _, opt := range opts {
 		opt(&o)

--- a/image_test.go
+++ b/image_test.go
@@ -3,6 +3,7 @@ package goai
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/zendev-sh/goai/provider"
 )
@@ -46,8 +47,10 @@ func TestGenerateImage(t *testing.T) {
 }
 
 func TestGenerateImage_Options(t *testing.T) {
+	called := false
 	model := &mockImageModel{
 		generateFn: func(ctx context.Context, params provider.ImageParams) (*provider.ImageResult, error) {
+			called = true
 			if params.N != 3 {
 				t.Errorf("n = %d, want 3", params.N)
 			}
@@ -61,7 +64,7 @@ func TestGenerateImage_Options(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateImage(t.Context(), model,
+	result, err := GenerateImage(t.Context(), model,
 		WithImagePrompt("test"),
 		WithImageCount(3),
 		WithImageSize("1024x1024"),
@@ -70,11 +73,19 @@ func TestGenerateImage_Options(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !called {
+		t.Fatal("generateFn was never called")
+	}
+	if len(result.Images) != 1 {
+		t.Errorf("images = %d, want 1", len(result.Images))
+	}
 }
 
 func TestGenerateImage_WithProviderOptions(t *testing.T) {
+	called := false
 	model := &mockImageModel{
 		generateFn: func(ctx context.Context, params provider.ImageParams) (*provider.ImageResult, error) {
+			called = true
 			if params.ProviderOptions["quality"] != "hd" {
 				t.Errorf("quality = %v, want hd", params.ProviderOptions["quality"])
 			}
@@ -89,6 +100,9 @@ func TestGenerateImage_WithProviderOptions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !called {
+		t.Fatal("generateFn was never called")
+	}
 }
 
 func TestGenerateImage_Error(t *testing.T) {
@@ -101,5 +115,49 @@ func TestGenerateImage_Error(t *testing.T) {
 	_, err := GenerateImage(t.Context(), model, WithImagePrompt("test"))
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestGenerateImage_WithTimeout(t *testing.T) {
+	model := &mockImageModel{
+		generateFn: func(ctx context.Context, params provider.ImageParams) (*provider.ImageResult, error) {
+			// Verify context has a deadline from WithImageTimeout.
+			if _, ok := ctx.Deadline(); !ok {
+				t.Error("expected context to have deadline from WithImageTimeout")
+			}
+			return &provider.ImageResult{Images: []provider.ImageData{{Data: []byte("x"), MediaType: "image/png"}}}, nil
+		},
+	}
+
+	_, err := GenerateImage(t.Context(), model,
+		WithImagePrompt("test"),
+		WithImageTimeout(5*time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateImage_WithMaxRetries(t *testing.T) {
+	calls := 0
+	model := &mockImageModel{
+		generateFn: func(ctx context.Context, params provider.ImageParams) (*provider.ImageResult, error) {
+			calls++
+			if calls < 3 {
+				return nil, &APIError{StatusCode: 429, Message: "rate limited", IsRetryable: true}
+			}
+			return &provider.ImageResult{Images: []provider.ImageData{{Data: []byte("x"), MediaType: "image/png"}}}, nil
+		},
+	}
+
+	_, err := GenerateImage(t.Context(), model,
+		WithImagePrompt("test"),
+		WithImageMaxRetries(3),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
 	}
 }

--- a/internal/gemini/schema.go
+++ b/internal/gemini/schema.go
@@ -44,7 +44,7 @@ func sanitizeImpl(obj any) any {
 				}
 			}
 			if nonNull != "" {
-				m["type"] = nonNull
+				result["type"] = nonNull
 				result["nullable"] = true
 			}
 		case []any:
@@ -55,13 +55,19 @@ func sanitizeImpl(obj any) any {
 				}
 			}
 			if nonNull != "" {
-				m["type"] = nonNull
+				result["type"] = nonNull
 				result["nullable"] = true
 			}
 		}
 	}
 
 	for k, v := range m {
+		// Skip "type" if we already normalized it from a nullable array above.
+		if k == "type" {
+			if _, already := result["type"]; already {
+				continue
+			}
+		}
 		if k == "enum" {
 			if enumArr, ok := v.([]any); ok {
 				strEnum := make([]any, len(enumArr))

--- a/internal/gemini/schema_test.go
+++ b/internal/gemini/schema_test.go
@@ -446,3 +446,68 @@ func TestSanitizeSchema_FullSchemaFromOutput(t *testing.T) {
 		t.Error("metadata.properties should be preserved")
 	}
 }
+
+func TestSanitizeSchema_NoInputMutation(t *testing.T) {
+	// Verify that SanitizeSchema does not mutate the input map.
+	input := map[string]any{
+		"type": []string{"object", "null"},
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+	// Save original type value.
+	origType := input["type"].([]string)
+	origLen := len(origType)
+
+	result := SanitizeSchema(input)
+
+	// Input must not be mutated.
+	inputType := input["type"]
+	switch tt := inputType.(type) {
+	case []string:
+		if len(tt) != origLen {
+			t.Errorf("input type was mutated: got %v", tt)
+		}
+		for _, s := range tt {
+			if s != "object" && s != "null" {
+				t.Errorf("input type element mutated to %q", s)
+			}
+		}
+	default:
+		t.Errorf("input type was mutated from []string to %T: %v", inputType, inputType)
+	}
+
+	// Result should have the nullable conversion applied.
+	if result["type"] != "object" {
+		t.Errorf("result type = %v, want 'object'", result["type"])
+	}
+	if result["nullable"] != true {
+		t.Error("result should have nullable: true")
+	}
+}
+
+func TestSanitizeSchema_NoInputMutation_AnySlice(t *testing.T) {
+	// Test the []any path (from JSON unmarshal) also does not mutate input.
+	input := map[string]any{
+		"type": []any{"string", "null"},
+	}
+
+	result := SanitizeSchema(input)
+
+	// Input must not be mutated.
+	inputType, ok := input["type"].([]any)
+	if !ok {
+		t.Fatalf("input type was mutated from []any to %T", input["type"])
+	}
+	if len(inputType) != 2 {
+		t.Errorf("input type length mutated: got %d", len(inputType))
+	}
+
+	// Result should have the nullable conversion.
+	if result["type"] != "string" {
+		t.Errorf("result type = %v, want 'string'", result["type"])
+	}
+	if result["nullable"] != true {
+		t.Error("result should have nullable: true")
+	}
+}

--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -248,9 +248,18 @@ func applyProviderOptions(body map[string]any, opts map[string]any) {
 		knownKeys["serviceTier"] = true
 	}
 
+	// Protected keys that must not be overwritten by provider options.
+	protectedKeys := map[string]bool{
+		"model": true, "stream": true, "messages": true,
+		"max_tokens": true, "max_completion_tokens": true,
+		"temperature": true, "top_p": true, "stop": true,
+		"seed": true, "frequency_penalty": true, "presence_penalty": true,
+		"tools": true, "tool_choice": true, "response_format": true,
+	}
+
 	// Pass through any remaining unknown keys.
 	for k, v := range opts {
-		if !knownKeys[k] {
+		if !knownKeys[k] && !protectedKeys[k] {
 			body[k] = v
 		}
 	}

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -33,10 +33,11 @@ func (s *Scanner) Next() (data string, ok bool) {
 
 	for s.scanner.Scan() {
 		line := s.scanner.Text()
-		if !strings.HasPrefix(line, "data: ") {
+		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
-		data = strings.TrimPrefix(line, "data: ")
+		data = strings.TrimPrefix(line, "data:")
+		data = strings.TrimPrefix(data, " ")
 
 		if data == "[DONE]" {
 			s.done = true

--- a/object.go
+++ b/object.go
@@ -134,6 +134,7 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 				Latency:      time.Since(os.startTime),
 				Usage:        os.usage,
 				FinishReason: os.finishReason,
+				Error:        os.streamErr,
 			})
 		}()
 	}
@@ -161,6 +162,11 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 		case provider.ChunkError:
 			if os.streamErr == nil {
 				os.streamErr = chunk.Error
+			}
+		}
+		if partialOut == nil {
+			if os.ctx.Err() != nil {
+				return
 			}
 		}
 	}
@@ -322,5 +328,10 @@ func truncate(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	return s[:max] + "..."
+	// Truncate at rune boundary to avoid splitting multi-byte UTF-8.
+	truncated := []rune(s)
+	if len(truncated) <= max {
+		return s
+	}
+	return string(truncated[:max]) + "..."
 }

--- a/object_test.go
+++ b/object_test.go
@@ -829,6 +829,14 @@ func TestStreamObject_ContextCancelDuringPartial(t *testing.T) {
 	cancel()
 	<-done
 
+	// Verify consume terminated: doneCh should be closed.
+	select {
+	case <-os.doneCh:
+		// expected: consume closed doneCh
+	default:
+		t.Error("expected doneCh to be closed after consume returns")
+	}
+
 	for range partialCh {
 	}
 }
@@ -1127,5 +1135,59 @@ func TestObjectStream_PartialObjectStreamAfterResult(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("expected 0 items from PartialObjectStream after Result(), got %d", count)
+	}
+}
+
+func TestStreamObject_ErrNilOnSuccess(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: `{"name":"Alice","age":30}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+	type Person struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	stream, err := StreamObject[Person](context.Background(), model, WithPrompt("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = stream.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stream.Err() != nil {
+		t.Errorf("expected nil Err(), got %v", stream.Err())
+	}
+}
+
+func TestStreamObject_ErrReturnsStreamError(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: `{"name":"Al`},
+				provider.StreamChunk{Type: provider.ChunkError, Error: errors.New("stream broke")},
+			), nil
+		},
+	}
+	type Person struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	stream, err := StreamObject[Person](context.Background(), model, WithPrompt("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = stream.Result()
+	if stream.Err() == nil {
+		t.Fatal("expected non-nil Err()")
+	}
+	if stream.Err().Error() != "stream broke" {
+		t.Errorf("unexpected error: %v", stream.Err())
 	}
 }

--- a/partial_json.go
+++ b/partial_json.go
@@ -162,7 +162,7 @@ func completeTrailing(s string) string {
 	// Complete truncated numbers.
 	last := trimmed[len(trimmed)-1]
 	switch last {
-	case '.', '-', 'e', 'E':
+	case '.', '-', '+', 'e', 'E':
 		return trimmed + "0"
 	}
 
@@ -195,6 +195,25 @@ func trimTrailingIncomplete(s string) string {
 			s = strings.TrimRight(s, " \t\n\r,")
 		}
 		return s
+	}
+
+	// Remove dangling key string inside an object (e.g. `{"a":1, "b"` → `{"a":1`).
+	// A trailing `"..."` is a dangling key if preceded by `{` or `,`.
+	if s[len(s)-1] == '"' {
+		idx := strings.LastIndex(s[:len(s)-1], `"`)
+		if idx >= 0 {
+			before := strings.TrimRight(s[:idx], " \t\n\r")
+			if len(before) > 0 {
+				switch before[len(before)-1] {
+				case '{':
+					// Keep the opening brace, just remove the dangling key.
+					return before
+				case ',':
+					// Strip the comma and the dangling key.
+					return strings.TrimRight(before[:len(before)-1], " \t\n\r")
+				}
+			}
+		}
 	}
 
 	return s

--- a/partial_json_test.go
+++ b/partial_json_test.go
@@ -87,7 +87,7 @@ func TestRepairJSON(t *testing.T) {
 		{
 			name:     "truncated object key only",
 			input:    `{"a": 1, "b"`,
-			expected: `{"a": 1, "b"}`,
+			expected: `{"a": 1}`,
 		},
 
 		// Nested truncation.
@@ -239,7 +239,7 @@ func TestCompleteTrailing(t *testing.T) {
 		{
 			name:     "trailing plus",
 			input:    `{"a": +`,
-			expected: `{"a": +`,
+			expected: `{"a": +0`,
 		},
 		{
 			name:     "trailing e",

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -26,6 +26,12 @@ import (
 	"github.com/zendev-sh/goai/provider"
 )
 
+// Compile-time interface compliance checks.
+var (
+	_ provider.LanguageModel = (*chatModel)(nil)
+	_ provider.CapableModel  = (*chatModel)(nil)
+)
+
 const (
 	defaultBaseURL    = "https://api.anthropic.com"
 	apiVersion        = "2023-06-01"
@@ -394,11 +400,18 @@ func (m *chatModel) buildRequest(params provider.GenerateParams, streaming bool)
 		"thinking": true, "_headers": true,
 		"disableParallelToolUse": true, "effort": true, "speed": true,
 		"container": true, "contextManagement": true,
+	}
+	protectedKeys := map[string]bool{
+		"model": true, "stream": true, "messages": true,
+		"max_tokens": true, "system": true, "temperature": true,
+		"top_p": true, "top_k": true, "stop_sequences": true,
+		"tools": true, "tool_choice": true,
+		// SDK-internal keys that are never sent on the wire.
 		"structuredOutputMode": true, "sendReasoning": true,
 		"cacheControl": true,
 	}
 	for k, v := range params.ProviderOptions {
-		if handledKeys[k] {
+		if handledKeys[k] || protectedKeys[k] {
 			continue
 		}
 		body[k] = v
@@ -565,12 +578,6 @@ func applyCacheControl(p map[string]any, partCC string, msgCC map[string]any, is
 		p["cache_control"] = msgCC
 	}
 }
-
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
 
 // --- Response format (structured output via tool trick or native output_format) ---
 

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -2166,7 +2166,7 @@ func TestDoGenerate_ProviderDefinedToolBeta(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`)
+		_, _ = fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-20250514","stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`)
 	}))
 	defer server.Close()
 

--- a/provider/anthropic/bf14_parity_test.go
+++ b/provider/anthropic/bf14_parity_test.go
@@ -19,13 +19,13 @@ func TestStream_FirstDelta_CodeExecutionWrapping(t *testing.T) {
 	// the first delta should be wrapped with {"type": "bash_code_execution",...}.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"tc1","name":"bash_code_execution"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\": \"ls\""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"tc1","name":"bash_code_execution"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\": \"ls\""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -71,7 +71,7 @@ func TestStream_FirstDelta_CodeExecutionWrapping(t *testing.T) {
 func TestDoGenerate_Iterations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"type": "message",
 			"id": "msg_1",
 			"model": "claude-sonnet-4-20250514",
@@ -124,12 +124,12 @@ func TestDoGenerate_Iterations(t *testing.T) {
 func TestStream_Iterations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":100}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50,"iterations":[{"type":"message","input_tokens":60,"output_tokens":30},{"type":"compaction","input_tokens":40,"output_tokens":20}]}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":100}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50,"iterations":[{"type":"message","input_tokens":60,"output_tokens":30},{"type":"compaction","input_tokens":40,"output_tokens":20}]}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -171,7 +171,7 @@ func TestStream_Iterations(t *testing.T) {
 func TestDoGenerate_ContextManagement(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"type": "message",
 			"id": "msg_1",
 			"model": "claude-sonnet-4-20250514",
@@ -215,12 +215,12 @@ func TestDoGenerate_ContextManagement(t *testing.T) {
 func TestStream_ContextManagement(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5},"context_management":{"applied_edits":[{"type":"clear_thinking_20251015","cleared_thinking_turns":2,"cleared_input_tokens":300}]}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5},"context_management":{"applied_edits":[{"type":"clear_thinking_20251015","cleared_thinking_turns":2,"cleared_input_tokens":300}]}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -253,7 +253,7 @@ func TestStream_ContextManagement(t *testing.T) {
 func TestDoGenerate_ReasoningTokens(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"type": "message",
 			"id": "msg_1",
 			"model": "claude-sonnet-4-20250514",
@@ -284,12 +284,12 @@ func TestDoGenerate_ReasoningTokens(t *testing.T) {
 func TestStream_ReasoningTokens(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50,"output_tokens_details":{"thinking_tokens":35}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50,"output_tokens_details":{"thinking_tokens":35}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -343,7 +343,7 @@ func TestDoGenerate_NativeOutputFormat(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"type": "message",
 			"id": "msg_1",
 			"model": "claude-sonnet-4-6-20260310",
@@ -403,7 +403,7 @@ func TestDoGenerate_NativeOutputFormat_Auto_Unsupported(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"type": "message",
 			"id": "msg_1",
 			"model": "claude-3-5-sonnet",
@@ -619,7 +619,7 @@ func TestBuildRequest_Container(t *testing.T) {
 func TestDoGenerate_ContainerResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"type": "message",
 			"id": "msg_1",
 			"model": "claude-sonnet-4-20250514",
@@ -778,7 +778,7 @@ func TestBuildRequest_HandledKeysNotPassthrough(t *testing.T) {
 func TestDoGenerate_Citations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 			"type": "message",
 			"id": "msg_1",
 			"model": "claude-sonnet-4-20250514",
@@ -848,13 +848,13 @@ func TestDoGenerate_Citations(t *testing.T) {
 func TestStream_CitationsDelta(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Found"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location","cited_text":"fact","url":"https://ex.com","title":"Ex","encrypted_index":"enc1"}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Found"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location","cited_text":"fact","url":"https://ex.com","title":"Ex","encrypted_index":"enc1"}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -892,16 +892,16 @@ func TestStream_CitationsDelta(t *testing.T) {
 func TestStream_SignatureDelta(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_abc123"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":1}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_abc123"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":1}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -935,12 +935,12 @@ func TestStream_SignatureDelta(t *testing.T) {
 func TestStream_ContainerInMessageDelta(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","container":{"expires_at":"2026-03-10T20:00:00Z","id":"ctr-1"}},"usage":{"output_tokens":5}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","container":{"expires_at":"2026-03-10T20:00:00Z","id":"ctr-1"}},"usage":{"output_tokens":5}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -973,12 +973,12 @@ func TestStream_ContainerInMessageDelta(t *testing.T) {
 func TestStream_EmptyToolArgs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tc1","name":"no_args_tool"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tc1","name":"no_args_tool"}}`+"\n\n")
 		// No input_json_delta events -- empty input.
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -1006,13 +1006,13 @@ func TestStream_EmptyToolArgs(t *testing.T) {
 func TestStream_FirstDelta_TextEditorWrapping(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"tc1","name":"text_editor_code_execution"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\": \"view\""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":", \"path\": \"/tmp/f.py\"}"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"tc1","name":"text_editor_code_execution"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\": \"view\""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":", \"path\": \"/tmp/f.py\"}"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 
@@ -1045,13 +1045,13 @@ func TestStream_FirstDelta_TextEditorWrapping(t *testing.T) {
 func TestStream_NormalToolUse_NoFirstDeltaWrapping(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tc1","name":"read_file"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\": \"/tmp\""}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}`+"\n\n")
-		fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tc1","name":"read_file"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\": \"/tmp\""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
 	}))
 	defer server.Close()
 

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -23,10 +23,10 @@ const okChatJSON = `{"id":"x","model":"m","choices":[{"message":{"content":"ok"}
 // responsesSSE returns SSE events for a Responses API streaming response.
 func responsesSSE(w http.ResponseWriter, text string) {
 	w.Header().Set("Content-Type", "text/event-stream")
-	fmt.Fprintf(w, "event: response.output_item.added\ndata: {\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[]}}\n\n")
-	fmt.Fprintf(w, "event: response.content_part.added\ndata: {\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"\"}}\n\n")
-	fmt.Fprintf(w, "event: response.output_text.delta\ndata: {\"output_index\":0,\"content_index\":0,\"delta\":\"%s\"}\n\n", text)
-	fmt.Fprintf(w, "event: response.completed\ndata: {\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n")
+	_, _ = fmt.Fprintf(w, "event: response.output_item.added\ndata: {\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[]}}\n\n")
+	_, _ = fmt.Fprintf(w, "event: response.content_part.added\ndata: {\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"\"}}\n\n")
+	_, _ = fmt.Fprintf(w, "event: response.output_text.delta\ndata: {\"output_index\":0,\"content_index\":0,\"delta\":\"%s\"}\n\n", text)
+	_, _ = fmt.Fprintf(w, "event: response.completed\ndata: {\"response\":{\"id\":\"resp_1\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n")
 }
 
 func TestChat_Stream(t *testing.T) {
@@ -1067,8 +1067,8 @@ func TestExtractResourceName(t *testing.T) {
 func TestAIServices_Stream(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\n")
-		fmt.Fprint(w, "data: [DONE]\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
 	}))
 	defer server.Close()
 

--- a/provider/bedrock/bedrock.go
+++ b/provider/bedrock/bedrock.go
@@ -22,7 +22,9 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -224,6 +226,7 @@ func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
 		Temperature:      true,
 		ToolCall:         modelSupportsTools(m.ModelID()),
+		Reasoning:        true,
 		InputModalities:  provider.ModalitySet{Text: true, Image: true},
 		OutputModalities: provider.ModalitySet{Text: true},
 	}
@@ -663,7 +666,12 @@ func (m *chatModel) applyBedrockOptions(body map[string]any, tools []provider.To
 	// - Remove topK, temperature, topP (Anthropic rejects them with thinking)
 	// - Add budgetTokens to maxTokens (Bedrock requires maxTokens >= budget_tokens)
 	if isThinkingEnabled {
-		if ic, ok := body["inferenceConfig"].(map[string]any); ok {
+		ic, ok := body["inferenceConfig"].(map[string]any)
+		if !ok {
+			ic = make(map[string]any)
+			body["inferenceConfig"] = ic
+		}
+		{
 			delete(ic, "topK")
 			delete(ic, "temperature")
 			delete(ic, "topP")
@@ -707,11 +715,15 @@ func (m *chatModel) doHTTP(ctx context.Context, body map[string]any, streaming b
 	id, region := m.readIDRegion()
 
 	var reqURL string
+	escapedID := url.PathEscape(id)
 	if m.opts.baseURL != "" {
-		reqURL = m.opts.baseURL + "/model/" + id + endpoint
+		reqURL = m.opts.baseURL + "/model/" + escapedID + endpoint
 	} else {
+		if !validRegion(region) {
+			return nil, fmt.Errorf("bedrock: invalid AWS region %q", region)
+		}
 		reqURL = fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s%s",
-			region, id, endpoint)
+			region, escapedID, endpoint)
 	}
 
 	req := httpc.MustNewRequest(ctx, "POST", reqURL, jsonBody)
@@ -895,6 +907,13 @@ func toolBetaForType(toolType string) string {
 	default:
 		return ""
 	}
+}
+
+// validRegion checks that the AWS region is safe for hostname interpolation.
+var validRegionRE = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
+
+func validRegion(region string) bool {
+	return validRegionRE.MatchString(region)
 }
 
 func isUnreserved(c byte) bool {

--- a/provider/bedrock/bedrock_test.go
+++ b/provider/bedrock/bedrock_test.go
@@ -4222,3 +4222,18 @@ func TestEnsureToolConfigForHistory_MultipleTools(t *testing.T) {
 		t.Fatalf("expected 2 unique tools, got %d", len(tools))
 	}
 }
+
+func TestValidRegion(t *testing.T) {
+	valid := []string{"us-east-1", "eu-west-2", "ap-southeast-1", "us-gov-west-1"}
+	for _, r := range valid {
+		if !validRegion(r) {
+			t.Errorf("expected %q to be valid", r)
+		}
+	}
+	invalid := []string{"", "us east 1", "../evil", "us-east-1.evil.com", "US-EAST-1"}
+	for _, r := range invalid {
+		if validRegion(r) {
+			t.Errorf("expected %q to be invalid", r)
+		}
+	}
+}

--- a/provider/cerebras/cerebras.go
+++ b/provider/cerebras/cerebras.go
@@ -145,8 +145,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/cohere/cohere.go
+++ b/provider/cohere/cohere.go
@@ -130,6 +130,7 @@ func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
 		Temperature:      true,
 		ToolCall:         true,
+		Reasoning:        true,
 		InputModalities:  provider.ModalitySet{Text: true},
 		OutputModalities: provider.ModalitySet{Text: true},
 	}
@@ -310,7 +311,10 @@ func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params pr
 
 	return &provider.EmbedResult{
 		Embeddings: result.Embeddings.Float,
-		Usage:      provider.Usage{InputTokens: result.Meta.BilledUnits.InputTokens},
+		Usage: provider.Usage{
+			InputTokens: result.Meta.BilledUnits.InputTokens,
+			TotalTokens: result.Meta.BilledUnits.InputTokens,
+		},
 	}, nil
 }
 
@@ -411,6 +415,26 @@ func buildChatRequest(params provider.GenerateParams, modelID string, streaming 
 		body["tools"] = tools
 	}
 
+	// Tool choice mapping (Cohere v2 uses OpenAI-compatible tool_choice).
+	if params.ToolChoice != "" {
+		switch params.ToolChoice {
+		case "auto", "none", "required":
+			body["tool_choice"] = params.ToolChoice
+		default:
+			// Specific tool name.
+			body["tool_choice"] = map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": params.ToolChoice,
+				},
+			}
+		}
+	}
+
+	if len(params.StopSequences) > 0 {
+		body["stop_sequences"] = params.StopSequences
+	}
+
 	if params.MaxOutputTokens > 0 {
 		body["max_tokens"] = params.MaxOutputTokens
 	}
@@ -423,7 +447,7 @@ func buildChatRequest(params provider.GenerateParams, modelID string, streaming 
 
 	// Thinking / reasoning support for command-a-reasoning models.
 	// Read from ProviderOptions["thinking"] -- matches Vercel AI SDK convention.
-	// Accepts: {type: "enabled"/"disabled", tokenBudget: N}
+	// Accepts: {type: "enabled"/"disabled", budgetTokens: N}
 	if thinking, ok := params.ProviderOptions["thinking"]; ok {
 		if tm, ok := thinking.(map[string]any); ok {
 			thinkingReq := map[string]any{}
@@ -432,7 +456,7 @@ func buildChatRequest(params provider.GenerateParams, modelID string, streaming 
 			} else {
 				thinkingReq["type"] = "enabled"
 			}
-			if budget, ok := tm["tokenBudget"]; ok {
+			if budget, ok := tm["budgetTokens"]; ok {
 				thinkingReq["token_budget"] = budget
 			}
 			body["thinking"] = thinkingReq
@@ -482,6 +506,7 @@ type cohereCitation struct {
 func parseChatResponse(body []byte) (*provider.GenerateResult, error) {
 	var resp struct {
 		ID      string `json:"id"`
+		Model   string `json:"model"`
 		Message struct {
 			Role    string `json:"role"`
 			Content []struct {
@@ -517,7 +542,7 @@ func parseChatResponse(body []byte) (*provider.GenerateResult, error) {
 	}
 
 	result := &provider.GenerateResult{
-		Response: provider.ResponseMetadata{ID: resp.ID},
+		Response: provider.ResponseMetadata{ID: resp.ID, Model: resp.Model},
 	}
 
 	// Extract text from content blocks. Reasoning (thinking) blocks are
@@ -795,6 +820,7 @@ func parseChatStream(ctx context.Context, body io.Reader, out chan<- provider.St
 				Type:         provider.ChunkFinish,
 				FinishReason: fr,
 				Usage:        usage,
+				Response:     provider.ResponseMetadata{},
 			}
 			if sources := extractCohereCitations(streamCitations); len(sources) > 0 {
 				finishChunk.Metadata = map[string]any{"sources": sources}
@@ -821,6 +847,8 @@ func mapFinishReason(reason string) provider.FinishReason {
 		return provider.FinishToolCalls
 	case "MAX_TOKENS":
 		return provider.FinishLength
+	case "ERROR":
+		return provider.FinishError
 	case "":
 		return ""
 	default:

--- a/provider/cohere/cohere_test.go
+++ b/provider/cohere/cohere_test.go
@@ -1069,7 +1069,7 @@ func TestBuildChatRequest_Thinking(t *testing.T) {
 		ProviderOptions: map[string]any{
 			"thinking": map[string]any{
 				"type":        "enabled",
-				"tokenBudget": 4096,
+				"budgetTokens": 4096,
 			},
 		},
 	}
@@ -1093,7 +1093,7 @@ func TestBuildChatRequest_ThinkingDefaultType(t *testing.T) {
 		},
 		ProviderOptions: map[string]any{
 			"thinking": map[string]any{
-				"tokenBudget": 2048,
+				"budgetTokens": 2048,
 			},
 		},
 	}

--- a/provider/compat/compat.go
+++ b/provider/compat/compat.go
@@ -311,7 +311,7 @@ func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params pr
 
 	return &provider.EmbedResult{
 		Embeddings: embeddings,
-		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens},
+		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens, TotalTokens: result.Usage.TotalTokens},
 	}, nil
 }
 

--- a/provider/deepinfra/deepinfra.go
+++ b/provider/deepinfra/deepinfra.go
@@ -145,8 +145,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/deepseek/deepseek.go
+++ b/provider/deepseek/deepseek.go
@@ -146,8 +146,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/fireworks/fireworks.go
+++ b/provider/fireworks/fireworks.go
@@ -145,8 +145,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/google/embedding.go
+++ b/provider/google/embedding.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/zendev-sh/goai"
@@ -89,10 +90,10 @@ func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params pr
 	}
 
 	body := map[string]any{"requests": requests}
-	url := fmt.Sprintf("%s/v1beta/models/%s:batchEmbedContents", m.opts.baseURL, m.id)
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:batchEmbedContents", m.opts.baseURL, url.PathEscape(m.id))
 
 	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", url, jsonBody)
+	req := httpc.MustNewRequest(ctx, "POST", reqURL, jsonBody)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-goog-api-key", token)
 

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -133,9 +134,9 @@ func (m *chatModel) DoGenerate(ctx context.Context, params provider.GeneratePara
 	if err != nil {
 		return nil, err
 	}
-	url := fmt.Sprintf("%s/v1beta/models/%s:generateContent", m.opts.baseURL, m.id)
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:generateContent", m.opts.baseURL, url.PathEscape(m.id))
 
-	resp, err := m.doHTTP(ctx, url, body, params.Headers)
+	resp, err := m.doHTTP(ctx, reqURL, body, params.Headers)
 	if err != nil {
 		return nil, err
 	}
@@ -154,9 +155,9 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	if err != nil {
 		return nil, err
 	}
-	url := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", m.opts.baseURL, m.id)
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", m.opts.baseURL, url.PathEscape(m.id))
 
-	resp, err := m.doHTTP(ctx, url, body, params.Headers)
+	resp, err := m.doHTTP(ctx, reqURL, body, params.Headers)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +175,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		parseSSE(ctx, resp.Body, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/google/image.go
+++ b/provider/google/image.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -107,10 +108,10 @@ func (m *imagenModel) DoGenerate(ctx context.Context, params provider.ImageParam
 		"parameters": parameters,
 	}
 
-	url := fmt.Sprintf("%s/v1beta/models/%s:predict", m.opts.baseURL, m.id)
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:predict", m.opts.baseURL, url.PathEscape(m.id))
 
 	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", url, jsonBody)
+	req := httpc.MustNewRequest(ctx, "POST", reqURL, jsonBody)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-goog-api-key", token)
 
@@ -235,10 +236,10 @@ func (m *geminiImageModel) DoGenerate(ctx context.Context, params provider.Image
 		"generationConfig": genConfig,
 	}
 
-	url := fmt.Sprintf("%s/v1beta/models/%s:generateContent", m.opts.baseURL, m.id)
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:generateContent", m.opts.baseURL, url.PathEscape(m.id))
 
 	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", url, jsonBody)
+	req := httpc.MustNewRequest(ctx, "POST", reqURL, jsonBody)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-goog-api-key", token)
 

--- a/provider/google/image_test.go
+++ b/provider/google/image_test.go
@@ -651,11 +651,6 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-// errBodyReader returns IO error on read.
-type errBodyReader struct{}
-
-func (errBodyReader) Read([]byte) (int, error) { return 0, fmt.Errorf("read error") }
-
 func TestImagenModel_TokenSourceError(t *testing.T) {
 	model := &imagenModel{
 		id: "imagen-4.0-generate-001",

--- a/provider/google/tools.go
+++ b/provider/google/tools.go
@@ -130,9 +130,7 @@ func codeExecutionTool() provider.ToolDefinition {
 func googleProviderTool(t provider.ToolDefinition) map[string]any {
 	// Map "google.google_search" -> "googleSearch", "google.url_context" -> "urlContext", etc.
 	apiKey := t.ProviderDefinedType
-	if strings.HasPrefix(apiKey, "google.") {
-		apiKey = strings.TrimPrefix(apiKey, "google.")
-	}
+	apiKey = strings.TrimPrefix(apiKey, "google.")
 	// Convert snake_case to camelCase: "google_search" -> "googleSearch"
 	apiKey = snakeToCamel(apiKey)
 

--- a/provider/groq/groq.go
+++ b/provider/groq/groq.go
@@ -145,8 +145,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/mistral/mistral.go
+++ b/provider/mistral/mistral.go
@@ -145,8 +145,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/openai/embedding.go
+++ b/provider/openai/embedding.go
@@ -121,7 +121,7 @@ func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params pr
 
 	return &provider.EmbedResult{
 		Embeddings: embeddings,
-		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens},
+		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens, TotalTokens: result.Usage.TotalTokens},
 	}, nil
 }
 

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -505,7 +506,8 @@ func TestChat_Responses_Failed(t *testing.T) {
 	var gotOverflow bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if _, ok := chunk.Error.(*goai.ContextOverflowError); ok {
+			var coe *goai.ContextOverflowError
+			if errors.As(chunk.Error, &coe) {
 				gotOverflow = true
 			}
 		}
@@ -948,7 +950,7 @@ func TestMapResponsesFinishReason(t *testing.T) {
 		{"tool_calls", "response.completed", "", true, provider.FinishToolCalls},
 		{"incomplete_length", "response.incomplete", "max_output_tokens", false, provider.FinishLength},
 		{"incomplete_filter", "response.incomplete", "content_filter", false, provider.FinishContentFilter},
-		{"incomplete_default", "response.incomplete", "", false, provider.FinishLength},
+		{"incomplete_default", "response.incomplete", "", false, provider.FinishOther},
 		{"incomplete_with_tools", "response.incomplete", "max_output_tokens", true, provider.FinishToolCalls},
 	}
 	for _, tt := range tests {
@@ -984,7 +986,8 @@ func TestChat_Responses_ErrorEvent(t *testing.T) {
 	var gotOverflow bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if _, ok := chunk.Error.(*goai.ContextOverflowError); ok {
+			var coe *goai.ContextOverflowError
+			if errors.As(chunk.Error, &coe) {
 				gotOverflow = true
 			}
 		}
@@ -1010,7 +1013,8 @@ func TestChat_Responses_Generate_Error(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if _, ok := err.(*goai.ContextOverflowError); !ok {
+	var coe *goai.ContextOverflowError
+	if !errors.As(err, &coe) {
 		t.Errorf("expected ContextOverflowError, got %T: %v", err, err)
 	}
 }
@@ -1232,8 +1236,8 @@ func TestStreamResponses_InsufficientQuota(t *testing.T) {
 	var gotError bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			apiErr, ok := chunk.Error.(*goai.APIError)
-			if ok && !apiErr.IsRetryable {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) && !apiErr.IsRetryable {
 				gotError = true
 			}
 		}
@@ -1264,7 +1268,8 @@ func TestStreamResponses_UsageNotIncluded(t *testing.T) {
 	var gotError bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if apiErr, ok := chunk.Error.(*goai.APIError); ok {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
 				if !apiErr.IsRetryable {
 					gotError = true
 				}
@@ -1297,7 +1302,8 @@ func TestStreamResponses_InvalidPrompt(t *testing.T) {
 	var gotError bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if apiErr, ok := chunk.Error.(*goai.APIError); ok {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
 				if !apiErr.IsRetryable && apiErr.Message == "bad prompt" {
 					gotError = true
 				}
@@ -1359,7 +1365,8 @@ func TestStreamResponses_ErrorWithMaxTokensCode(t *testing.T) {
 	var gotOverflow bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if _, ok := chunk.Error.(*goai.ContextOverflowError); ok {
+			var coe *goai.ContextOverflowError
+			if errors.As(chunk.Error, &coe) {
 				gotOverflow = true
 			}
 		}
@@ -1390,7 +1397,8 @@ func TestStreamResponses_GenericErrorEvent(t *testing.T) {
 	var gotError bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if apiErr, ok := chunk.Error.(*goai.APIError); ok {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
 				if apiErr.Message == "server error" {
 					gotError = true
 				}
@@ -1423,7 +1431,8 @@ func TestStreamResponses_FailedEmptyMessage(t *testing.T) {
 	var gotError bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if apiErr, ok := chunk.Error.(*goai.APIError); ok {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
 				if apiErr.Message == "response failed" {
 					gotError = true
 				}
@@ -1456,7 +1465,8 @@ func TestStreamResponses_ErrorEmptyMessage(t *testing.T) {
 	var gotError bool
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkError {
-			if apiErr, ok := chunk.Error.(*goai.APIError); ok {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
 				if apiErr.Message == "stream error" {
 					gotError = true
 				}
@@ -1502,7 +1512,8 @@ func TestParseResponsesResult_GenericError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if apiErr, ok := err.(*goai.APIError); !ok {
+	var apiErr *goai.APIError
+	if !errors.As(err, &apiErr) {
 		t.Errorf("expected APIError, got %T: %v", err, err)
 	} else if apiErr.Message != "some error" {
 		t.Errorf("Message = %q, want %q", apiErr.Message, "some error")
@@ -1828,9 +1839,9 @@ func TestParseResponsesResult_IncompleteNoDetails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Default to FinishLength when no details
-	if result.FinishReason != provider.FinishLength {
-		t.Errorf("FinishReason = %q, want %q", result.FinishReason, provider.FinishLength)
+	// Default to FinishOther when no details
+	if result.FinishReason != provider.FinishOther {
+		t.Errorf("FinishReason = %q, want %q", result.FinishReason, provider.FinishOther)
 	}
 }
 

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -257,9 +257,17 @@ func applyResponsesProviderOptions(body map[string]any, opts map[string]any) {
 		addIncludeKey(body, "reasoning.encrypted_content")
 	}
 
+	// Protected keys that must not be overwritten by provider options.
+	protectedKeys := map[string]bool{
+		"model": true, "stream": true, "input": true,
+		"instructions": true, "max_output_tokens": true,
+		"temperature": true, "top_p": true, "stop": true,
+		"tools": true, "tool_choice": true,
+	}
+
 	// Pass through any remaining unknown keys.
 	for k, v := range opts {
-		if !consumed[k] {
+		if !consumed[k] && !protectedKeys[k] {
 			body[k] = v
 		}
 	}
@@ -627,6 +635,7 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 				if ev.Response.Usage.InputTokensDetails != nil {
 					usage.CacheReadTokens = ev.Response.Usage.InputTokensDetails.CachedTokens
 				}
+				usage.InputTokens -= usage.CacheReadTokens
 			}
 
 			// Flush remaining tool call args.
@@ -764,7 +773,7 @@ func mapResponsesFinishReason(eventType string, incompleteReason string, hasFunc
 		case "content_filter":
 			return provider.FinishContentFilter
 		default:
-			return provider.FinishLength
+			return provider.FinishOther
 		}
 	}
 	return provider.FinishStop
@@ -927,7 +936,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 		case "content_filter":
 			result.FinishReason = provider.FinishContentFilter
 		default:
-			result.FinishReason = provider.FinishLength
+			result.FinishReason = provider.FinishOther
 		}
 	} else {
 		result.FinishReason = provider.FinishStop
@@ -944,6 +953,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 		if resp.Usage.InputTokensDetails != nil {
 			result.Usage.CacheReadTokens = resp.Usage.InputTokensDetails.CachedTokens
 		}
+		result.Usage.InputTokens -= result.Usage.CacheReadTokens
 	}
 
 	if len(providerMeta) > 0 {

--- a/provider/openrouter/openrouter.go
+++ b/provider/openrouter/openrouter.go
@@ -158,8 +158,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/perplexity/perplexity.go
+++ b/provider/perplexity/perplexity.go
@@ -145,8 +145,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/together/together.go
+++ b/provider/together/together.go
@@ -146,8 +146,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/vertex/adc.go
+++ b/provider/vertex/adc.go
@@ -44,9 +44,13 @@ func ADCTokenSource(ctx context.Context, scopes ...string) (provider.TokenSource
 		if err != nil {
 			return nil, err
 		}
+		var expiresAt time.Time
+		if !tok.Expiry.IsZero() {
+			expiresAt = tok.Expiry.Add(-30 * time.Second) // refresh 30s early
+		}
 		return &provider.Token{
 			Value:     tok.AccessToken,
-			ExpiresAt: tok.Expiry.Add(-30 * time.Second), // refresh 30s early
+			ExpiresAt: expiresAt,
 		}, nil
 	}), nil
 }

--- a/provider/vertex/adc_test.go
+++ b/provider/vertex/adc_test.go
@@ -24,7 +24,7 @@ func TestADCTokenSource_Type(t *testing.T) {
 	if ts == nil {
 		t.Fatal("ADCTokenSource returned nil without error")
 	}
-	var _ provider.TokenSource = ts
+	var _ = ts
 }
 
 func TestADCTokenSource_FindCredsError(t *testing.T) {

--- a/provider/vertex/embedding.go
+++ b/provider/vertex/embedding.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/internal/httpc"
@@ -83,13 +84,13 @@ func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params pr
 		body["parameters"] = parameters
 	}
 
-	url, err := nativeURL(m.opts, fmt.Sprintf("models/%s:predict", m.id))
+	reqURL, err := nativeURL(m.opts, fmt.Sprintf("models/%s:predict", url.PathEscape(m.id)))
 	if err != nil {
 		return nil, err
 	}
 
 	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", url, jsonBody)
+	req := httpc.MustNewRequest(ctx, "POST", reqURL, jsonBody)
 	req.Header.Set("Content-Type", "application/json")
 
 	// Native endpoints use ?key= for API keys (already in URL), Bearer for OAuth.

--- a/provider/vertex/image.go
+++ b/provider/vertex/image.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"slices"
 
 	"github.com/zendev-sh/goai"
@@ -81,13 +82,13 @@ func (m *imageModel) DoGenerate(ctx context.Context, params provider.ImageParams
 		"parameters": parameters,
 	}
 
-	url, err := nativeURL(m.opts, fmt.Sprintf("models/%s:predict", m.id))
+	reqURL, err := nativeURL(m.opts, fmt.Sprintf("models/%s:predict", url.PathEscape(m.id)))
 	if err != nil {
 		return nil, err
 	}
 
 	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", url, jsonBody)
+	req := httpc.MustNewRequest(ctx, "POST", reqURL, jsonBody)
 	req.Header.Set("Content-Type", "application/json")
 
 	// Native endpoints use ?key= for API keys (already in URL), Bearer for OAuth.

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -18,7 +18,9 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -204,14 +206,26 @@ func setAuth(ctx context.Context, req *http.Request, ts provider.TokenSource) er
 // For API key auth, appends ?key= (native Gemini API requires query param, not Bearer).
 // For OAuth/ADC, uses Bearer header (set by setAuth).
 func nativeURL(o options, modelPath string) (string, error) {
+	// Validate location/project before hostname interpolation to prevent SSRF.
+	// Skip empty values; they are caught by the project=="" check below.
+	if o.baseURL == "" {
+		if _, ok := o.tokenSource.(*apiKeyTokenSource); !ok {
+			if o.location != "" && !validGCPIdentifier(o.location) {
+				return "", fmt.Errorf("vertex: invalid location %q", o.location)
+			}
+			if o.project != "" && !validGCPIdentifier(o.project) {
+				return "", fmt.Errorf("vertex: invalid project %q", o.project)
+			}
+		}
+	}
 	base := nativeBaseURL(o)
-	url := fmt.Sprintf("%s/%s", base, modelPath)
+	reqURL := fmt.Sprintf("%s/%s", base, modelPath)
 	if aks, ok := o.tokenSource.(*apiKeyTokenSource); ok {
-		url += "?key=" + aks.key
+		reqURL += "?key=" + url.QueryEscape(aks.key)
 	} else if o.project == "" && o.baseURL == "" {
 		return "", fmt.Errorf("vertex: GOOGLE_CLOUD_PROJECT required (or set GOOGLE_API_KEY for Gemini API fallback)")
 	}
-	return url, nil
+	return reqURL, nil
 }
 
 // isNativeAPIKeyAuth returns true if using API key with native endpoints.
@@ -298,8 +312,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil
@@ -362,6 +376,13 @@ func (m *chatModel) resolveURL(ctx context.Context, path string) (string, error)
 	if m.opts.project == "" {
 		return "", fmt.Errorf("vertex: GOOGLE_CLOUD_PROJECT required (or set GOOGLE_API_KEY for Gemini API fallback)")
 	}
+	// Validate location/project before hostname interpolation to prevent SSRF.
+	if !validGCPIdentifier(m.opts.location) {
+		return "", fmt.Errorf("vertex: invalid location %q", m.opts.location)
+	}
+	if !validGCPIdentifier(m.opts.project) {
+		return "", fmt.Errorf("vertex: invalid project %q", m.opts.project)
+	}
 	return fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/openapi%s",
 		m.opts.location, m.opts.project, m.opts.location, path), nil
 }
@@ -414,4 +435,17 @@ func sanitizeToolSchemas(params *provider.GenerateParams) {
 		}
 		params.Tools[i].InputSchema = cleaned
 	}
+}
+
+// validGCPIdentifier checks that a GCP location or project ID is safe for URL interpolation.
+// Allows standard projects (my-project-123), domain-scoped projects (example.com:my-project),
+// and locations (us-central1). Blocks SSRF characters (/, \, @, .., whitespace).
+var validGCPIdentifierRE = regexp.MustCompile(`^[a-z0-9][a-z0-9.:_-]{0,127}$`)
+
+func validGCPIdentifier(s string) bool {
+	if !validGCPIdentifierRE.MatchString(s) {
+		return false
+	}
+	// Block path traversal even if individual chars are allowed.
+	return !strings.Contains(s, "..")
 }

--- a/provider/vertex/vertex_test.go
+++ b/provider/vertex/vertex_test.go
@@ -711,3 +711,30 @@ func TestSanitizeToolSchemas_MarshalError(t *testing.T) {
 		t.Error("expected schema unchanged after marshal error")
 	}
 }
+
+func TestValidGCPIdentifier(t *testing.T) {
+	valid := []string{
+		"us-central1",
+		"my-project-123",
+		"example.com:my-project", // domain-scoped project
+		"a",
+	}
+	for _, v := range valid {
+		if !validGCPIdentifier(v) {
+			t.Errorf("expected %q to be valid", v)
+		}
+	}
+	invalid := []string{
+		"",
+		"../evil",
+		"us-central1/../../x",
+		"has spaces",
+		"-starts-with-dash",
+		"foo..bar", // path traversal
+	}
+	for _, v := range invalid {
+		if validGCPIdentifier(v) {
+			t.Errorf("expected %q to be invalid", v)
+		}
+	}
+}

--- a/provider/xai/xai.go
+++ b/provider/xai/xai.go
@@ -145,8 +145,8 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
+		defer close(done)
 		openaicompat.ParseStream(ctx, scanner, out)
-		close(done)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/retry.go
+++ b/retry.go
@@ -56,13 +56,19 @@ func retryAfterDuration(err error) time.Duration {
 	}
 	// OpenAI uses retry-after-ms (milliseconds).
 	if ms, ok := apiErr.ResponseHeaders["retry-after-ms"]; ok {
-		if v, parseErr := strconv.ParseInt(ms, 10, 64); parseErr == nil && v > 0 && v <= 60000 {
+		if v, parseErr := strconv.ParseInt(ms, 10, 64); parseErr == nil && v > 0 {
+			if v > 60000 {
+				v = 60000
+			}
 			return time.Duration(v) * time.Millisecond
 		}
 	}
 	// Standard Retry-After (seconds).
 	if secs, ok := apiErr.ResponseHeaders["retry-after"]; ok {
-		if v, parseErr := strconv.ParseInt(secs, 10, 64); parseErr == nil && v > 0 && v <= 60 {
+		if v, parseErr := strconv.ParseInt(secs, 10, 64); parseErr == nil && v > 0 {
+			if v > 60 {
+				v = 60
+			}
 			return time.Duration(v) * time.Second
 		}
 	}

--- a/retry_test.go
+++ b/retry_test.go
@@ -188,7 +188,7 @@ func TestRetryAfterDuration(t *testing.T) {
 				IsRetryable:     true,
 				ResponseHeaders: map[string]string{"retry-after-ms": "120000"},
 			},
-			want: 0,
+			want: 60000 * time.Millisecond,
 		},
 		{
 			name: "retry-after-ms zero",
@@ -233,7 +233,7 @@ func TestRetryAfterDuration(t *testing.T) {
 				IsRetryable:     true,
 				ResponseHeaders: map[string]string{"retry-after": "120"},
 			},
-			want: 0,
+			want: 60 * time.Second,
 		},
 		{
 			name: "retry-after seconds zero",


### PR DESCRIPTION
## Summary

- 7-round red-team loop + 4-round deep-review audit of the entire GoAI codebase
- 55 files changed, 60+ issues found and fixed across security, correctness, code quality, docs, and tests
- All 26 packages pass, 0 lint issues, root coverage 92.7% -> 94.5%

### Security (7 fixes)
- URL-encode model IDs with `url.PathEscape` in google, bedrock, vertex providers
- Validate bedrock region (`validRegion`) and vertex location/project (`validGCPIdentifier`) before hostname interpolation to prevent SSRF
- URL-encode vertex API key query parameter
- Protect ProviderOptions from overwriting built-in fields (model, stream, messages) in openaicompat, anthropic, and responses API

### Correctness (18 fixes)
- Fix input mutation in `gemini/schema.go` (write to `result` map, not input `m`)
- `defer close(done)` in all 18 streaming providers for goroutine leak prevention
- Cap Retry-After >60s at 60s instead of discarding the header entirely
- SSE parser handles `data:value` without space after colon (per SSE spec)
- Partial JSON: handle `e+` exponent sign, strip truncated object keys
- Bedrock: create `inferenceConfig` when thinking is enabled without other inference params
- Vertex ADC: guard zero `Expiry` before subtracting 30s (prevents perpetual cache miss)
- Responses API: normalize `InputTokens -= CacheReadTokens` (match openaicompat convention)
- Pass `streamErr` to `OnResponse` hook in streaming consume goroutines
- Add ctx cancellation check in `executeTools` loop and `consume()` drain path
- Cohere: rename `tokenBudget` to `budgetTokens` (consistency with anthropic/bedrock)
- Cohere: add missing `ToolChoice` and `StopSequences` handling
- Fix finish reason mappings: Cohere ERROR to FinishError, Responses API unknown to FinishOther
- Populate `TotalTokens` in OpenAI/compat/cohere embedding responses

### Code Quality (10 fixes)
- Add `var _ provider.LanguageModel` compile-time interface checks to all 18 providers
- Convert 11 type assertions to `errors.As` in openai_test.go
- Rune-aware `truncate()` in object.go for UTF-8 safety
- Fix all golangci-lint warnings (errcheck, staticcheck, unused)
- Declare `Reasoning: true` capability in bedrock and cohere
- Remove dead `handledKeys` entries in anthropic

### Documentation (10 fixes)
- Document `Err()` method in core-functions.md for TextStream and ObjectStream
- Fix openai.md dall-e-3 description and Responses API annotations
- Fix vertex.md dual routing documentation
- Fix README prompt caching claim (Anthropic, Bedrock - not OpenAI)
- Update ROADMAP version, SKILL.md image options, bug report template
- Fix llms-full.txt missing image options and provider prefix

### Tests (8 additions)
- Tests for `TextStream.Err()` and `ObjectStream.Err()`
- Tests for `WithImageMaxRetries` and `WithImageTimeout`
- Tests for `validRegion()` and `validGCPIdentifier()`
- No-input-mutation tests for both `[]string` and `[]any` paths
- Added `called` guards and error type checks to prevent vacuous passes

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` 0 issues
- [x] `go test -count=1 ./...` all 26 packages pass
- [x] `go test -cover ./...` all packages >= 90%
- [x] `go test -race ./...` zero data races