### PR TITLE
feat(provider): add RunPod serverless vLLM provider

### DIFF
--- a/provider/runpod/runpod.go
+++ b/provider/runpod/runpod.go
@@ -1,0 +1,214 @@
+// Package runpod provides a RunPod language model implementation for GoAI.
+//
+// RunPod exposes an OpenAI-compatible API via serverless vLLM workers.
+// Each deployment has a unique endpoint ID visible in the RunPod console.
+//
+// Usage:
+//
+//	model := runpod.Chat("your-endpoint-id", "meta-llama/Llama-3.3-70B-Instruct",
+//		runpod.WithAPIKey("your-runpod-api-key"),
+//	)
+//	result, err := goai.GenerateText(ctx, model, goai.WithPrompt("Hello"))
+package runpod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/internal/httpc"
+	"github.com/zendev-sh/goai/internal/openaicompat"
+	"github.com/zendev-sh/goai/internal/sse"
+	"github.com/zendev-sh/goai/provider"
+)
+
+// Compile-time interface compliance checks.
+var (
+	_ provider.LanguageModel = (*chatModel)(nil)
+	_ provider.CapableModel  = (*chatModel)(nil)
+)
+
+const baseURLTemplate = "https://api.runpod.ai/v2/%s/openai/v1"
+
+// Option configures the RunPod provider.
+type Option func(*options)
+
+type options struct {
+	tokenSource provider.TokenSource
+	baseURL     string
+	headers     map[string]string
+	httpClient  *http.Client
+}
+
+// WithAPIKey sets a static API key for authentication.
+func WithAPIKey(key string) Option {
+	return func(o *options) {
+		o.tokenSource = provider.StaticToken(key)
+	}
+}
+
+// WithTokenSource sets a dynamic token source for authentication.
+func WithTokenSource(ts provider.TokenSource) Option {
+	return func(o *options) {
+		o.tokenSource = ts
+	}
+}
+
+// WithBaseURL overrides the default API base URL.
+func WithBaseURL(url string) Option {
+	return func(o *options) {
+		o.baseURL = url
+	}
+}
+
+// WithHeaders sets additional HTTP headers sent with every request.
+func WithHeaders(h map[string]string) Option {
+	return func(o *options) {
+		o.headers = h
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client for all requests.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *options) {
+		o.httpClient = c
+	}
+}
+
+// Chat creates a RunPod language model for the given endpoint and model IDs.
+// endpointID is the RunPod serverless endpoint ID (visible in the RunPod console).
+func Chat(endpointID, modelID string, opts ...Option) provider.LanguageModel {
+	defaultBaseURL := fmt.Sprintf(baseURLTemplate, endpointID)
+	o := options{baseURL: defaultBaseURL}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	// Resolve API key from env if not set.
+	if o.tokenSource == nil {
+		if key := os.Getenv("RUNPOD_API_KEY"); key != "" {
+			o.tokenSource = provider.StaticToken(key)
+		}
+	}
+	// Resolve base URL from env if not overridden.
+	if o.baseURL == defaultBaseURL {
+		if base := os.Getenv("RUNPOD_BASE_URL"); base != "" {
+			o.baseURL = base
+		}
+	}
+	return &chatModel{id: modelID, opts: o}
+}
+
+type chatModel struct {
+	id   string
+	opts options
+}
+
+func (m *chatModel) ModelID() string { return m.id }
+
+func (m *chatModel) Capabilities() provider.ModelCapabilities {
+	return provider.ModelCapabilities{
+		Temperature:      true,
+		ToolCall:         true,
+		InputModalities:  provider.ModalitySet{Text: true},
+		OutputModalities: provider.ModalitySet{Text: true},
+	}
+}
+
+func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
+	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
+
+	resp, err := m.doHTTP(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	return openaicompat.ParseResponse(respBody)
+}
+
+func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+		IncludeStreamOptions: true,
+	})
+
+	resp, err := m.doHTTP(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan provider.StreamChunk, 64)
+	scanner := sse.NewScanner(resp.Body)
+	go func() {
+		defer func() { _ = resp.Body.Close() }()
+		done := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+			case <-done:
+			}
+		}()
+		defer close(done)
+		openaicompat.ParseStream(ctx, scanner, out)
+	}()
+
+	return &provider.StreamResult{Stream: out}, nil
+}
+
+func (m *chatModel) doHTTP(ctx context.Context, body map[string]any) (*http.Response, error) {
+	token, err := m.resolveToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving auth token: %w", err)
+	}
+
+	reqHeaders, _ := body["_headers"].(map[string]string)
+	delete(body, "_headers")
+
+	jsonBody := httpc.MustMarshalJSON(body)
+	req := httpc.MustNewRequest(ctx, "POST", m.opts.baseURL+"/chat/completions", jsonBody)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	for k, v := range m.opts.headers {
+		req.Header.Set(k, v)
+	}
+	for k, v := range reqHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := m.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, goai.ParseHTTPErrorWithHeaders("runpod", resp.StatusCode, respBody, resp.Header)
+	}
+
+	return resp, nil
+}
+
+func (m *chatModel) httpClient() *http.Client {
+	if m.opts.httpClient != nil {
+		return m.opts.httpClient
+	}
+	return http.DefaultClient
+}
+
+func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
+	if m.opts.tokenSource == nil {
+		return "", errors.New("no API key or token source configured")
+	}
+	return m.opts.tokenSource.Token(ctx)
+}

--- a/provider/runpod/runpod_test.go
+++ b/provider/runpod/runpod_test.go
@@ -1,0 +1,311 @@
+package runpod
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestChat_Stream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openai/v1/chat/completions" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("auth = %s", r.Header.Get("Authorization"))
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{},\"index\":0,\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "meta-llama/Llama-3.3-70B-Instruct", WithAPIKey("test-key"), WithBaseURL(server.URL+"/openai/v1"))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var texts []string
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkText {
+			texts = append(texts, chunk.Text)
+		}
+	}
+	if len(texts) != 1 || texts[0] != "Hello" {
+		t.Errorf("texts = %v, want [Hello]", texts)
+	}
+}
+
+func TestChat_Generate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"chatcmpl-123","model":"meta-llama/Llama-3.3-70B-Instruct","choices":[{"message":{"role":"assistant","content":"Hello world"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "meta-llama/Llama-3.3-70B-Instruct", WithAPIKey("test-key"), WithBaseURL(server.URL+"/openai/v1"))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "Hello world" {
+		t.Errorf("Text = %q, want 'Hello world'", result.Text)
+	}
+}
+
+func TestChat_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"Rate limited"}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "model", WithAPIKey("test-key"), WithBaseURL(server.URL+"/openai/v1"))
+	_, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNoTokenSource(t *testing.T) {
+	model := Chat("ep-abc123", "model")
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	c := &http.Client{}
+	model := Chat("ep-abc123", "model", WithAPIKey("key"), WithHTTPClient(c))
+	cm := model.(*chatModel)
+	if cm.httpClient() != c {
+		t.Error("custom client not set")
+	}
+}
+
+func TestWithHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "val" {
+			t.Error("missing custom header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "m", WithAPIKey("k"), WithBaseURL(server.URL+"/openai/v1"), WithHeaders(map[string]string{"X-Custom": "val"}))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWithTokenSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer dynamic" {
+			t.Errorf("auth = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "m", WithTokenSource(provider.StaticToken("dynamic")), WithBaseURL(server.URL+"/openai/v1"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	model := Chat("ep-abc123", "m", WithAPIKey("k"))
+	caps := provider.ModelCapabilitiesOf(model)
+	if !caps.Temperature || !caps.ToolCall {
+		t.Error("unexpected capabilities")
+	}
+}
+
+func TestModelID(t *testing.T) {
+	model := Chat("ep-abc123", "meta-llama/Llama-3.3-70B-Instruct", WithAPIKey("k"))
+	if model.ModelID() != "meta-llama/Llama-3.3-70B-Instruct" {
+		t.Errorf("ModelID() = %q", model.ModelID())
+	}
+}
+
+func TestConnectionError(t *testing.T) {
+	model := Chat("ep-abc123", "m", WithAPIKey("k"), WithBaseURL("http://127.0.0.1:1/openai/v1"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "sending request") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestPerRequestHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Per-Request") != "val" {
+			t.Error("missing per-request header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "m", WithAPIKey("k"), WithBaseURL(server.URL+"/openai/v1"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+		Headers: map[string]string{"X-Per-Request": "val"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestToolCallStreaming(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		tools, _ := req["tools"].([]any)
+		if len(tools) != 1 {
+			t.Errorf("tools count = %d, want 1", len(tools))
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\"\"}}]},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\": \\\"Paris\\\"}\"}}]},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{},\"index\":0,\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":20}}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "meta-llama/Llama-3.3-70B-Instruct", WithAPIKey("test-key"), WithBaseURL(server.URL+"/openai/v1"))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "weather in Paris"}}},
+		},
+		Tools: []provider.ToolDefinition{
+			{Name: "get_weather", Description: "Get weather", InputSchema: []byte(`{"type":"object","properties":{"city":{"type":"string"}}}`)},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotToolCall bool
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkToolCall {
+			gotToolCall = true
+			if chunk.ToolName != "get_weather" {
+				t.Errorf("ToolName = %q", chunk.ToolName)
+			}
+		}
+	}
+	if !gotToolCall {
+		t.Error("no tool call chunk received")
+	}
+}
+
+func TestReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"id"`)
+	}))
+	defer server.Close()
+
+	model := Chat("ep-abc123", "m", WithAPIKey("k"), WithBaseURL(server.URL+"/openai/v1"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestChat_EnvVarResolution(t *testing.T) {
+	t.Setenv("RUNPOD_API_KEY", "env-key")
+	m := Chat("ep-abc123", "m")
+	cm := m.(*chatModel)
+	if cm.opts.tokenSource == nil {
+		t.Error("tokenSource should be set from RUNPOD_API_KEY")
+	}
+}
+
+func TestChat_EnvVarBaseURL(t *testing.T) {
+	t.Setenv("RUNPOD_API_KEY", "env-key")
+	t.Setenv("RUNPOD_BASE_URL", "https://custom.runpod.example/v1")
+	m := Chat("ep-abc123", "m")
+	cm := m.(*chatModel)
+	if cm.opts.baseURL != "https://custom.runpod.example/v1" {
+		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	}
+}
+
+func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	t.Setenv("RUNPOD_API_KEY", "env-key")
+	t.Setenv("RUNPOD_BASE_URL", "https://env.url")
+	m := Chat("ep-abc123", "m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
+	cm := m.(*chatModel)
+	if cm.opts.baseURL != "https://explicit.url" {
+		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	}
+}
+
+func TestEndpointIDInURL(t *testing.T) {
+	endpointID := "abc123def456"
+	m := Chat(endpointID, "some-model", WithAPIKey("k"))
+	cm := m.(*chatModel)
+	if !strings.Contains(cm.opts.baseURL, endpointID) {
+		t.Errorf("baseURL %q does not contain endpoint ID %q", cm.opts.baseURL, endpointID)
+	}
+	expected := "https://api.runpod.ai/v2/abc123def456/openai/v1"
+	if cm.opts.baseURL != expected {
+		t.Errorf("baseURL = %q, want %q", cm.opts.baseURL, expected)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `provider/runpod` — an OpenAI-compatible provider for [RunPod](https://www.runpod.io/) serverless vLLM workers
- `Chat(endpointID, modelID string, opts ...Option)` builds the base URL as `https://api.runpod.ai/v2/{endpointID}/openai/v1`
- Supports `RUNPOD_API_KEY` and `RUNPOD_BASE_URL` env vars, plus the full option set (`WithAPIKey`, `WithTokenSource`, `WithBaseURL`, `WithHeaders`, `WithHTTPClient`)
- 17 tests covering streaming, generation, tool calls, error handling, env var resolution, and endpoint ID URL construction

## Motivation

I've been using GoAI on a personal project and it's genuinely the cleanest Go AI SDK I've found — the unified interface across providers is exactly the right abstraction. I run some of my inference on RunPod serverless endpoints and needed this provider to keep using GoAI end-to-end.

## Test plan

- [x] `go test ./provider/runpod/` — all 17 tests pass
- [x] `go test ./...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)