### PR TITLE
fix: deep-review audit - docs accuracy, streaming metadata, provider capabilities

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -392,13 +392,14 @@ goai.WithImageProviderOptions(opts map[string]any) // provider-specific params
 
 ```go
 type TextResult struct {
-    Text         string                  // accumulated generated text
-    ToolCalls    []provider.ToolCall     // tool calls from final step
-    Steps        []StepResult            // per-step results
-    TotalUsage   provider.Usage          // aggregated token usage
-    FinishReason provider.FinishReason   // "stop", "tool-calls", "length", etc.
-    Response     provider.ResponseMetadata // provider metadata (ID, Model)
-    Sources      []provider.Source       // citations/references
+    Text             string                         // accumulated generated text
+    ToolCalls        []provider.ToolCall            // tool calls from final step
+    Steps            []StepResult                   // per-step results
+    TotalUsage       provider.Usage                 // aggregated token usage
+    FinishReason     provider.FinishReason          // "stop", "tool-calls", "length", etc.
+    Response         provider.ResponseMetadata      // provider metadata (ID, Model)
+    ProviderMetadata map[string]map[string]any      // provider-specific response data
+    Sources          []provider.Source              // citations/references
 }
 ```
 
@@ -406,10 +407,11 @@ type TextResult struct {
 
 ```go
 type ObjectResult[T any] struct {
-    Object       T                       // the parsed typed object
-    Usage        provider.Usage
-    FinishReason provider.FinishReason
-    Response     provider.ResponseMetadata
+    Object           T                              // the parsed typed object
+    Usage            provider.Usage
+    FinishReason     provider.FinishReason
+    Response         provider.ResponseMetadata
+    ProviderMetadata map[string]map[string]any      // provider-specific response data
 }
 ```
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -159,6 +159,7 @@ export default defineConfig({
                 { text: 'OpenRouter', link: '/providers/openrouter' },
                 { text: 'Perplexity', link: '/providers/perplexity' },
                 { text: 'Cerebras', link: '/providers/cerebras' },
+                { text: 'RunPod', link: '/providers/runpod' },
               ],
             },
             {

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -288,7 +288,7 @@ func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []stri
 | `values` | `[]string`                | The texts to embed.                                                                                |
 | `opts`   | `...Option`               | Options (`WithMaxParallelCalls`, `WithTimeout`, `WithMaxRetries`, `WithEmbeddingProviderOptions`). |
 
-**Returns:** `*EmbedManyResult` containing one embedding vector per input value and aggregated usage.
+**Returns:** `*EmbedManyResult` containing one embedding vector per input value and aggregated usage. When `EmbedMany` auto-chunks a large batch, `ProviderMetadata` in the result is taken from the first chunk only.
 
 **Example:**
 

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -59,7 +59,15 @@ GoAI detects context overflow from error messages across all supported providers
 - Amazon Bedrock ("input is too long for requested model")
 - OpenAI ("exceeds the context window")
 - Google Gemini ("input token count exceeds the maximum")
-- And many others (xAI, Groq, OpenRouter, DeepSeek, etc.)
+- xAI / Grok ("maximum prompt length is N")
+- Groq ("reduce the length of the messages")
+- OpenRouter / DeepSeek ("maximum context length is N tokens")
+- GitHub Copilot ("exceeds the limit of N")
+- llama.cpp / LM Studio ("exceeds the available context size", "greater than the context length")
+- MiniMax ("context window exceeds limit")
+- Kimi / Moonshot ("exceeded model token limit")
+- Cerebras / Mistral (400/413 status with no body)
+- Generic fallback ("context_length_exceeded", "context length exceeded")
 
 ---
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -79,6 +79,8 @@ func WithMaxSteps(n int) Option
 
 **Default:** `1` (no tool loop - the model generates once and returns, even if it requests tool calls).
 
+Values below 1 are silently clamped to 1.
+
 Set to 2 or higher to enable automatic tool execution. For example, `WithMaxSteps(2)` allows: step 1 = model calls tool, step 2 = model uses tool result to generate final answer.
 
 ### WithToolChoice
@@ -312,7 +314,7 @@ Sets the maximum number of concurrent API calls when `EmbedMany` auto-chunks a l
 func WithMaxParallelCalls(n int) Option
 ```
 
-**Default:** `0` (applied at runtime in `embed.go:112-115` as `4`).
+**Default:** `0` (applied at runtime in `embed.go:121-123` as `4`).
 
 ### WithEmbeddingProviderOptions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ description: "GoAI SDK architecture overview — layers, data flow, provider sys
 
 # Architecture
 
-GoAI is a Go SDK that provides one unified API across 21+ LLM providers. This document describes the overall architecture, key layers, data flow, and design decisions.
+GoAI is a Go SDK that provides one unified API across 22+ LLM providers. This document describes the overall architecture, key layers, data flow, and design decisions.
 
 ## High-Level Overview
 
@@ -24,7 +24,7 @@ GoAI is a Go SDK that provides one unified API across 21+ LLM providers. This do
 └──┬─────────┬──────────┬──────────┬──────────┬─────────┬──────────┘
    │         │          │          │          │         │
 ┌──▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼────┐ ┌───▼──┐ ┌───▼────────┐
-│OpenAI│ │Anthro.│ │Google │ │Bedrock │ │Cohere│ │12 compat   │
+│OpenAI│ │Anthro.│ │Google │ │Bedrock │ │Cohere│ │13 compat   │
 │      │ │       │ │       │ │        │ │      │ │providers   │
 └──┬───┘ └───┬───┘ └───┬───┘ └───┬────┘ └───┬──┘ └───┬────────┘
    │         │         │         │          │        │
@@ -112,7 +112,7 @@ An optional `CapableModel` interface allows providers to declare feature support
 
 | Package                 | Description                                                                                                                                                                                                    |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `internal/openaicompat` | Shared request building and response parsing for all OpenAI-compatible APIs. `BuildRequest` constructs the wire format, `ParseStream`/`ParseResponse` decode responses into GoAI types. Used by 13 packages directly. |
+| `internal/openaicompat` | Shared request building and response parsing for all OpenAI-compatible APIs. `BuildRequest` constructs the wire format, `ParseStream`/`ParseResponse` decode responses into GoAI types. Used by 14 packages directly. |
 | `internal/gemini`       | Gemini schema sanitization (`SanitizeSchema`). Used by the Vertex and Google providers to conform JSON Schemas to Gemini's stricter requirements.                                                                     |
 | `internal/sse`          | Minimal SSE (Server-Sent Events) scanner. Handles `data:` prefix, blank lines, `[DONE]` sentinel. JSON deserialization is left to the caller.                                                                         |
 | `internal/httpc`        | HTTP utilities: `MustMarshalJSON`, `MustNewRequest`, `ParseDataURL`. Shared across all providers.                                                                                                                     |
@@ -130,29 +130,30 @@ These providers implement their own request/response codec because their APIs di
 | **OpenAI**    | Chat Completions + Responses API | All models default to Responses API (matching Vercel v2.0.89+). Chat Completions available via `useResponsesAPI: false` in ProviderOptions. Separate `responses.go` handles different SSE format. Provider-defined tools: web search, code interpreter, file search, image generation. |
 | **Anthropic** | Messages API                     | Custom SSE event format (`message_start`, `content_block_start`, `content_block_delta`, etc.). Structured output via tool trick (injects synthetic tool) or native `output_format`. Provider-defined tools: computer use, bash, text editor, web search, web fetch, code execution.               |
 | **Google**    | Gemini REST API                  | Custom JSON format with `contents[]` array, `generationConfig`, `tools[]`. Structured output via `responseMimeType` + `responseSchema` in `generationConfig`. Provider-defined tools: Google Search grounding, URL context, code execution.                                                        |
-| **Bedrock**   | AWS Converse API                 | Binary EventStream protocol for streaming, SigV4 request signing (without AWS SDK), cross-region inference fallback with `us.` prefix retry.                                                                                                                                                       |
+| **Bedrock**   | AWS Converse + InvokeModel API   | Binary EventStream protocol for streaming, SigV4 request signing (without AWS SDK), cross-region inference fallback with `us.` prefix retry. InvokeModel API for embeddings (Titan, Cohere, Nova, Marengo).                                                                                                                                                       |
 | **Cohere**    | Chat v2 + Embed API              | Custom message format with native embed API. Tool results use standard `role: "tool"` with `tool_call_id`. Structured output via native `response_format` (`json_object` type with `json_schema`).                                                                                                                      |
 
 ### OpenAI-Compatible Providers (shared codec)
 
-13 packages directly import `internal/openaicompat` (including `openai` for its Chat Completions path). Each thin wrapper:
+14 packages directly import `internal/openaicompat` (including `openai` for its Chat Completions path). Each thin wrapper:
 
 1. Sets the correct base URL and auth headers
 2. Resolves credentials from environment variables
 3. Delegates to `openaicompat.BuildRequest` / `ParseStream` / `ParseResponse`
 
 ```
-Direct openaicompat importers (13):
+Direct openaicompat importers (14):
 ├── openai/      ← Chat Completions path uses openaicompat; Responses path is native
 ├── vertex/      ← Uses OAuth2 ADC for auth
 ├── mistral/     ├── groq/       ├── xai/
 ├── deepseek/    ├── fireworks/  ├── together/
 ├── deepinfra/   ├── openrouter/ ├── perplexity/
-├── cerebras/
+├── cerebras/    ├── runpod/
 └── compat/      ← Generic, user-configured endpoint
 
 Indirect users (via delegation):
 ├── azure/       ← Delegates to openai/ (OpenAI models), anthropic/ (Claude), AI Services (others)
+├── minimax/     ← Delegates to anthropic/ (Anthropic-compatible API)
 ├── ollama/      ← Wraps compat/ (localhost:11434)
 └── vllm/        ← Wraps compat/ (localhost:8000)
 ```
@@ -306,7 +307,7 @@ HTTP error response
   │
   ├─ goai.ParseHTTPErrorWithHeaders(providerID, status, body, headers)
   │   ├─ extractErrorMessage() — tries 3 JSON paths ({error.message}, {message}, {error} as string)
-  │   ├─ IsOverflow(message) — matches 14 regex patterns across 21+ providers
+  │   ├─ IsOverflow(message) — matches 14 regex patterns across 22+ providers
   │   │   └─ return *ContextOverflowError
   │   └─ return *APIError{StatusCode, IsRetryable, ResponseHeaders}
   │
@@ -358,7 +359,7 @@ Key architectural decisions that shape the SDK:
 
 - **OpenAI dual API routing**: All models default to Responses API (matching Vercel v2.0.89+). Chat Completions available via `useResponsesAPI: false` in ProviderOptions. `isReasoningModel` is used only for capability detection (temperature, reasoning), not routing. Separate `responses.go` handles different SSE format.
 - **Token caching without blocking**: `CachedTokenSource` releases mutex before network calls, accepting brief double‑fetch to avoid goroutine deadlock.
-- **Cross‑provider error pattern matching**: 14 regex patterns detect "context overflow" across 21+ providers' inconsistent error messages, enabling uniform `ContextOverflowError`.
+- **Cross‑provider error pattern matching**: 14 regex patterns detect "context overflow" across 22+ providers' inconsistent error messages, enabling uniform `ContextOverflowError`.
 - **Bedrock AWS independence**: Manual SigV4 signing and EventStream binary protocol parsing avoid AWS SDK dependency.
 - **Provider‑defined tools scale**: 20 tools across 5 providers, each with options structs, version handling, and provider‑specific serialization (~1200 LOC).
 - **Structured output multi‑strategy**: Anthropic uses native `output_format` (Opus 4.1+, Sonnet 4.5+: claude‑opus‑4‑1, claude‑sonnet‑4‑5, claude‑opus‑4‑5, claude‑sonnet‑4‑6, claude‑opus‑4‑6) or tool trick (older models), adapting to varying provider capabilities.
@@ -387,13 +388,14 @@ goai/
 │   ├── openai/             # OpenAI (Chat Completions + Responses API)
 │   ├── anthropic/          # Anthropic (Messages API)
 │   ├── google/             # Google Gemini (REST API)
-│   ├── bedrock/            # AWS Bedrock (Converse API + SigV4 + EventStream)
+│   ├── bedrock/            # AWS Bedrock (Converse API + SigV4 + EventStream; InvokeModel for embeddings)
 │   ├── vertex/             # Vertex AI (OpenAI-compat + OAuth2 ADC)
 │   ├── azure/              # Azure OpenAI (+ auto-routes Claude to Anthropic endpoint)
 │   ├── cohere/             # Cohere (Chat v2 + native Embed)
 │   ├── compat/             # Generic OpenAI-compatible
 │   └── ...                 # mistral, groq, xai, deepseek, fireworks, together,
-│                           # deepinfra, openrouter, perplexity, cerebras, ollama, vllm
+│                           # deepinfra, openrouter, perplexity, cerebras, runpod,
+│                           # minimax, ollama, vllm
 │
 ├── internal/
 │   ├── openaicompat/       # Shared codec: BuildRequest, ParseStream, ParseResponse

--- a/docs/concepts/provider-tools.md
+++ b/docs/concepts/provider-tools.md
@@ -130,6 +130,44 @@ td := openai.Tools.ImageGeneration(
 )
 ```
 
+**Additional WebSearch options:**
+
+| Option                                         | Type                 | Description                                         |
+| ---------------------------------------------- | -------------------- | --------------------------------------------------- |
+| `WithSearchContextSize(size string)`           | `string`             | `"low"`, `"medium"` (default), `"high"` — controls context breadth and cost |
+| `WithUserLocation(loc WebSearchLocation)`      | `WebSearchLocation`  | Location hint for geographically relevant results (`Country`, `City`, `Timezone`) |
+| `WithSearchFilters(filters WebSearchFilters)`  | `WebSearchFilters`   | Domain allow-list for search results                |
+| `WithExternalWebAccess(enabled bool)`          | `bool`               | `true` = live content (default), `false` = cached   |
+
+**Additional CodeInterpreter options:**
+
+| Option                                               | Type                         | Description                                       |
+| ---------------------------------------------------- | ---------------------------- | ------------------------------------------------- |
+| `WithContainerID(id string)`                         | `string`                     | Use an existing container by ID                   |
+| `WithContainerFiles(container *CodeInterpreterContainer)` | `*CodeInterpreterContainer` | Auto-provisioned container with uploaded file IDs |
+
+**Additional FileSearch options:**
+
+| Option                                           | Type                 | Description                                              |
+| ------------------------------------------------ | -------------------- | -------------------------------------------------------- |
+| `WithRanking(ranking FileSearchRanking)`         | `FileSearchRanking`  | Ranking options: `Ranker` (string) and `ScoreThreshold` (0–1) |
+| `WithFileSearchFilters(filters FileSearchFilter)` | `FileSearchFilter`  | Metadata filter; use `*FileSearchComparisonFilter` or `*FileSearchCompoundFilter` |
+
+**Additional ImageGeneration options:**
+
+| Option                                           | Type                    | Description                                                |
+| ------------------------------------------------ | ----------------------- | ---------------------------------------------------------- |
+| `WithBackground(bg string)`                     | `string`                | Background type for the generated image                    |
+| `WithInputFidelity(fidelity string)`             | `string`                | `"low"` or `"high"` input processing fidelity              |
+| `WithInputImageMask(mask ImageGenerationMask)`   | `ImageGenerationMask`   | Inpainting mask (`FileID` or `ImageURL`)                   |
+| `WithImageModel(model string)`                   | `string`                | Image model to use (default: `"gpt-image-1"`)             |
+| `WithModeration(mod string)`                     | `string`                | Moderation level (default: `"auto"`)                       |
+| `WithOutputCompression(level int)`               | `int`                   | Output compression 0–100                                   |
+| `WithOutputFormat(format string)`                | `string`                | `"png"`, `"jpeg"`, `"webp"`                                |
+| `WithPartialImages(n int)`                       | `int`                   | Partial images in streaming (0–3)                          |
+| `WithImageQuality(quality string)`               | `string`                | `"auto"`, `"low"`, `"medium"`, `"high"`                    |
+| `WithImageSize(size string)`                     | `string`                | `"auto"`, `"1024x1024"`, `"1024x1536"`, `"1536x1024"`     |
+
 ### Google (3 tools)
 
 Import: `github.com/zendev-sh/goai/provider/google`

--- a/docs/concepts/providers-and-models.md
+++ b/docs/concepts/providers-and-models.md
@@ -121,7 +121,7 @@ If no API key or token source is provided, providers read from environment varia
 | Google     | `github.com/zendev-sh/goai/provider/google`     | `Chat`, `Embedding`, `Image` |
 | Azure      | `github.com/zendev-sh/goai/provider/azure`      | `Chat`, `Image`              |
 | Vertex AI  | `github.com/zendev-sh/goai/provider/vertex`     | `Chat`, `Embedding`, `Image` |
-| Bedrock    | `github.com/zendev-sh/goai/provider/bedrock`    | `Chat`                       |
+| Bedrock    | `github.com/zendev-sh/goai/provider/bedrock`    | `Chat`, `Embedding`          |
 | Mistral    | `github.com/zendev-sh/goai/provider/mistral`    | `Chat`                       |
 | xAI        | `github.com/zendev-sh/goai/provider/xai`        | `Chat`                       |
 | Groq       | `github.com/zendev-sh/goai/provider/groq`       | `Chat`                       |
@@ -133,6 +133,8 @@ If no API key or token source is provided, providers read from environment varia
 | Cohere     | `github.com/zendev-sh/goai/provider/cohere`     | `Chat`, `Embedding`          |
 | Cerebras   | `github.com/zendev-sh/goai/provider/cerebras`   | `Chat`                       |
 | Perplexity | `github.com/zendev-sh/goai/provider/perplexity` | `Chat`                       |
+| MiniMax    | `github.com/zendev-sh/goai/provider/minimax`    | `Chat`                       |
+| RunPod     | `github.com/zendev-sh/goai/provider/runpod`     | `Chat`                       |
 | Ollama     | `github.com/zendev-sh/goai/provider/ollama`     | `Chat`, `Embedding`          |
 | vLLM       | `github.com/zendev-sh/goai/provider/vllm`       | `Chat`, `Embedding`          |
 | Compat     | `github.com/zendev-sh/goai/provider/compat`     | `Chat`, `Embedding`          |

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -48,6 +48,22 @@ for chunk := range stream.Stream() {
 }
 ```
 
+### Chunk Types
+
+| Type | Fields Used | Description |
+|------|------------|-------------|
+| `ChunkText` | `Text`, `Metadata` | Generated text content |
+| `ChunkReasoning` | `Text`, `Metadata` | Extended thinking / chain-of-thought |
+| `ChunkToolCall` | `ToolCallID`, `ToolName`, `ToolInput` | Complete tool call |
+| `ChunkToolCallStreamStart` | `ToolCallID`, `ToolName` | Start of a streaming tool call |
+| `ChunkToolCallDelta` | `ToolInput` | Incremental tool call input |
+| `ChunkToolResult` | `Text` | Tool execution result |
+| `ChunkStepFinish` | `FinishReason`, `Usage`, `Response`, `Metadata` | End of a tool-loop step |
+| `ChunkFinish` | `FinishReason`, `Usage`, `Response`, `Metadata` | End of generation |
+| `ChunkError` | `Error` | Stream error |
+
+`Metadata` carries provider-specific data: `ChunkFinish` may include `"providerMetadata"` (OpenAI Chat Completions via openaicompat) or flat keys like `"iterations"` (Anthropic) and `"cacheWriteInputTokens"` (Bedrock). These are propagated into `TextResult.ProviderMetadata` and `Response.ProviderMetadata` respectively. Note: the OpenAI Responses API streaming path does not populate `ProviderMetadata` on the finish chunk — logprobs are only available via `GenerateText`. Reasoning summaries are delivered as `ChunkReasoning` chunks during streaming rather than appearing in `ProviderMetadata`.
+
 ### Result() - block for final result
 
 Blocks until the stream completes, then returns a `*TextResult` with accumulated text, tool calls, usage, and metadata.

--- a/docs/concepts/token-source.md
+++ b/docs/concepts/token-source.md
@@ -66,6 +66,7 @@ Key properties:
 - **Thread-safe.** Multiple goroutines can call `Token()` concurrently.
 - **Lazy.** The fetch function is not called until the first `Token()` call.
 - **TTL-based.** The cached token is reused as long as `time.Now()` is before `ExpiresAt`. Set `ExpiresAt` to zero for tokens that never expire.
+- **Non-blocking refresh.** The fetch function is called outside any lock. Concurrent callers during a refresh are never blocked waiting on each other's network call (brief double-fetch is acceptable).
 
 ## Token Invalidation
 
@@ -113,6 +114,8 @@ model := azure.Chat("gpt-4o", azure.WithTokenSource(ts))
 ```
 
 ### Google Service Account
+
+> **Note:** The Google Gemini provider (`provider/google`) sends all tokens via the `x-goog-api-key` header, which only accepts API keys — not OAuth2 Bearer tokens. For OAuth2 or service account authentication with Google, use the Vertex AI provider (`provider/vertex`) instead, which supports standard Bearer auth.
 
 ```go
 ts := provider.CachedTokenSource(func(ctx context.Context) (*provider.Token, error) {

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -258,7 +258,7 @@ MCP tools with GoAI LLM integration. Connects to an MCP server, converts its too
 - **Source:** [`examples/mcp-tools/`](https://github.com/zendev-sh/goai/tree/main/examples/mcp-tools)
 
 ```bash
-export GOOGLE_API_KEY=...
+export GEMINI_API_KEY=...
 go run ./examples/mcp-tools
 ```
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -45,6 +45,7 @@ All use the shared `internal/openaicompat` codec.
 | [OpenRouter](openrouter.md) | `openrouter.ai`     | `OPENROUTER_API_KEY`  |
 | [Perplexity](perplexity.md) | `api.perplexity.ai` | `PERPLEXITY_API_KEY`  |
 | [Cerebras](cerebras.md)     | `api.cerebras.ai`   | `CEREBRAS_API_KEY`    |
+| [RunPod](runpod.md)         | `api.runpod.ai`     | `RUNPOD_API_KEY`      |
 
 ## Local / Custom
 

--- a/docs/providers/runpod.md
+++ b/docs/providers/runpod.md
@@ -1,0 +1,58 @@
+---
+title: RunPod Provider
+description: "Use RunPod serverless vLLM endpoints in Go with GoAI. Run any model on RunPod via the OpenAI-compatible Chat Completions API."
+---
+
+# RunPod
+
+RunPod serverless vLLM inference provider using the OpenAI-compatible Chat Completions API.
+
+## Setup
+
+```bash
+go get github.com/zendev-sh/goai@latest
+```
+
+```go
+import "github.com/zendev-sh/goai/provider/runpod"
+```
+
+Set the `RUNPOD_API_KEY` environment variable, or pass `WithAPIKey()` directly.
+
+## Models
+
+Model IDs depend on your RunPod endpoint configuration. Common examples:
+
+- `meta-llama/Llama-3.3-70B-Instruct`
+- `mistralai/Mistral-7B-Instruct-v0.3`
+- `Qwen/Qwen2.5-72B-Instruct`
+
+## Usage
+
+RunPod requires **two arguments**: an endpoint ID and a model ID. This differs from most other providers.
+
+```go
+model := runpod.Chat("your-endpoint-id", "meta-llama/Llama-3.3-70B-Instruct")
+
+result, err := goai.GenerateText(ctx, model, goai.WithPrompt("Hello"))
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(result.Text)
+```
+
+## Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `WithAPIKey(key)` | `string` | Set a static API key |
+| `WithTokenSource(ts)` | `provider.TokenSource` | Set a dynamic token source |
+| `WithBaseURL(url)` | `string` | Override the default `https://api.runpod.ai/v2/{endpointID}/openai/v1` endpoint |
+| `WithHeaders(h)` | `map[string]string` | Set additional HTTP headers |
+| `WithHTTPClient(c)` | `*http.Client` | Set a custom `*http.Client` |
+
+## Notes
+
+- Environment variable `RUNPOD_BASE_URL` can override the default endpoint.
+- The default base URL is constructed from the endpoint ID: `https://api.runpod.ai/v2/{endpointID}/openai/v1`.
+- Chat only — no embedding or image generation support.

--- a/examples/mcp-tools/main.go
+++ b/examples/mcp-tools/main.go
@@ -5,12 +5,12 @@
 // Connects to an MCP testserver, converts its tools to GoAI tools, and passes
 // them to GenerateText so the LLM can call MCP tools in an agent loop.
 //
-// Requires a GOOGLE_API_KEY (Gemini) for the LLM. The MCP servers are local
+// Requires a GEMINI_API_KEY (Gemini) for the LLM. The MCP servers are local
 // (no external dependencies beyond the API key).
 //
 // Usage:
 //
-//	export GOOGLE_API_KEY=...
+//	export GEMINI_API_KEY=...
 //	go run ./examples/mcp-tools
 package main
 
@@ -26,9 +26,9 @@ import (
 )
 
 func main() {
-	apiKey := os.Getenv("GOOGLE_API_KEY")
+	apiKey := os.Getenv("GEMINI_API_KEY")
 	if apiKey == "" {
-		log.Fatal("GOOGLE_API_KEY environment variable is required")
+		log.Fatal("GEMINI_API_KEY environment variable is required")
 	}
 
 	ctx := context.Background()

--- a/generate.go
+++ b/generate.go
@@ -93,13 +93,14 @@ type TextStream struct {
 	startTime  time.Time
 
 	// Accumulated state (written by consume goroutine, read after doneCh closes).
-	text         strings.Builder
-	toolCalls    []provider.ToolCall
-	sources      []provider.Source
-	finishReason provider.FinishReason
-	usage        provider.Usage
-	response     provider.ResponseMetadata
-	streamErr    error
+	text             strings.Builder
+	toolCalls        []provider.ToolCall
+	sources          []provider.Source
+	finishReason     provider.FinishReason
+	usage            provider.Usage
+	response         provider.ResponseMetadata
+	providerMetadata map[string]map[string]any
+	streamErr        error
 }
 
 func newTextStream(ctx context.Context, source <-chan provider.StreamChunk) *TextStream {
@@ -207,6 +208,25 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 			if sources, ok := chunk.Metadata["sources"].([]provider.Source); ok {
 				ts.sources = append(ts.sources, sources...)
 			}
+			// Extract provider metadata embedded in the finish chunk.
+			// openaicompat encodes it as Metadata["providerMetadata"] = map[string]map[string]any.
+			// The type assertion safely returns false for any other type (no panic).
+			if pm, ok := chunk.Metadata["providerMetadata"].(map[string]map[string]any); ok {
+				ts.providerMetadata = pm
+			}
+			// Copy remaining flat metadata keys into Response.ProviderMetadata.
+			// Providers use this for per-response data: Anthropic ("iterations",
+			// "contextManagement", "container"), Bedrock ("cacheWriteInputTokens").
+			// Skip "providerMetadata" (handled above) and "sources" (handled separately).
+			for k, v := range chunk.Metadata {
+				if k == "providerMetadata" || k == "sources" {
+					continue
+				}
+				if ts.response.ProviderMetadata == nil {
+					ts.response.ProviderMetadata = map[string]any{}
+				}
+				ts.response.ProviderMetadata[k] = v
+			}
 		case provider.ChunkError:
 			if ts.streamErr == nil {
 				ts.streamErr = chunk.Error
@@ -238,20 +258,22 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 func (ts *TextStream) buildResult() *TextResult {
 	text := ts.text.String()
 	return &TextResult{
-		Text:         text,
-		ToolCalls:    ts.toolCalls,
-		FinishReason: ts.finishReason,
-		TotalUsage:   ts.usage,
-		Response:     ts.response,
-		Sources:      ts.sources,
+		Text:             text,
+		ToolCalls:        ts.toolCalls,
+		FinishReason:     ts.finishReason,
+		TotalUsage:       ts.usage,
+		Response:         ts.response,
+		Sources:          ts.sources,
+		ProviderMetadata: ts.providerMetadata,
 		Steps: []StepResult{{
-			Number:       1,
-			Text:         text,
-			ToolCalls:    ts.toolCalls,
-			FinishReason: ts.finishReason,
-			Usage:        ts.usage,
-			Response:     ts.response,
-			Sources:      ts.sources,
+			Number:           1,
+			Text:             text,
+			ToolCalls:        ts.toolCalls,
+			FinishReason:     ts.finishReason,
+			Usage:            ts.usage,
+			Response:         ts.response,
+			Sources:          ts.sources,
+			ProviderMetadata: ts.providerMetadata,
 		}},
 	}
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -1795,3 +1795,239 @@ func TestConsume_ContextCancelledResultPath(t *testing.T) {
 	// Result should have at most the text sent before cancel.
 	_ = result
 }
+
+// TestStreamText_ProviderMetadata verifies that nested providerMetadata
+// (OpenAI Chat Completions convention) flows from ChunkFinish.Metadata through
+// consume() into TextResult.ProviderMetadata and StepResult.ProviderMetadata.
+// The provider-level counterpart is TestParseStream_ProviderMetadataInFinish
+// in internal/openaicompat/, which verifies the codec emits the right chunk shape.
+func TestStreamText_ProviderMetadata(t *testing.T) {
+	wantMeta := map[string]map[string]any{
+		"openai": {"logprobs": []float64{-0.1, -0.2}},
+	}
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hello"},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Usage:        provider.Usage{InputTokens: 5, OutputTokens: 1},
+					Metadata: map[string]any{
+						"providerMetadata": wantMeta,
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model, WithPrompt("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.TextStream() {
+	}
+	result := stream.Result()
+
+	if result.ProviderMetadata == nil {
+		t.Fatal("ProviderMetadata is nil, want non-nil")
+	}
+	openaiMeta, ok := result.ProviderMetadata["openai"]
+	if !ok {
+		t.Fatal("missing 'openai' key in ProviderMetadata")
+	}
+	if openaiMeta["logprobs"] == nil {
+		t.Error("missing 'logprobs' in openai ProviderMetadata")
+	}
+
+	// Also check StepResult propagation.
+	if len(result.Steps) == 0 {
+		t.Fatal("no steps in result")
+	}
+	if result.Steps[0].ProviderMetadata == nil {
+		t.Error("StepResult.ProviderMetadata is nil")
+	}
+}
+
+func TestStreamText_ProviderMetadata_ResponseLevel(t *testing.T) {
+	// Anthropic convention: flat metadata keys go into Response.ProviderMetadata.
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hi"},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Metadata: map[string]any{
+						"iterations": 3,
+						"container":  "abc",
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model, WithPrompt("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.TextStream() {
+	}
+	result := stream.Result()
+
+	if result.Response.ProviderMetadata == nil {
+		t.Fatal("Response.ProviderMetadata is nil")
+	}
+	if result.Response.ProviderMetadata["iterations"] != 3 {
+		t.Errorf("iterations = %v, want 3", result.Response.ProviderMetadata["iterations"])
+	}
+	if result.Response.ProviderMetadata["container"] != "abc" {
+		t.Errorf("container = %v, want abc", result.Response.ProviderMetadata["container"])
+	}
+}
+
+func TestStreamText_ProviderMetadata_BothConventions(t *testing.T) {
+	// A chunk that carries both nested providerMetadata (OpenAI) and flat keys (Anthropic).
+	wantNested := map[string]map[string]any{
+		"openai": {"logprobs": true},
+	}
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hi"},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Metadata: map[string]any{
+						"providerMetadata": wantNested,
+						"iterations":       5,
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model, WithPrompt("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.TextStream() {
+	}
+	result := stream.Result()
+
+	// Nested convention → TextResult.ProviderMetadata
+	if result.ProviderMetadata == nil {
+		t.Fatal("ProviderMetadata is nil")
+	}
+	if _, ok := result.ProviderMetadata["openai"]; !ok {
+		t.Error("missing 'openai' key in ProviderMetadata")
+	}
+
+	// Flat convention → Response.ProviderMetadata
+	if result.Response.ProviderMetadata == nil {
+		t.Fatal("Response.ProviderMetadata is nil")
+	}
+	if result.Response.ProviderMetadata["iterations"] != 5 {
+		t.Errorf("iterations = %v, want 5", result.Response.ProviderMetadata["iterations"])
+	}
+
+	// Flat loop must NOT include the "providerMetadata" key.
+	if _, ok := result.Response.ProviderMetadata["providerMetadata"]; ok {
+		t.Error("providerMetadata key should not leak into Response.ProviderMetadata")
+	}
+}
+
+func TestStreamText_ChunkStepFinish_ProviderMetadata(t *testing.T) {
+	// ChunkStepFinish and ChunkFinish share the same case in consume().
+	// Verify that metadata from ChunkStepFinish is captured and then
+	// overwritten by ChunkFinish (last-write-wins, matching non-streaming).
+	stepMeta := map[string]map[string]any{
+		"openai": {"step": "first"},
+	}
+	finishMeta := map[string]map[string]any{
+		"openai": {"step": "final"},
+	}
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "step1"},
+				provider.StreamChunk{
+					Type:         provider.ChunkStepFinish,
+					FinishReason: provider.FinishToolCalls,
+					Usage:        provider.Usage{InputTokens: 5, OutputTokens: 2},
+					Metadata: map[string]any{
+						"providerMetadata": stepMeta,
+					},
+				},
+				provider.StreamChunk{Type: provider.ChunkText, Text: " step2"},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Usage:        provider.Usage{InputTokens: 8, OutputTokens: 4},
+					Metadata: map[string]any{
+						"providerMetadata": finishMeta,
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model, WithPrompt("multi-step"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.TextStream() {
+	}
+	result := stream.Result()
+
+	// Final metadata should be from ChunkFinish (last-write-wins).
+	if result.ProviderMetadata == nil {
+		t.Fatal("ProviderMetadata is nil")
+	}
+	openaiMeta := result.ProviderMetadata["openai"]
+	if openaiMeta["step"] != "final" {
+		t.Errorf("step = %v, want 'final' (last-write-wins)", openaiMeta["step"])
+	}
+}
+
+func TestStreamText_FlatMetadata_CacheTokens(t *testing.T) {
+	// Bedrock puts cacheWriteInputTokens as a flat key on ChunkFinish.Metadata.
+	// Verify it surfaces in Response.ProviderMetadata.
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "cached"},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Metadata: map[string]any{
+						"cacheWriteInputTokens": 25,
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model, WithPrompt("cache test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.TextStream() {
+	}
+	result := stream.Result()
+
+	if result.Response.ProviderMetadata == nil {
+		t.Fatal("Response.ProviderMetadata is nil")
+	}
+	if result.Response.ProviderMetadata["cacheWriteInputTokens"] != 25 {
+		t.Errorf("cacheWriteInputTokens = %v, want 25", result.Response.ProviderMetadata["cacheWriteInputTokens"])
+	}
+}

--- a/object.go
+++ b/object.go
@@ -47,13 +47,14 @@ type ObjectStream[T any] struct {
 	startTime  time.Time
 
 	// Accumulated state.
-	text         strings.Builder
-	finishReason provider.FinishReason
-	usage        provider.Usage
-	response     provider.ResponseMetadata
-	finalObject  *T
-	parseErr     error
-	streamErr    error
+	text             strings.Builder
+	finishReason     provider.FinishReason
+	usage            provider.Usage
+	response         provider.ResponseMetadata
+	providerMetadata map[string]map[string]any
+	finalObject      *T
+	parseErr         error
+	streamErr        error
 }
 
 func newObjectStream[T any](ctx context.Context, source <-chan provider.StreamChunk) *ObjectStream[T] {
@@ -99,16 +100,18 @@ func (os *ObjectStream[T]) Result() (*ObjectResult[T], error) {
 
 	if os.finalObject == nil {
 		return &ObjectResult[T]{
-			Usage:        os.usage,
-			FinishReason: os.finishReason,
-			Response:     os.response,
+			Usage:            os.usage,
+			FinishReason:     os.finishReason,
+			Response:         os.response,
+			ProviderMetadata: os.providerMetadata,
 		}, nil
 	}
 	return &ObjectResult[T]{
-		Object:       *os.finalObject,
-		Usage:        os.usage,
-		FinishReason: os.finishReason,
-		Response:     os.response,
+		Object:           *os.finalObject,
+		Usage:            os.usage,
+		FinishReason:     os.finishReason,
+		Response:         os.response,
+		ProviderMetadata: os.providerMetadata,
 	}, nil
 }
 
@@ -162,6 +165,25 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 			os.finishReason = chunk.FinishReason
 			os.usage = chunk.Usage
 			os.response = chunk.Response
+			// Extract provider metadata embedded in the finish chunk.
+			// openaicompat encodes it as Metadata["providerMetadata"] = map[string]map[string]any.
+			// The type assertion safely returns false for any other type (no panic).
+			if pm, ok := chunk.Metadata["providerMetadata"].(map[string]map[string]any); ok {
+				os.providerMetadata = pm
+			}
+			// Copy remaining flat metadata keys into Response.ProviderMetadata.
+			// Providers use this for per-response data: Anthropic ("iterations",
+			// "contextManagement", "container"), Bedrock ("cacheWriteInputTokens").
+			// Skip "providerMetadata" (handled above) and "sources" (ObjectResult has no Sources field).
+			for k, v := range chunk.Metadata {
+				if k == "providerMetadata" || k == "sources" {
+					continue
+				}
+				if os.response.ProviderMetadata == nil {
+					os.response.ProviderMetadata = map[string]any{}
+				}
+				os.response.ProviderMetadata[k] = v
+			}
 		case provider.ChunkError:
 			if os.streamErr == nil {
 				os.streamErr = chunk.Error

--- a/object_test.go
+++ b/object_test.go
@@ -1191,3 +1191,146 @@ func TestStreamObject_ErrReturnsStreamError(t *testing.T) {
 		t.Errorf("unexpected error: %v", stream.Err())
 	}
 }
+
+func TestStreamObject_ProviderMetadata(t *testing.T) {
+	wantMeta := map[string]map[string]any{
+		"openai": {"logprobs": true},
+	}
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: `{"name":"Alice","age":30}`},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+					Metadata: map[string]any{
+						"providerMetadata": wantMeta,
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamObject[simpleObject](t.Context(), model, WithPrompt("generate"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.PartialObjectStream() {
+	}
+
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ProviderMetadata == nil {
+		t.Fatal("ProviderMetadata is nil, want non-nil")
+	}
+	openaiMeta, ok := result.ProviderMetadata["openai"]
+	if !ok {
+		t.Fatal("missing 'openai' key in ProviderMetadata")
+	}
+	if openaiMeta["logprobs"] != true {
+		t.Error("missing 'logprobs' in openai ProviderMetadata")
+	}
+}
+
+func TestStreamObject_ProviderMetadata_ResponseLevel(t *testing.T) {
+	// Anthropic convention: flat metadata keys go into Response.ProviderMetadata.
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: `{"name":"Eve","age":28}`},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Metadata: map[string]any{
+						"iterations": 2,
+						"container":  "xyz",
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamObject[simpleObject](t.Context(), model, WithPrompt("gen"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.PartialObjectStream() {
+	}
+
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response.ProviderMetadata == nil {
+		t.Fatal("Response.ProviderMetadata is nil")
+	}
+	if result.Response.ProviderMetadata["iterations"] != 2 {
+		t.Errorf("iterations = %v, want 2", result.Response.ProviderMetadata["iterations"])
+	}
+	if result.Response.ProviderMetadata["container"] != "xyz" {
+		t.Errorf("container = %v, want xyz", result.Response.ProviderMetadata["container"])
+	}
+}
+
+func TestStreamObject_ProviderMetadata_BothConventions(t *testing.T) {
+	// Both nested (OpenAI) and flat (Anthropic) conventions in a single chunk.
+	wantNested := map[string]map[string]any{
+		"openai": {"logprobs": true},
+	}
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: `{"name":"Zoe","age":22}`},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Metadata: map[string]any{
+						"providerMetadata": wantNested,
+						"iterations":       7,
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamObject[simpleObject](t.Context(), model, WithPrompt("gen"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.PartialObjectStream() {
+	}
+
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Nested convention → ObjectResult.ProviderMetadata
+	if result.ProviderMetadata == nil {
+		t.Fatal("ProviderMetadata is nil")
+	}
+	if _, ok := result.ProviderMetadata["openai"]; !ok {
+		t.Error("missing 'openai' key in ProviderMetadata")
+	}
+
+	// Flat convention → Response.ProviderMetadata
+	if result.Response.ProviderMetadata == nil {
+		t.Fatal("Response.ProviderMetadata is nil")
+	}
+	if result.Response.ProviderMetadata["iterations"] != 7 {
+		t.Errorf("iterations = %v, want 7", result.Response.ProviderMetadata["iterations"])
+	}
+
+	// "providerMetadata" key must NOT leak into flat.
+	if _, ok := result.Response.ProviderMetadata["providerMetadata"]; ok {
+		t.Error("providerMetadata key should not leak into Response.ProviderMetadata")
+	}
+}

--- a/options.go
+++ b/options.go
@@ -183,8 +183,14 @@ func WithMaxSteps(n int) Option {
 }
 
 // WithMaxRetries sets the retry count for transient errors.
+// Values below 0 are clamped to 0 (no retries).
 func WithMaxRetries(n int) Option {
-	return func(o *options) { o.MaxRetries = n }
+	return func(o *options) {
+		if n < 0 {
+			n = 0
+		}
+		o.MaxRetries = n
+	}
 }
 
 // WithTimeout sets the timeout for the entire generation call.

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -115,10 +115,17 @@ type chatModel struct {
 
 func (m *chatModel) ModelID() string { return m.id }
 
+// supportsThinking returns true for Anthropic models that support extended thinking.
+func supportsThinking(modelID string) bool {
+	return strings.Contains(modelID, "claude-3-7-sonnet") ||
+		strings.Contains(modelID, "claude-sonnet-4") ||
+		strings.Contains(modelID, "claude-opus-4")
+}
+
 func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
 		Temperature: true,
-		Reasoning:   true,
+		Reasoning:   supportsThinking(m.id),
 		ToolCall:    true,
 		Attachment:  true,
 		InputModalities: provider.ModalitySet{

--- a/provider/bedrock/bedrock.go
+++ b/provider/bedrock/bedrock.go
@@ -223,13 +223,26 @@ func (m *chatModel) readIDRegion() (string, string) {
 }
 
 func (m *chatModel) Capabilities() provider.ModelCapabilities {
+	id := m.ModelID()
 	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         modelSupportsTools(m.ModelID()),
-		Reasoning:        true,
-		InputModalities:  provider.ModalitySet{Text: true, Image: true},
+		Temperature: true,
+		ToolCall:    modelSupportsTools(id),
+		Reasoning:   bedrockSupportsThinking(id),
+		InputModalities: provider.ModalitySet{
+			Text:  true,
+			Image: true,
+			PDF:   true,
+		},
 		OutputModalities: provider.ModalitySet{Text: true},
 	}
+}
+
+// bedrockSupportsThinking returns true for Bedrock model IDs that support extended thinking.
+// Bedrock model IDs include the Anthropic model name (e.g., "anthropic.claude-sonnet-4-20250514-v1:0").
+func bedrockSupportsThinking(modelID string) bool {
+	return strings.Contains(modelID, "claude-3-7-sonnet") ||
+		strings.Contains(modelID, "claude-sonnet-4") ||
+		strings.Contains(modelID, "claude-opus-4")
 }
 
 // modelSupportsTools returns whether a Bedrock model supports tool_use.

--- a/provider/bedrock/converse.go
+++ b/provider/bedrock/converse.go
@@ -495,6 +495,21 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 	}
 	blocks := make(map[int]*blockInfo)
 
+	var finishSent bool
+	var accUsage provider.Usage
+
+	defer func() {
+		// Fallback: if the stream ended without a metadata frame (e.g. premature
+		// connection close), emit a ChunkFinish so consumers always see one.
+		if !finishSent {
+			provider.TrySend(ctx, out, provider.StreamChunk{
+				Type:     provider.ChunkFinish,
+				Usage:    accUsage,
+				Response: responseMeta,
+			})
+		}
+	}()
+
 	for {
 		frame, err := decoder.Next()
 		if err != nil {
@@ -647,6 +662,7 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 				usage.CacheReadTokens = intVal(u, "cacheReadInputTokens")
 				usage.CacheWriteTokens = intVal(u, "cacheWriteInputTokens")
 			}
+			accUsage = usage
 			chunk := provider.StreamChunk{
 				Type:     provider.ChunkFinish,
 				Usage:    usage,
@@ -658,6 +674,7 @@ func parseEventStream(ctx context.Context, body io.ReadCloser, out chan<- provid
 					"cacheWriteInputTokens": usage.CacheWriteTokens,
 				}
 			}
+			finishSent = true
 			if !provider.TrySend(ctx, out, chunk) {
 				return
 			}

--- a/provider/bedrock/embed.go
+++ b/provider/bedrock/embed.go
@@ -329,10 +329,10 @@ func parseCohereEmbeddings(raw json.RawMessage) ([][]float64, error) {
 		Float [][]float64 `json:"float"`
 	}
 	if err := json.Unmarshal(raw, &nested); err != nil {
-		return nil, errors.New("unrecognised embeddings format")
+		return nil, errors.New("bedrock: unrecognised embeddings format")
 	}
 	if len(nested.Float) == 0 {
-		return nil, errors.New("cohere embeddings: no float embeddings in response (embedding_types may not include \"float\")")
+		return nil, errors.New("bedrock: no float embeddings in response (embedding_types may not include \"float\")")
 	}
 	return nested.Float, nil
 }

--- a/provider/bedrock/embed_test.go
+++ b/provider/bedrock/embed_test.go
@@ -576,7 +576,7 @@ func TestEmbedding_CohereInvalidFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid embeddings format")
 	}
-	if !strings.Contains(err.Error(), "unrecognised embeddings format") {
+	if !strings.Contains(err.Error(), "bedrock: unrecognised embeddings format") {
 		t.Errorf("error = %v", err)
 	}
 }

--- a/provider/cohere/cohere.go
+++ b/provider/cohere/cohere.go
@@ -130,7 +130,7 @@ func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
 		Temperature:      true,
 		ToolCall:         true,
-		Reasoning:        true,
+		Reasoning:        strings.Contains(m.id, "reasoning"),
 		InputModalities:  provider.ModalitySet{Text: true},
 		OutputModalities: provider.ModalitySet{Text: true},
 	}
@@ -642,6 +642,21 @@ func parseChatStream(ctx context.Context, body io.Reader, out chan<- provider.St
 	var pending *pendingToolCall
 	var isReasoning bool
 	var streamCitations []cohereCitation
+	var finishSent bool
+	var streamResponseMeta provider.ResponseMetadata
+
+	// Deferred fallback: if the stream ends without a message-end event (e.g. [DONE]
+	// arrived without message-end, premature close, or mid-loop return on context cancel),
+	// emit a ChunkFinish so consumers always see one.
+	defer func() {
+		if !finishSent {
+			provider.TrySend(ctx, out, provider.StreamChunk{
+				Type:         provider.ChunkFinish,
+				FinishReason: provider.FinishOther,
+				Response:     streamResponseMeta,
+			})
+		}
+	}()
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -656,6 +671,9 @@ func parseChatStream(ctx context.Context, body io.Reader, out chan<- provider.St
 		var event struct {
 			Type  string `json:"type"`
 			Index int    `json:"index"`
+			// message-start fields.
+			ID    string `json:"id"`
+			Model string `json:"model"`
 			Delta struct {
 				Message struct {
 					Content json.RawMessage `json:"content"`
@@ -694,6 +712,13 @@ func parseChatStream(ctx context.Context, body io.Reader, out chan<- provider.St
 		}
 
 		switch event.Type {
+		case "message-start":
+			// Capture response ID and model for use in ChunkFinish.
+			streamResponseMeta = provider.ResponseMetadata{
+				ID:    event.ID,
+				Model: event.Model,
+			}
+
 		case "content-start":
 			// Check if this is a thinking content block.
 			var ct struct {
@@ -820,11 +845,12 @@ func parseChatStream(ctx context.Context, body io.Reader, out chan<- provider.St
 				Type:         provider.ChunkFinish,
 				FinishReason: fr,
 				Usage:        usage,
-				Response:     provider.ResponseMetadata{},
+				Response:     streamResponseMeta,
 			}
 			if sources := extractCohereCitations(streamCitations); len(sources) > 0 {
 				finishChunk.Metadata = map[string]any{"sources": sources}
 			}
+			finishSent = true
 			if !provider.TrySend(ctx, out, finishChunk) {
 				return
 			}
@@ -837,6 +863,7 @@ func parseChatStream(ctx context.Context, body io.Reader, out chan<- provider.St
 			Error: fmt.Errorf("reading stream: %w", err),
 		})
 	}
+	// Deferred fallback (above) handles ChunkFinish emission.
 }
 
 func mapFinishReason(reason string) provider.FinishReason {

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -116,13 +116,12 @@ func (m *chatModel) ModelID() string { return m.id }
 func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
 		Temperature: true,
-		Reasoning:   true,
+		Reasoning:   modelSupportsThinking(m.id),
 		ToolCall:    true,
 		Attachment:  true,
 		InputModalities: provider.ModalitySet{
 			Text:  true,
 			Image: true,
-			Video: true,
 			PDF:   true,
 		},
 		OutputModalities: provider.ModalitySet{Text: true},

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -951,8 +951,18 @@ func TestCapabilities(t *testing.T) {
 	if !caps.Temperature || !caps.Reasoning || !caps.ToolCall || !caps.Attachment {
 		t.Error("unexpected capabilities")
 	}
-	if !caps.InputModalities.Video {
-		t.Error("expected Video input modality")
+	if caps.InputModalities.Video {
+		t.Error("expected Video input modality to be false: no PartVideo type exists")
+	}
+	if !caps.InputModalities.PDF {
+		t.Error("expected PDF input modality")
+	}
+
+	// Non-thinking model should not advertise Reasoning.
+	model2 := Chat("gemini-1.5-flash", WithAPIKey("key"))
+	caps2 := provider.ModelCapabilitiesOf(model2)
+	if caps2.Reasoning {
+		t.Error("gemini-1.5-flash should have Reasoning=false")
 	}
 }
 

--- a/provider/google/tools.go
+++ b/provider/google/tools.go
@@ -126,9 +126,9 @@ func codeExecutionTool() provider.ToolDefinition {
 // ---------------------------------------------------------------------------
 
 // googleProviderTool maps a ProviderDefinedType to the Gemini API tool format.
-// Gemini uses camelCase keys: {"googleSearchRetrieval": {...}}, {"urlContext": {}}, {"codeExecution": {}}.
+// Gemini uses camelCase keys: {"googleSearch": {...}}, {"urlContext": {}}, {"codeExecution": {}}.
 func googleProviderTool(t provider.ToolDefinition) map[string]any {
-	// Map "google.google_search" -> "googleSearchRetrieval", "google.url_context" -> "urlContext", etc.
+	// Map "google.google_search" -> "googleSearch", "google.url_context" -> "urlContext", etc.
 	apiKey := t.ProviderDefinedType
 	apiKey = strings.TrimPrefix(apiKey, "google.")
 


### PR DESCRIPTION
## Summary

- Propagate ProviderMetadata through StreamText/StreamObject (was silently dropped)
- Fix Capabilities() Reasoning overclaim in 4 providers (now model-specific)
- Add streaming fallback ChunkFinish in bedrock/cohere for premature stream close
- Fix 15+ documentation inaccuracies across docs site
- Add RunPod provider docs (missing from PR #20)
- 8 new tests for ProviderMetadata streaming propagation

## Code fixes

- **ProviderMetadata streaming**: `StreamText` and `StreamObject` now extract provider metadata from `ChunkFinish.Metadata` and propagate it into `TextResult.ProviderMetadata` / `ObjectResult.ProviderMetadata`, matching the non-streaming `GenerateText`/`GenerateObject` behavior
- **Capabilities accuracy**: Google, Anthropic, Bedrock, and Cohere now return `Reasoning: true` only for models that actually support extended thinking (was unconditionally true)
- **Google**: Removed phantom `Video: true` input modality (no PartVideo type exists). **Bedrock**: Added `PDF: true` (converse.go handles PartFile/PDF)
- **Streaming robustness**: Bedrock and Cohere now emit a fallback `ChunkFinish` via `defer` if the stream ends before the normal terminal event
- **WithMaxRetries**: Negative values now clamped to 0
- **Error prefixes**: `bedrock/embed.go` errors now consistently use `bedrock:` prefix
- **google/tools.go**: Fixed stale comment `googleSearchRetrieval` -> `googleSearch`
- **mcp-tools example**: `GOOGLE_API_KEY` -> `GEMINI_API_KEY` (consistency with all other Google examples)

## Docs fixes

- **RunPod**: New `docs/providers/runpod.md`, added to sidebar, index, providers-and-models
- **MiniMax + RunPod**: Added to providers-and-models.md table
- **Bedrock**: Updated factory functions to show `Chat, Embedding`
- **architecture.md**: Updated all counts (22+ providers, 14 openaicompat importers, 13 compat)
- **streaming.md**: Added Chunk Types table (all 9 types with Metadata field), documented Responses API streaming limitation
- **provider-tools.md**: Documented all 18 OpenAI tool options (was missing 13)
- **errors.md**: Expanded overflow pattern list (8 additional providers)
- **token-source.md**: Added non-blocking refresh property, Google OAuth2 `x-goog-api-key` warning
- **options.md**: Added WithMaxSteps clamping note, fixed stale embed.go line reference
- **core-functions.md**: Added EmbedMany ProviderMetadata chunking note
- **SKILL.md**: Added ProviderMetadata to TextResult/ObjectResult structs

## Test plan

- [x] 8 new ProviderMetadata streaming tests (nested, flat, both conventions, multi-step, cache tokens)
- [x] All 29 packages pass (`go test -race ./...`)
- [x] Coverage: 98.1% total, all packages >= 90%
- [x] Race detector clean
- [x] Pre-commit hooks pass (coverage + diff coverage >= 90%)