### PR TITLE
feat: add tool loop to StreamText, parallel tool execution, OnToolCallStart hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 
 - **7 core functions**: `GenerateText`, `StreamText`, `GenerateObject[T]`, `StreamObject[T]`, `Embed`, `EmbedMany`, `GenerateImage`
 - **22+ providers**: OpenAI, Anthropic, Google, Bedrock, Azure, Vertex, Mistral, xAI, Groq, Cohere, DeepSeek, MiniMax, Fireworks, Together, DeepInfra, OpenRouter, Perplexity, Cerebras, Ollama, vLLM, RunPod, + generic OpenAI-compatible
-- **Auto tool loop**: Define tools with `Execute` handlers, set `MaxSteps`, GoAI handles the loop
+- **Auto tool loop**: Define tools with `Execute` handlers, set `MaxSteps` for `GenerateText` and `StreamText`
 - **Structured output**: `GenerateObject[T]` auto-generates JSON Schema from Go types via reflection
 - **Streaming**: Real-time text and partial object streaming via channels
 - **Dynamic auth**: `TokenSource` interface for OAuth, rotating keys, cloud IAM, with `CachedTokenSource` for TTL-based caching
@@ -50,6 +50,7 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 - **Computer use**: Anthropic computer, bash, text editor tools for autonomous desktop interaction
 - **20 provider-defined tools**: Web fetch, file search, image generation, X search, and more - [full list](#provider-defined-tools)
 - **MCP client**: Connect to any MCP server (stdio, HTTP, SSE), auto-convert tools for use with GoAI
+- **Observability**: Built-in Langfuse integration with hooks for request/response/step/tool tracing
 - **Telemetry hooks**: `OnRequest`, `OnResponse`, `OnStepFinish`, `OnToolCall` callbacks
 - **Retry/backoff**: Automatic retry with exponential backoff on 429/5xx errors
 - **Minimal dependencies**: Core uses only stdlib; Vertex adds `golang.org/x/oauth2` for ADC
@@ -125,6 +126,24 @@ if err := stream.Err(); err != nil {
 }
 fmt.Printf("\nTokens: %d in, %d out\n",
 	result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)
+```
+
+Streaming with tools:
+
+```go
+stream, err := goai.StreamText(ctx, model,
+	goai.WithPrompt("What's the weather in Tokyo?"),
+	goai.WithTools(weatherTool),
+	goai.WithMaxSteps(5),
+)
+for chunk := range stream.Stream() {
+	switch chunk.Type {
+	case provider.ChunkText:
+		fmt.Print(chunk.Text)
+	case provider.ChunkStepFinish:
+		fmt.Println("\n[step complete]")
+	}
+}
 ```
 
 ## Structured Output
@@ -291,6 +310,26 @@ os.WriteFile("sunset.png", result.Images[0].Data, 0644)
 ```
 
 Also supported: Google Imagen (`google.Image("imagen-4.0-generate-001")`) and Vertex AI (`vertex.Image(...)`).
+
+## Observability
+
+Built-in [Langfuse](https://langfuse.com) integration for tracing generations, tool calls, and multi-step loops:
+
+```go
+import "github.com/zendev-sh/goai/observability/langfuse"
+
+lf := langfuse.New(langfuse.WithBaseURL("https://cloud.langfuse.com"))
+trace := lf.Trace("my-trace")
+
+result, err := goai.GenerateText(ctx, model,
+    goai.WithPrompt("Hello"),
+    trace.Hooks()...,  // wires OnRequest, OnResponse, OnStepFinish, OnToolCall
+)
+trace.End(result.Text)
+lf.Flush(ctx)
+```
+
+See [examples/langfuse](examples/langfuse/) and [observability docs](https://goai.dev/concepts/observability) for details.
 
 ## Providers
 

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -68,7 +68,11 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 
 **Returns:** `*TextStream` for consuming the response incrementally. Returns an error if the initial API call fails.
 
-**Example:**
+**Tool Loop Support:**
+
+When `WithMaxSteps` is set > 1 and tools with `Execute` functions are provided, `StreamText` runs an automatic tool loop. All steps stream through a single unified channel. Step boundaries are marked by `ChunkStepFinish` chunks. The initial `DoStream` failure returns `(nil, error)`. Subsequent step errors flow through the stream as `ChunkError` chunks — check `stream.Err()` after consuming.
+
+**Example (basic):**
 
 ```go
 stream, err := goai.StreamText(context.Background(), model,
@@ -85,6 +89,32 @@ fmt.Println()
 
 result := stream.Result()
 fmt.Printf("Tokens: %d in, %d out\n", result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)
+```
+
+**Example (streaming with tools):**
+
+```go
+stream, err := goai.StreamText(ctx, model,
+    goai.WithPrompt("What's the weather in Tokyo?"),
+    goai.WithTools(weatherTool),
+    goai.WithMaxSteps(5),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+for chunk := range stream.Stream() {
+    switch chunk.Type {
+    case provider.ChunkText:
+        fmt.Print(chunk.Text)
+    case provider.ChunkStepFinish:
+        fmt.Println("\n[step complete]")
+    }
+}
+
+if err := stream.Err(); err != nil {
+    log.Fatal("stream error:", err)
+}
 ```
 
 ### TextStream

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -264,6 +264,16 @@ func WithOnStepFinish(fn func(StepResult)) Option
 
 **Default:** `nil`. Only relevant when `MaxSteps > 1`.
 
+### WithOnToolCallStart
+
+Sets a callback invoked before each tool execution. Fires from the tool's goroutine in `executeToolsParallel`.
+
+```go
+func WithOnToolCallStart(fn func(ToolCallStartInfo)) Option
+```
+
+**Default:** `nil`. Only relevant when tools with `Execute` are provided and `MaxSteps > 1`.
+
 ### WithOnToolCall
 
 Sets a callback invoked after each tool execution.
@@ -273,6 +283,8 @@ func WithOnToolCall(fn func(ToolCallInfo)) Option
 ```
 
 **Default:** `nil`. Only relevant when tools with `Execute` are provided and `MaxSteps > 1`.
+
+> **Note:** When multiple tools execute in a single step, OnToolCall callbacks fire concurrently from separate goroutines. Order is non-deterministic.
 
 ---
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -201,6 +201,19 @@ type ToolCallInfo struct {
 }
 ```
 
+### ToolCallStartInfo
+
+Passed to the `OnToolCallStart` hook before a tool executes.
+
+```go
+type ToolCallStartInfo struct {
+    ToolCallID string          // Provider-assigned identifier for this tool call.
+    ToolName   string          // Name of the tool called.
+    Step       int             // 1-based index of the generation step in which this tool was called.
+    Input      json.RawMessage // Raw JSON arguments passed to the tool.
+}
+```
+
 ### APIError
 
 Represents a non-overflow API error. See [Errors](errors.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,8 +188,8 @@ User calls goai.GenerateText(ctx, model, opts...)
   │   │       └─ Return {Text, ToolCalls, Usage, FinishReason, Sources}
   │   ├─ OnResponse callback
   │   ├─ if FinishReason == ToolCalls:
-  │   │   ├─ executeTools(ctx, calls, toolMap, OnToolCall)
-  │   │   └─ appendToolRoundTrip(msgs, result, toolMsgs)
+  │   │   ├─ executeToolsParallel(ctx, calls, toolMap, step, OnToolCallStart, OnToolCall)
+  │   │   └─ appendToolRoundTrip(msgs, text, toolCalls, toolMsgs)
   │   └─ else: return buildTextResult(steps, totalUsage)
   │
   └─ return TextResult{Text, Steps, TotalUsage, FinishReason, Sources}
@@ -200,15 +200,30 @@ User calls goai.GenerateText(ctx, model, opts...)
 ```
 User calls goai.StreamText(ctx, model, opts...)
   │
-  ├─ withRetry → model.DoStream(ctx, params)
-  │   └─ Inside provider DoStream:
-  │       ├─ Build HTTP request (provider-specific)
-  │       ├─ Send HTTP POST (streaming)
-  │       ├─ Create channel (cap 64)
-  │       ├─ Launch goroutine: parse SSE → emit StreamChunks
-  │       └─ Return StreamResult{Stream: <-chan StreamChunk}
+  ├─ Single-step path (no executable tools or MaxSteps == 1):
+  │   ├─ withRetry → model.DoStream(ctx, params)
+  │   │   └─ Inside provider DoStream:
+  │   │       ├─ Build HTTP request (provider-specific)
+  │   │       ├─ Send HTTP POST (streaming)
+  │   │       ├─ Create channel (cap 64)
+  │   │       ├─ Launch goroutine: parse SSE → emit StreamChunks
+  │   │       └─ Return StreamResult{Stream: <-chan StreamChunk}
+  │   └─ Wrap in TextStream
   │
-  └─ Wrap in TextStream
+  ├─ Multi-step path (MaxSteps > 1 and executable tools):
+  │   └─ streamWithToolLoop(ctx, model, opts, toolMap)
+  │       ├─ Launch step loop goroutine
+  │       │   ├─ for step = 1..MaxSteps:
+  │       │   │   ├─ model.DoStream(ctx, params)
+  │       │   │   ├─ drainStep: forward chunks to unified output channel
+  │       │   │   ├─ if FinishReason == ToolCalls:
+  │       │   │   │   ├─ executeToolsParallel(ctx, calls, toolMap, step, OnToolCallStart, OnToolCall)
+  │       │   │   │   └─ appendToolRoundTrip(msgs, text, toolCalls, toolMsgs)
+  │       │   │   └─ else: break
+  │       │   └─ close unified output channel
+  │       └─ Wrap in TextStream
+  │
+  └─ TextStream API:
       ├─ .TextStream() → <-chan string  (text-only)
       ├─ .Stream()     → <-chan StreamChunk (raw chunks)
       └─ .Result()     → *TextResult (blocks until done)

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -5,7 +5,7 @@ description: "Trace LLM calls, tool executions, and agent runs in GoAI. Plug-in 
 
 # Observability
 
-GoAI's observability is built on four lifecycle hooks: `OnRequest`, `OnResponse`, `OnToolCall`, and `OnStepFinish`. Any observability provider can plug into these hooks to trace LLM calls, tool executions, and multi-step agent runs.
+GoAI's observability is built on five lifecycle hooks: `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, and `OnStepFinish`. Any observability provider can plug into these hooks to trace LLM calls, tool executions, and multi-step agent runs.
 
 ## How It Works
 
@@ -25,6 +25,7 @@ Each hook fires at a specific point in the request lifecycle:
 |------|------|------|
 | `OnRequest` | Before each LLM call | Model, full message history, tool count |
 | `OnResponse` | After each LLM call | Latency, token usage, finish reason, errors |
+| `OnToolCallStart` | Before each tool execution | Tool call ID, tool name, step, input |
 | `OnToolCall` | After each tool execution | Tool name, input/output, duration, errors |
 | `OnStepFinish` | After each step completes | Step number, finish reason, tool calls |
 

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -111,6 +111,41 @@ fmt.Printf("Finish reason: %s, tokens: %d\n",
     result.FinishReason, result.TotalUsage.TotalTokens)
 ```
 
+## Streaming Tool Loops
+
+`StreamText` supports the same auto tool loop as `GenerateText`. Pass `WithMaxSteps` and tools with `Execute` functions. All steps stream through a single unified channel, with `ChunkStepFinish` marking step boundaries.
+
+```go
+stream, err := goai.StreamText(ctx, model,
+    goai.WithPrompt("What's the weather in Tokyo and London?"),
+    goai.WithTools(weatherTool),
+    goai.WithMaxSteps(5),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+for chunk := range stream.Stream() {
+    switch chunk.Type {
+    case provider.ChunkText:
+        fmt.Print(chunk.Text)
+    case provider.ChunkToolCall:
+        fmt.Printf("\n[tool call: %s]\n", chunk.ToolName)
+    case provider.ChunkStepFinish:
+        fmt.Printf("[step done, reason=%s]\n", chunk.FinishReason)
+    case provider.ChunkFinish:
+        fmt.Printf("\n[finished, tokens=%d]\n", chunk.Usage.TotalTokens)
+    }
+}
+
+if err := stream.Err(); err != nil {
+    log.Fatal("stream error:", err)
+}
+
+result := stream.Result()
+fmt.Printf("Completed in %d steps\n", len(result.Steps))
+```
+
 ## Non-Streaming Alternative
 
 `GenerateText` blocks until the full response is ready. No stream, no channels - just the result.

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -105,6 +105,14 @@ result, err := goai.GenerateText(ctx, model,
 
 ## Tool Call Hooks
 
+`WithOnToolCallStart` is called before each individual tool execution:
+
+```go
+goai.WithOnToolCallStart(func(info goai.ToolCallStartInfo) {
+    fmt.Printf("[step %d] starting tool %s (call %s)\n", info.Step, info.ToolName, info.ToolCallID)
+})
+```
+
 `WithOnToolCall` is called after each individual tool execution:
 
 ```go
@@ -136,6 +144,10 @@ goai.WithOnToolCall(func(info goai.ToolCallInfo) {
 | `Duration`     | `time.Duration`    | Time taken to execute the tool                                              |
 | `Error`        | `error`            | Error returned by the tool, if any                                          |
 
+> **Note:** When multiple tools execute in a single step, OnToolCall callbacks fire concurrently from separate goroutines. Order is non-deterministic.
+
+> **Security:** `ToolCallInfo` contains the full `Input` and `Output` of tool executions, which may include sensitive data. Consumers that log or export hook data should sanitize accordingly. Tool `Execute` errors are also forwarded to the model as tool result messages — do not include credentials or internal paths in error strings.
+
 ## Tools Without Execute
 
 If a tool has no `Execute` function, GoAI sends the tool definition to the model but does not participate in the auto loop. The model can still request the tool call, and it appears in `result.ToolCalls`. This is useful when you manage the tool loop yourself.
@@ -154,3 +166,32 @@ Each step in a multi-step tool loop produces a `goai.StepResult`:
 | `Response`         | `provider.ResponseMetadata` | Provider metadata for this step      |
 | `ProviderMetadata` | `map[string]map[string]any` | Provider-specific data for this step |
 | `Sources`          | `[]provider.Source`         | Citations from this step             |
+
+## Streaming Tool Loops
+
+`StreamText` supports the same auto tool loop as `GenerateText`. Pass `WithMaxSteps` and tools with `Execute` functions:
+
+```go
+stream, err := goai.StreamText(ctx, model,
+    goai.WithPrompt("What's the weather in Tokyo?"),
+    goai.WithTools(weatherTool),
+    goai.WithMaxSteps(5),
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+for chunk := range stream.Stream() {
+    switch chunk.Type {
+    case provider.ChunkText:
+        fmt.Print(chunk.Text)
+    case provider.ChunkStepFinish:
+        fmt.Println("\n[step complete]")
+    }
+}
+
+result := stream.Result()
+fmt.Printf("Steps: %d\n", len(result.Steps))
+```
+
+All steps stream through a single unified channel. Step boundaries are marked by `ChunkStepFinish` chunks. The initial `DoStream` failure returns `(nil, error)`. Subsequent step errors flow through the stream as `ChunkError` chunks — check `stream.Err()` after consuming.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai), GoAI is designed idiomat
 ## Core Features
 
 - **GenerateText** — non-streaming text generation across all providers
-- **StreamText** — real-time streaming via Go channels
+- **StreamText** — real-time streaming with auto tool loops via Go channels
 - **GenerateObject[T]** — type-safe structured output using Go generics
 - **StreamObject[T]** — partial object streaming with typed results
 - **Embed / EmbedMany** — text embeddings with auto-chunking
@@ -31,6 +31,7 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai), GoAI is designed idiomat
 - **20 Provider-Defined Tools** — web search, code execution, computer use, file search
 - **[MCP Client](/concepts/mcp)** — connect to any MCP server (stdio, HTTP, SSE), auto-convert tools for GoAI
 - **Prompt Caching** — automatic cache control for Anthropic and OpenAI
+- **[Observability](/concepts/observability)** — built-in Langfuse integration for tracing generations, tools, and multi-step loops
 
 ## Why GoAI?
 

--- a/examples/streaming-tools/main.go
+++ b/examples/streaming-tools/main.go
@@ -1,0 +1,82 @@
+//go:build ignore
+
+// Example: streaming text generation with multi-step tool loops.
+//
+// Usage:
+//
+//	export OPENAI_API_KEY=...
+//	go run examples/streaming-tools/main.go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/provider"
+	"github.com/zendev-sh/goai/provider/openai"
+)
+
+func main() {
+	model := openai.Chat("gpt-4o-mini", openai.WithAPIKey(os.Getenv("OPENAI_API_KEY")))
+
+	weatherTool := goai.Tool{
+		Name:        "get_weather",
+		Description: "Get the current weather for a city.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"city": {"type": "string", "description": "City name"}
+			},
+			"required": ["city"]
+		}`),
+		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
+			var args struct {
+				City string `json:"city"`
+			}
+			if err := json.Unmarshal(input, &args); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf(`{"city": %q, "temp": "18°C", "condition": "partly cloudy"}`, args.City), nil
+		},
+	}
+
+	stream, err := goai.StreamText(context.Background(), model,
+		goai.WithSystem("You are a helpful weather assistant. Be concise."),
+		goai.WithPrompt("What's the weather in Tokyo and Paris?"),
+		goai.WithTools(weatherTool),
+		goai.WithMaxSteps(5),
+		goai.WithOnToolCallStart(func(info goai.ToolCallStartInfo) {
+			fmt.Printf("  [running %s...]\n", info.ToolName)
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Consume raw chunks to observe every event in the multi-step loop.
+	for chunk := range stream.Stream() {
+		switch chunk.Type {
+		case provider.ChunkText:
+			fmt.Print(chunk.Text)
+		case provider.ChunkToolCall:
+			fmt.Printf("\n  [calling %s]\n", chunk.ToolName)
+		case provider.ChunkStepFinish:
+			fmt.Printf("  [step done: %s]\n", chunk.FinishReason)
+		case provider.ChunkFinish:
+			fmt.Printf("\n  [finish: %d in, %d out]\n", chunk.Usage.InputTokens, chunk.Usage.OutputTokens)
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Final result with aggregated steps and usage.
+	result := stream.Result()
+	fmt.Printf("\nTotal steps: %d, Tokens: %d in, %d out\n",
+		len(result.Steps), result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)
+}

--- a/generate.go
+++ b/generate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -18,7 +19,9 @@ var ErrUnknownTool = errors.New("goai: unknown tool")
 
 // TextResult is the final result of a text generation call.
 type TextResult struct {
-	// Text is the accumulated generated text.
+	// Text is the accumulated generated text across all steps.
+	// For StreamText, this includes reasoning tokens (ChunkReasoning) for backward
+	// compatibility. Use Steps[n].Text for text-only content excluding reasoning.
 	Text string
 
 	// ToolCalls requested by the model in the final step.
@@ -49,7 +52,8 @@ type StepResult struct {
 	// Number is the 1-based step index.
 	Number int
 
-	// Text generated in this step.
+	// Text generated in this step (excludes reasoning tokens).
+	// For StreamText, reasoning is included in TextResult.Text but excluded here.
 	Text string
 
 	// ToolCalls requested in this step.
@@ -73,6 +77,9 @@ type StepResult struct {
 
 // TextStream is a streaming text generation response.
 //
+// Callers must consume the stream (via Stream, TextStream, or Result) or cancel
+// the context. Discarding a TextStream without consuming leaks goroutines.
+//
 // It provides three consumption modes (Stream, TextStream, Result).
 // Stream() and TextStream() are mutually exclusive -- only call one.
 // Result() can always be called, including after Stream() or TextStream(),
@@ -90,8 +97,9 @@ type TextStream struct {
 	textCh <-chan string
 
 	// Hook support.
-	onResponse func(ResponseInfo)
-	startTime  time.Time
+	onResponse   func(ResponseInfo)
+	onStepFinish func(StepResult)
+	startTime    time.Time
 
 	// Accumulated state (written by consume goroutine, read after doneCh closes).
 	text             strings.Builder
@@ -102,6 +110,13 @@ type TextStream struct {
 	response         provider.ResponseMetadata
 	providerMetadata map[string]map[string]any
 	streamErr        error
+
+	// Multi-step accumulation (written by consume goroutine).
+	steps         []StepResult
+	currentStep   int
+	stepText      strings.Builder
+	stepToolCalls []provider.ToolCall
+	stepSources   []provider.Source
 }
 
 func newTextStream(ctx context.Context, source <-chan provider.StreamChunk) *TextStream {
@@ -177,9 +192,31 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 		defer close(textOut)
 	}
 
+	// Call OnStepFinish hook when consume finishes (single-step streaming only).
+	// For multi-step streaming (streamWithToolLoop), OnStepFinish fires inline per
+	// step and ts.onStepFinish is nil, so this block is skipped.
+	// Deferred BEFORE OnResponse so it runs AFTER it (LIFO order), matching
+	// GenerateText's OnResponse → OnStepFinish sequence.
+	if ts.onStepFinish != nil {
+		defer func() {
+			defer func() { _ = recover() }()
+			ts.onStepFinish(StepResult{
+				Number:           1,
+				Text:             ts.stepText.String(),
+				ToolCalls:        ts.toolCalls,
+				FinishReason:     ts.finishReason,
+				Usage:            ts.usage,
+				Response:         ts.response,
+				Sources:          ts.sources,
+				ProviderMetadata: ts.providerMetadata,
+			})
+		}()
+	}
+
 	// Call OnResponse hook when consume finishes (after all chunks processed).
 	if ts.onResponse != nil {
 		defer func() {
+			defer func() { _ = recover() }()
 			info := ResponseInfo{
 				Latency:      time.Since(ts.startTime),
 				Usage:        ts.usage,
@@ -196,36 +233,108 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 
 	for chunk := range ts.source {
 		switch chunk.Type {
-		case provider.ChunkText, provider.ChunkReasoning:
-			ts.text.WriteString(chunk.Text)
-			// Capture per-annotation sources (e.g. url_citation).
+		case provider.ChunkText:
+			ts.text.WriteString(chunk.Text)      // global accumulator (existing, includes reasoning)
+			ts.stepText.WriteString(chunk.Text)   // per-step text-only accumulator (new)
 			if s, ok := chunk.Metadata["source"].(provider.Source); ok {
-				ts.sources = append(ts.sources, s)
+				ts.sources = append(ts.sources, s)           // global (existing)
+				ts.stepSources = append(ts.stepSources, s)   // per-step (new)
 			}
+
+		case provider.ChunkReasoning:
+			ts.text.WriteString(chunk.Text)      // global accumulator (existing, includes reasoning)
+			// NOTE: reasoning is NOT written to ts.stepText. This matches drainStep behavior
+			// where text and reasoning are separated. StepResult.Text contains text-only,
+			// consistent between OnStepFinish hook (from drainStep) and Result().Steps (from consume).
+			if s, ok := chunk.Metadata["source"].(provider.Source); ok {
+				ts.sources = append(ts.sources, s)           // global (preserve existing behavior)
+				ts.stepSources = append(ts.stepSources, s)   // per-step
+			}
+
 		case provider.ChunkToolCall:
-			ts.toolCalls = append(ts.toolCalls, provider.ToolCall{
-				ID:    chunk.ToolCallID,
-				Name:  chunk.ToolName,
-				Input: json.RawMessage(chunk.ToolInput),
-			})
-		case provider.ChunkFinish, provider.ChunkStepFinish:
+			tc := provider.ToolCall{ID: chunk.ToolCallID, Name: chunk.ToolName, Input: json.RawMessage(chunk.ToolInput)}
+			ts.toolCalls = append(ts.toolCalls, tc)
+			ts.stepToolCalls = append(ts.stepToolCalls, tc)
+
+		case provider.ChunkStepFinish:
+			// GoAI-emitted step boundaries: build per-step StepResult.
+			if stepSource, _ := chunk.Metadata["stepSource"].(string); stepSource == "goai" {
+				ts.currentStep++
+				// Response is set directly on the chunk by the step loop.
+				// ProviderMetadata is embedded in Metadata (no dedicated StreamChunk field).
+				var stepProviderMeta map[string]map[string]any
+				if pm, ok := chunk.Metadata["providerMetadata"].(map[string]map[string]any); ok {
+					stepProviderMeta = pm
+				}
+				ts.steps = append(ts.steps, StepResult{
+					Number:           ts.currentStep,
+					Text:             ts.stepText.String(),
+					ToolCalls:        ts.stepToolCalls,
+					FinishReason:     chunk.FinishReason,
+					Usage:            chunk.Usage,
+					Sources:          ts.stepSources,
+					Response:         chunk.Response,
+					ProviderMetadata: stepProviderMeta,
+				})
+				// Accumulate per-step usage and finishReason for resilience:
+				// if stream terminates before ChunkFinish (e.g., context cancel between
+				// ChunkStepFinish and ChunkFinish sends), ts.usage still reflects completed steps.
+				// ChunkFinish will overwrite with the authoritative totalUsage when it arrives.
+				ts.usage = addUsage(ts.usage, chunk.Usage)
+				ts.finishReason = chunk.FinishReason
+				// Update ts.response for the overall TextResult (last step wins).
+				ts.response = chunk.Response
+				ts.providerMetadata = stepProviderMeta
+				// Reset per-step accumulators.
+				ts.stepText.Reset()
+				ts.stepToolCalls = nil
+				ts.stepSources = nil
+			} else {
+				// Provider-internal step boundary (e.g., Anthropic extended thinking).
+				// Preserve existing behavior: extract response, metadata, sources.
+				// This ensures single-step streaming continues to work correctly.
+				// NOTE: Do NOT accumulate usage here with addUsage. Provider-internal
+				// ChunkStepFinish usage is already included in the provider's ChunkFinish
+				// (which uses direct assignment), and the GoAI ChunkStepFinish (which uses
+				// addUsage via drainStep). Accumulating here would double-count.
+				ts.finishReason = chunk.FinishReason
+				ts.response = chunk.Response
+				if sources, ok := chunk.Metadata["sources"].([]provider.Source); ok {
+					ts.sources = append(ts.sources, sources...)
+					ts.stepSources = append(ts.stepSources, sources...)
+				}
+				if pm, ok := chunk.Metadata["providerMetadata"].(map[string]map[string]any); ok {
+					ts.providerMetadata = pm
+				}
+				// Copy flat metadata keys to Response.ProviderMetadata (existing behavior).
+				for k, v := range chunk.Metadata {
+					if k == "providerMetadata" || k == "sources" {
+						continue
+					}
+					if ts.response.ProviderMetadata == nil {
+						ts.response.ProviderMetadata = map[string]any{}
+					}
+					ts.response.ProviderMetadata[k] = v
+				}
+			}
+
+		case provider.ChunkFinish:
+			// Direct assignment (not addUsage): ChunkFinish carries authoritative total usage.
+			ts.usage = chunk.Usage
 			ts.finishReason = chunk.FinishReason
-			ts.usage = addUsage(ts.usage, chunk.Usage)
-			ts.response = chunk.Response
-			// Capture top-level citations (xAI, Perplexity).
+			// Preserve existing single-step behavior: extract response, metadata, sources
+			// from the provider's ChunkFinish. For multi-step, the goai-emitted ChunkFinish
+			// does not carry these (they are embedded in ChunkStepFinish metadata instead).
+			if chunk.Response.ID != "" || chunk.Response.Model != "" {
+				ts.response = chunk.Response
+			}
 			if sources, ok := chunk.Metadata["sources"].([]provider.Source); ok {
 				ts.sources = append(ts.sources, sources...)
 			}
-			// Extract provider metadata embedded in the finish chunk.
-			// openaicompat encodes it as Metadata["providerMetadata"] = map[string]map[string]any.
-			// The type assertion safely returns false for any other type (no panic).
 			if pm, ok := chunk.Metadata["providerMetadata"].(map[string]map[string]any); ok {
 				ts.providerMetadata = pm
 			}
-			// Copy remaining flat metadata keys into Response.ProviderMetadata.
-			// Providers use this for per-response data: Anthropic ("iterations",
-			// "contextManagement", "container"), Bedrock ("cacheWriteInputTokens").
-			// Skip "providerMetadata" (handled above) and "sources" (handled separately).
+			// Copy flat metadata keys to Response.ProviderMetadata (existing behavior).
 			for k, v := range chunk.Metadata {
 				if k == "providerMetadata" || k == "sources" {
 					continue
@@ -235,6 +344,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				}
 				ts.response.ProviderMetadata[k] = v
 			}
+
 		case provider.ChunkError:
 			if ts.streamErr == nil {
 				ts.streamErr = chunk.Error
@@ -267,8 +377,8 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 }
 
 func (ts *TextStream) buildResult() *TextResult {
-	text := ts.text.String()
-	return &TextResult{
+	text := ts.text.String() // full accumulated text across all steps
+	result := &TextResult{
 		Text:             text,
 		ToolCalls:        ts.toolCalls,
 		FinishReason:     ts.finishReason,
@@ -276,17 +386,26 @@ func (ts *TextStream) buildResult() *TextResult {
 		Response:         ts.response,
 		Sources:          ts.sources,
 		ProviderMetadata: ts.providerMetadata,
-		Steps: []StepResult{{
+	}
+	if len(ts.steps) > 0 {
+		result.Steps = ts.steps
+		// Match GenerateText: ToolCalls is the LAST step's tool calls, not all steps'.
+		result.ToolCalls = ts.steps[len(ts.steps)-1].ToolCalls
+	} else if text != "" || len(ts.toolCalls) > 0 || ts.finishReason != "" {
+		// Single-step fallback (no multi-step ChunkStepFinish received, but data exists).
+		result.Steps = []StepResult{{
 			Number:           1,
-			Text:             text,
+			Text:             ts.stepText.String(),
 			ToolCalls:        ts.toolCalls,
 			FinishReason:     ts.finishReason,
 			Usage:            ts.usage,
 			Response:         ts.response,
 			Sources:          ts.sources,
 			ProviderMetadata: ts.providerMetadata,
-		}},
+		}}
 	}
+	// No data: Steps is nil.
+	return result
 }
 
 // buildParams converts options to provider.GenerateParams.
@@ -333,13 +452,217 @@ func buildParams(opts options) provider.GenerateParams {
 	}
 }
 
+func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o options, toolMap map[string]Tool) (*TextStream, error) {
+	params := buildParams(o)
+
+	var timeoutCancel context.CancelFunc
+	if o.Timeout > 0 {
+		ctx, timeoutCancel = context.WithTimeout(ctx, o.Timeout)
+	}
+
+	// --- Step 1 DoStream: synchronous (preserves (nil, error) contract) ---
+	// This ensures StreamText ALWAYS returns (nil, error) when the first DoStream
+	// fails, regardless of MaxSteps. Eliminates the split error contract.
+	if o.OnRequest != nil {
+		o.OnRequest(RequestInfo{
+			Model:        model.ModelID(),
+			MessageCount: len(params.Messages),
+			ToolCount:    len(params.Tools),
+			Timestamp:    time.Now(),
+			Messages:     requestMessages(params.System, params.Messages),
+		})
+	}
+
+	start := time.Now()
+	firstResult, err := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+		return model.DoStream(ctx, params)
+	})
+	if err != nil {
+		if timeoutCancel != nil {
+			timeoutCancel()
+		}
+		// OnRequest/OnResponse: not recover-wrapped (caller's goroutine).
+		// OnStepFinish: always recover-wrapped (prevents losing accumulated results).
+		// Inside goroutines: all hooks recover-wrapped.
+		if o.OnResponse != nil {
+			info := ResponseInfo{Latency: time.Since(start), Error: err}
+			var apiErr *APIError
+			if errors.As(err, &apiErr) {
+				info.StatusCode = apiErr.StatusCode
+			}
+			o.OnResponse(info)
+		}
+		return nil, err // SAME error contract as single-step StreamText
+	}
+
+	// Step 1 succeeded. Goroutine-local copy of start time avoids closure capture.
+	step1Start := start
+	out := make(chan provider.StreamChunk, 64)
+
+	go func() {
+		defer close(out)
+		if timeoutCancel != nil {
+			defer timeoutCancel()
+		}
+
+		var totalUsage provider.Usage
+		var lastFinishReason provider.FinishReason
+		firstStep := true // true only for step 1 (already have firstResult)
+		stepStart := step1Start // goroutine-local start time per step
+
+		for step := 1; step <= o.MaxSteps; step++ {
+			var result *provider.StreamResult
+
+			if firstStep {
+				// Step 1: use the already-obtained firstResult.
+				result = firstResult
+				firstStep = false
+			} else {
+				// Steps 2+: DoStream inside goroutine.
+				if o.OnRequest != nil {
+					func() {
+						defer func() { _ = recover() }()
+						o.OnRequest(RequestInfo{
+							Model:        model.ModelID(),
+							MessageCount: len(params.Messages),
+							ToolCount:    len(params.Tools),
+							Timestamp:    time.Now(),
+							Messages:     requestMessages(params.System, params.Messages),
+						})
+					}()
+				}
+
+				stepStart = time.Now()
+				var err error
+				result, err = withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+					return model.DoStream(ctx, params)
+				})
+				if err != nil {
+					// Fire OnResponse on error (recover-wrapped).
+					if o.OnResponse != nil {
+						func() {
+							defer func() { _ = recover() }()
+							info := ResponseInfo{Latency: time.Since(stepStart), Error: err}
+							var apiErr *APIError
+							if errors.As(err, &apiErr) {
+								info.StatusCode = apiErr.StatusCode
+							}
+							o.OnResponse(info)
+						}()
+					}
+					provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: err})
+					provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: lastFinishReason, Usage: totalUsage})
+					return
+				}
+			}
+
+			ds := drainStep(ctx, result.Stream, out)
+			if ds.err != nil {
+				// Context cancelled during drain.
+				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: ds.err})
+				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, Usage: totalUsage})
+				return
+			}
+
+			// Guard: skip empty step (provider closed channel without sending
+			// any meaningful chunks, e.g., after a ChunkError). Prevents emitting
+			// a phantom empty StepResult and ChunkStepFinish.
+			if ds.text == "" && len(ds.toolCalls) == 0 && ds.finishReason == "" {
+				break
+			}
+
+			// OnResponse: Error is NOT set (call succeeded). Mid-stream errors use stream.Err().
+			if o.OnResponse != nil {
+				func() {
+					defer func() { _ = recover() }()
+					o.OnResponse(ResponseInfo{
+						Latency:      time.Since(stepStart),
+						Usage:        ds.usage,
+						FinishReason: ds.finishReason,
+					})
+				}()
+			}
+
+			// --- Build StepResult, fire OnStepFinish ---
+			stepResult := StepResult{
+				Number:           step,
+				Text:             ds.text,
+				ToolCalls:        ds.toolCalls,
+				FinishReason:     ds.finishReason,
+				Usage:            ds.usage,
+				Sources:          ds.sources,
+				Response:         ds.response,
+				ProviderMetadata: ds.providerMetadata,
+			}
+			totalUsage = addUsage(totalUsage, ds.usage)
+			lastFinishReason = ds.finishReason
+
+			// OnStepFinish (recover-wrapped).
+			if o.OnStepFinish != nil {
+				func() {
+					defer func() { _ = recover() }()
+					o.OnStepFinish(stepResult)
+				}()
+			}
+
+			// --- Emit ChunkStepFinish ---
+			// Set Response directly on the chunk (StreamChunk.Response is a plain struct
+			// field with no restriction on who sets it). ProviderMetadata goes in Metadata
+			// since there is no dedicated field for it on StreamChunk.
+			provider.TrySend(ctx, out, provider.StreamChunk{
+				Type:         provider.ChunkStepFinish,
+				FinishReason: ds.finishReason,
+				Usage:        ds.usage,
+				Response:     ds.response,
+				Metadata: map[string]any{
+					"stepSource":       "goai",
+					"providerMetadata": ds.providerMetadata,
+				},
+			})
+
+			// --- Exit conditions (same as GenerateText, generate.go:464) ---
+			if ds.finishReason != provider.FinishToolCalls || len(ds.toolCalls) == 0 || len(toolMap) == 0 {
+				break
+			}
+
+			// --- Execute tools in parallel ---
+			toolMsgs := executeToolsParallel(ctx, ds.toolCalls, toolMap, step, o.OnToolCallStart, o.OnToolCall)
+
+			// --- Append messages for next step ---
+			params.Messages = appendToolRoundTrip(params.Messages, ds.text, ds.toolCalls, toolMsgs)
+			// Clear ToolChoice so model can freely respond on subsequent steps (matches generate.go:471).
+			// Set on every iteration for simplicity; idempotent after step 1.
+			params.ToolChoice = ""
+		}
+
+		// Emit final ChunkFinish with total usage.
+		provider.TrySend(ctx, out, provider.StreamChunk{
+			Type:         provider.ChunkFinish,
+			FinishReason: lastFinishReason,
+			Usage:        totalUsage,
+		})
+	}()
+
+	ts := newTextStream(ctx, out)
+	// OnResponse handled per-step inside the goroutine (ts.onResponse not set).
+	return ts, nil
+}
+
 // StreamText performs a streaming text generation.
+// When MaxSteps > 1 and executable tools are provided, StreamText runs an automatic
+// tool loop. The initial DoStream failure still returns (nil, error). Subsequent step
+// errors flow through the stream as ChunkError chunks; check stream.Err() after consuming.
 func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Option) (*TextStream, error) {
 	if model == nil {
 		return nil, errors.New("goai: model must not be nil")
 	}
 
 	o := applyOptions(opts...)
+	toolMap := buildToolMap(o.Tools)
+
+	if o.MaxSteps > 1 && len(toolMap) > 0 {
+		return streamWithToolLoop(ctx, model, o, toolMap)
+	}
 
 	var timeoutCancel context.CancelFunc
 	if o.Timeout > 0 {
@@ -380,6 +703,7 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	ts := newTextStream(ctx, result.Stream)
 	ts.timeoutCancel = timeoutCancel
 	ts.onResponse = o.OnResponse
+	ts.onStepFinish = o.OnStepFinish
 	ts.startTime = start
 	return ts, nil
 }
@@ -455,12 +779,16 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		totalUsage = addUsage(totalUsage, result.Usage)
 
 		if o.OnStepFinish != nil {
-			o.OnStepFinish(stepResult)
+			func() {
+				defer func() { _ = recover() }()
+				o.OnStepFinish(stepResult)
+			}()
 		}
 
 		// If no tools have Execute functions, skip the tool loop regardless of MaxSteps.
 		// This allows callers to provide tool definitions for the model's awareness
 		// without requiring executable tools.
+		// No empty-step guard needed (unlike streaming): DoGenerate returns content or error.
 		if result.FinishReason != provider.FinishToolCalls || len(result.ToolCalls) == 0 || len(toolMap) == 0 {
 			return buildTextResult(steps, totalUsage), nil
 		}
@@ -469,10 +797,10 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// Clear tool_choice after the first tool step so the model can freely
 		// produce a text response on subsequent steps.
 		params.ToolChoice = ""
-		toolMessages := executeTools(ctx, result.ToolCalls, toolMap, step, o.OnToolCall)
+		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, o.OnToolCallStart, o.OnToolCall)
 
 		// Append assistant message with tool calls + tool result messages.
-		params.Messages = appendToolRoundTrip(params.Messages, result, toolMessages)
+		params.Messages = appendToolRoundTrip(params.Messages, result.Text, result.ToolCalls, toolMessages)
 	}
 
 	// MaxSteps reached.
@@ -509,48 +837,149 @@ func buildToolMap(tools []Tool) map[string]Tool {
 	return m
 }
 
-// executeTools runs each tool call and returns the tool result messages.
-func executeTools(ctx context.Context, calls []provider.ToolCall, toolMap map[string]Tool, step int, onToolCall func(ToolCallInfo)) []provider.Message {
-	var msgs []provider.Message
-	for _, tc := range calls {
-		if ctx.Err() != nil {
-			return msgs
-		}
+// toolOutput holds the result of a single tool execution (package-level type
+// shared between executeToolsParallel and buildToolMessages).
+type toolOutput struct {
+	index  int
+	result string
+	err    error
+}
+
+func executeToolsParallel(
+	ctx context.Context,
+	calls []provider.ToolCall,
+	toolMap map[string]Tool,
+	step int,
+	onToolCallStart func(ToolCallStartInfo),
+	onToolCall func(ToolCallInfo),
+) []provider.Message {
+
+	results := make([]toolOutput, len(calls))
+	var wg sync.WaitGroup
+
+	for i, tc := range calls {
 		tool, ok := toolMap[tc.Name]
 		if !ok {
+			// Unknown tool: fire OnToolCallStart + OnToolCall with ErrUnknownTool.
+			// Each hook is independently recover-wrapped so a panic in OnToolCallStart
+			// does not prevent OnToolCall from firing.
+			//
+			// Asymmetry with known-tool path (below): for known tools, OnToolCallStart
+			// panic prevents Execute from running (the tool should not execute if the
+			// pre-hook crashed). For unknown tools, Execute never runs anyway, so both
+			// hooks fire independently for observability completeness.
+			results[i] = toolOutput{index: i, err: ErrUnknownTool}
+			if onToolCallStart != nil {
+				func() {
+					defer func() { _ = recover() }()
+					onToolCallStart(ToolCallStartInfo{ToolCallID: tc.ID, ToolName: tc.Name, Step: step, Input: tc.Input})
+				}()
+			}
 			if onToolCall != nil {
-				onToolCall(ToolCallInfo{ToolCallID: tc.ID, ToolName: tc.Name, Step: step, Input: tc.Input, Error: ErrUnknownTool})
+				func() {
+					defer func() { _ = recover() }()
+					onToolCall(ToolCallInfo{
+						ToolCallID: tc.ID,
+						ToolName:   tc.Name,
+						Step:       step,
+						Input:      tc.Input,
+						Error:      ErrUnknownTool,
+					})
+				}()
 			}
-			msgs = append(msgs, ToolMessage(tc.ID, tc.Name, "error: unknown tool"))
 			continue
 		}
-		start := time.Now()
-		output, err := tool.Execute(ctx, tc.Input)
-		if onToolCall != nil {
-			info := ToolCallInfo{ToolCallID: tc.ID, ToolName: tc.Name, Step: step, Input: tc.Input, Output: output, StartTime: start, Duration: time.Since(start), Error: err}
-			var parsed any
-			if err == nil && json.Unmarshal([]byte(output), &parsed) == nil {
-				info.OutputObject = parsed
+
+		wg.Add(1)
+		go func(i int, tc provider.ToolCall, tool Tool) {
+			defer wg.Done()
+			var hookFired bool // true after OnToolCallStart completes (before Execute)
+			var executed bool  // tracks whether Execute ran (for panic recovery)
+			defer func() {
+				if r := recover(); r != nil {
+					if !executed {
+						// Distinguish OnToolCallStart panic from Execute panic.
+						if !hookFired {
+							results[i] = toolOutput{index: i, err: fmt.Errorf("goai: OnToolCallStart hook for tool %q panicked: %v", tc.Name, r)}
+						} else {
+							results[i] = toolOutput{index: i, err: fmt.Errorf("goai: tool %q panicked: %v", tc.Name, r)}
+						}
+					}
+					// executed==true: Execute succeeded, results[i] already set.
+					// OnToolCall panic after Execute is swallowed (preserve result).
+				}
+			}()
+
+			// OnToolCallStart: pre-execution.
+			if onToolCallStart != nil {
+				onToolCallStart(ToolCallStartInfo{
+					ToolCallID: tc.ID,
+					ToolName:   tc.Name,
+					Step:       step,
+					Input:      tc.Input,
+				})
 			}
-			onToolCall(info)
+			hookFired = true
+
+			start := time.Now()
+			output, err := tool.Execute(ctx, tc.Input)
+			executed = true
+			results[i] = toolOutput{index: i, result: output, err: err}
+
+			// OnToolCall: post-execution.
+			if onToolCall != nil {
+				info := ToolCallInfo{
+					ToolCallID: tc.ID,
+					ToolName:   tc.Name,
+					Step:       step,
+					Input:      tc.Input,
+					Output:     output,
+					StartTime:  start,
+					Duration:   time.Since(start),
+					Error:      err,
+				}
+				var parsed any
+				if err == nil && json.Unmarshal([]byte(output), &parsed) == nil {
+					info.OutputObject = parsed
+				}
+				onToolCall(info)
+			}
+		}(i, tc, tool)
+	}
+
+	wg.Wait()
+	return buildToolMessages(calls, results)
+}
+
+// buildToolMessages converts tool call results to provider messages.
+// Note: toolOutput is defined as a package-level type (not function-scoped)
+// so both executeToolsParallel and buildToolMessages can reference it.
+func buildToolMessages(calls []provider.ToolCall, results []toolOutput) []provider.Message {
+	msgs := make([]provider.Message, 0, len(calls))
+	for i, tc := range calls {
+		r := results[i]
+		if r.err != nil {
+			msgs = append(msgs, ToolMessage(tc.ID, tc.Name, "error: "+r.err.Error()))
+		} else {
+			msgs = append(msgs, ToolMessage(tc.ID, tc.Name, r.result))
 		}
-		if err != nil {
-			msgs = append(msgs, ToolMessage(tc.ID, tc.Name, "error: "+err.Error()))
-			continue
-		}
-		msgs = append(msgs, ToolMessage(tc.ID, tc.Name, output))
 	}
 	return msgs
 }
 
-// appendToolRoundTrip appends an assistant message (with tool_use parts) and tool result messages.
-func appendToolRoundTrip(msgs []provider.Message, result *provider.GenerateResult, toolMsgs []provider.Message) []provider.Message {
-	// Build assistant message with text + tool_use parts.
+// appendToolRoundTrip appends an assistant message (with tool_use parts)
+// and tool result messages for the streaming tool loop.
+func appendToolRoundTrip(
+	msgs []provider.Message,
+	text string,
+	toolCalls []provider.ToolCall,
+	toolMsgs []provider.Message,
+) []provider.Message {
 	var parts []provider.Part
-	if result.Text != "" {
-		parts = append(parts, provider.Part{Type: provider.PartText, Text: result.Text})
+	if text != "" {
+		parts = append(parts, provider.Part{Type: provider.PartText, Text: text})
 	}
-	for _, tc := range result.ToolCalls {
+	for _, tc := range toolCalls {
 		parts = append(parts, provider.Part{
 			Type:       provider.PartToolCall,
 			ToolCallID: tc.ID,
@@ -590,6 +1019,141 @@ func buildTextResult(steps []StepResult, totalUsage provider.Usage) *TextResult 
 		Response:         last.Response,
 		ProviderMetadata: last.ProviderMetadata,
 		Sources:          allSources,
+	}
+}
+
+type drainResult struct {
+	text             string // text-only (ChunkText), used for appendToolRoundTrip
+	// Note: ChunkReasoning is forwarded to consumer but NOT accumulated here.
+	// Reasoning is visible via Stream()/TextStream() but not echoed back to the model.
+	toolCalls        []provider.ToolCall
+	usage            provider.Usage
+	finishReason     provider.FinishReason
+	sources          []provider.Source
+	response         provider.ResponseMetadata
+	providerMetadata map[string]map[string]any
+	err              error // non-nil if context cancelled during drain
+}
+
+func drainStep(
+	ctx context.Context,
+	source <-chan provider.StreamChunk,
+	out chan<- provider.StreamChunk,
+) drainResult {
+	var (
+		textBuf strings.Builder // ChunkText only (reasoning excluded)
+		dr      drainResult
+	)
+
+	for chunk := range source {
+		// Forward chunk to consumer. Suppress these types (handled explicitly below):
+		// - ChunkFinish: step loop emits its own ChunkFinish with totalUsage
+		// - ChunkError: forwarded explicitly in the switch to avoid double-send
+		// Provider ChunkStepFinish IS forwarded (not suppressed) so Stream() consumers
+		// can see provider-internal boundaries (e.g., Anthropic thinking steps). These
+		// do NOT carry Metadata["stepSource"]="goai", so consume() distinguishes them.
+		if chunk.Type != provider.ChunkFinish && chunk.Type != provider.ChunkError {
+			if !provider.TrySend(ctx, out, chunk) {
+				// Drain source to unblock provider.
+				drainRemaining(source)
+				dr.err = ctx.Err()
+				return dr
+			}
+		}
+
+		// Accumulate state (same logic as TextStream.consume, generate.go:198-242).
+		// Note: ChunkToolCallDelta, ChunkToolCallStreamStart, and ChunkToolResult are
+		// forwarded to the consumer (not suppressed) but NOT accumulated here. drainStep
+		// only captures complete ChunkToolCall chunks. Providers always emit a final
+		// ChunkToolCall with complete data after all deltas.
+		switch chunk.Type {
+		case provider.ChunkText:
+			textBuf.WriteString(chunk.Text)
+			if s, ok := chunk.Metadata["source"].(provider.Source); ok {
+				dr.sources = append(dr.sources, s)
+			}
+		case provider.ChunkReasoning:
+			// Forwarded but not accumulated in text (reasoning excluded from tool round-trip).
+			if s, ok := chunk.Metadata["source"].(provider.Source); ok {
+				dr.sources = append(dr.sources, s)
+			}
+		case provider.ChunkToolCall:
+			dr.toolCalls = append(dr.toolCalls, provider.ToolCall{
+				ID:    chunk.ToolCallID,
+				Name:  chunk.ToolName,
+				Input: json.RawMessage(chunk.ToolInput),
+			})
+		case provider.ChunkStepFinish:
+			// Provider-internal step boundary (e.g., Anthropic extended thinking).
+			// Use direct assignment (last value wins), matching ChunkFinish below.
+			// This is correct for both zero-usage providers (Anthropic: 0 overwrites 0)
+			// and running-total providers (Google: last total is authoritative).
+			dr.finishReason = chunk.FinishReason
+			dr.usage = chunk.Usage
+			dr.response = chunk.Response
+			if sources, ok := chunk.Metadata["sources"].([]provider.Source); ok {
+				dr.sources = append(dr.sources, sources...)
+			}
+			if pm, ok := chunk.Metadata["providerMetadata"].(map[string]map[string]any); ok {
+				dr.providerMetadata = pm
+			}
+			for k, v := range chunk.Metadata {
+				if k == "providerMetadata" || k == "sources" {
+					continue
+				}
+				if dr.response.ProviderMetadata == nil {
+					dr.response.ProviderMetadata = map[string]any{}
+				}
+				dr.response.ProviderMetadata[k] = v
+			}
+		case provider.ChunkFinish:
+			// Terminal chunk. Use direct assignment for usage (not addUsage) to avoid
+			// double-counting when providers emit both ChunkStepFinish and ChunkFinish
+			// with the same accumulated usage (e.g., Google).
+			dr.finishReason = chunk.FinishReason
+			dr.usage = chunk.Usage
+			dr.response = chunk.Response
+			if sources, ok := chunk.Metadata["sources"].([]provider.Source); ok {
+				dr.sources = append(dr.sources, sources...)
+			}
+			if pm, ok := chunk.Metadata["providerMetadata"].(map[string]map[string]any); ok {
+				dr.providerMetadata = pm
+			}
+			// Copy flat metadata keys to Response.ProviderMetadata (same as consume(),
+			// generate.go:229-237). Providers use this for per-response data: Anthropic
+			// ("iterations", "contextManagement"), Bedrock ("cacheWriteInputTokens").
+			for k, v := range chunk.Metadata {
+				if k == "providerMetadata" || k == "sources" {
+					continue
+				}
+				if dr.response.ProviderMetadata == nil {
+					dr.response.ProviderMetadata = map[string]any{}
+				}
+				dr.response.ProviderMetadata[k] = v
+			}
+		case provider.ChunkError:
+			// Forward error chunks to consumer. Mid-stream errors flow through
+			// ChunkError chunks to the consumer; OnResponse does not report them.
+			if !provider.TrySend(ctx, out, chunk) {
+				drainRemaining(source)
+				dr.err = ctx.Err()
+				return dr
+			}
+		}
+	}
+
+	dr.text = textBuf.String()
+	return dr
+}
+
+// drainRemaining reads and discards all remaining chunks from source.
+// This unblocks the provider's write-side goroutine on context cancellation,
+// preventing goroutine leaks. Note: this blocks until the provider closes its
+// channel. A misbehaving provider that never closes will cause this to hang.
+// All current providers use defer close(out) so this is safe in practice.
+func drainRemaining(source <-chan provider.StreamChunk) {
+	for range source {
+		// discard
 	}
 }
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -985,7 +986,7 @@ func TestGenerateText_ToolLoop_UnknownTool(t *testing.T) {
 			// Check tool result is "error: unknown tool".
 			for _, msg := range params.Messages {
 				for _, p := range msg.Content {
-					if p.Type == provider.PartToolResult && p.ToolOutput == "error: unknown tool" {
+					if p.Type == provider.PartToolResult && p.ToolOutput == "error: goai: unknown tool" {
 						return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop}, nil
 					}
 				}
@@ -1748,7 +1749,7 @@ func TestStreamText_ErrReturnsStreamError(t *testing.T) {
 	}
 }
 
-func TestExecuteTools_ContextCancelled(t *testing.T) {
+func TestExecuteToolsParallel_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately.
 
@@ -1767,10 +1768,11 @@ func TestExecuteTools_ContextCancelled(t *testing.T) {
 		{ID: "tc2", Name: "slow", Input: json.RawMessage(`{}`)},
 	}
 
-	msgs := executeTools(ctx, calls, toolMap, 1, nil)
-	// With a cancelled context, executeTools should return early (0 or fewer results).
-	if len(msgs) >= 2 {
-		t.Errorf("expected fewer than 2 messages (ctx cancelled), got %d", len(msgs))
+	// With parallel execution, all tools run via goroutines and complete.
+	// The cancelled context is passed to Execute, but the tool ignores it.
+	msgs := executeToolsParallel(ctx, calls, toolMap, 1, nil, nil)
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 messages (parallel execution completes all), got %d", len(msgs))
 	}
 }
 
@@ -2266,5 +2268,1713 @@ func TestGenerateText_ContextCancelBetweenSteps(t *testing.T) {
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+// --- StreamText Tool Loop tests ---
+
+// TestStreamText_ToolLoop_TwoStep verifies a two-step tool loop via streaming:
+// step 1 returns a tool call, step 2 returns text. Checks unified stream chunk
+// order and Result() accumulation.
+func TestStreamText_ToolLoop_TwoStep(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test-stream",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "Looking up..."},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "get_weather", ToolInput: `{"city":"NYC"}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}, Response: provider.ResponseMetadata{ID: "resp-1", Model: "test-model"}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "Sunny in NYC"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 8}, Response: provider.ResponseMetadata{ID: "resp-2", Model: "test-model"}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("weather?"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:        "get_weather",
+			Description: "Get weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			Execute: func(_ context.Context, input json.RawMessage) (string, error) {
+				return "Sunny", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var chunkTypes []provider.StreamChunkType
+	for chunk := range stream.Stream() {
+		chunkTypes = append(chunkTypes, chunk.Type)
+	}
+
+	// Expected order: ChunkText, ChunkToolCall, ChunkStepFinish(goai), ChunkText, ChunkStepFinish(goai), ChunkFinish
+	want := []provider.StreamChunkType{
+		provider.ChunkText, provider.ChunkToolCall, provider.ChunkStepFinish,
+		provider.ChunkText, provider.ChunkStepFinish, provider.ChunkFinish,
+	}
+	if len(chunkTypes) != len(want) {
+		t.Fatalf("chunk types = %v, want %v", chunkTypes, want)
+	}
+	for i := range want {
+		if chunkTypes[i] != want[i] {
+			t.Errorf("chunkTypes[%d] = %q, want %q", i, chunkTypes[i], want[i])
+		}
+	}
+
+	result := stream.Result()
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	if result.Steps[0].Text != "Looking up..." {
+		t.Errorf("Steps[0].Text = %q, want %q", result.Steps[0].Text, "Looking up...")
+	}
+	if result.Steps[1].Text != "Sunny in NYC" {
+		t.Errorf("Steps[1].Text = %q, want %q", result.Steps[1].Text, "Sunny in NYC")
+	}
+	if result.TotalUsage.InputTokens != 30 || result.TotalUsage.OutputTokens != 13 {
+		t.Errorf("TotalUsage = %+v, want InputTokens=30, OutputTokens=13", result.TotalUsage)
+	}
+	if result.FinishReason != provider.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", result.FinishReason)
+	}
+	if result.Response.ID != "resp-2" {
+		t.Errorf("Response.ID = %q, want resp-2 (last step wins)", result.Response.ID)
+	}
+	if result.Steps[0].Response.ID != "resp-1" {
+		t.Errorf("Steps[0].Response.ID = %q, want resp-1", result.Steps[0].Response.ID)
+	}
+}
+
+// TestStreamText_ToolLoop_MaxStepsReached verifies the loop stops at MaxSteps
+// when the model keeps returning tool calls.
+func TestStreamText_ToolLoop_MaxStepsReached(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: fmt.Sprintf("tc%d", n), ToolName: "loop", ToolInput: `{}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(2),
+		WithTools(Tool{
+			Name:    "loop",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "looping", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if int(callCount.Load()) != 2 {
+		t.Errorf("model called %d times, want 2 (MaxSteps)", callCount.Load())
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	if result.FinishReason != provider.FinishToolCalls {
+		t.Errorf("FinishReason = %q, want tool_calls", result.FinishReason)
+	}
+}
+
+// TestStreamText_ToolLoop_ParallelExecution verifies that two tool calls in one
+// step are both executed.
+func TestStreamText_ToolLoop_ParallelExecution(t *testing.T) {
+	var callCount atomic.Int32
+	var execCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "work", ToolInput: `{"id":"a"}`},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc2", ToolName: "work", ToolInput: `{"id":"b"}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "work",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				execCount.Add(1)
+				return "ok", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if execCount.Load() != 2 {
+		t.Errorf("tools executed %d times, want 2", execCount.Load())
+	}
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want %q", result.Text, "done")
+	}
+}
+
+// TestStreamText_ToolLoop_ContextCancel verifies clean shutdown when context
+// is cancelled during step 1 drain. Uses a slow-producing channel so the
+// cancel fires while drainStep is blocked trying to forward chunks.
+func TestStreamText_ToolLoop_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Create a stream that produces many chunks (more than out buffer of 64).
+	ch := make(chan provider.StreamChunk, 1)
+	go func() {
+		defer close(ch)
+		for range 500 {
+			select {
+			case ch <- provider.StreamChunk{Type: provider.ChunkText, Text: "x"}:
+			case <-ctx.Done():
+				return
+			}
+		}
+		ch <- provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop}
+	}()
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return &provider.StreamResult{Stream: ch}, nil
+		},
+	}
+
+	stream, err := StreamText(ctx, model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start consuming via Stream but stop reading to let the out buffer fill.
+	rawCh := stream.Stream()
+	<-rawCh // Read one chunk.
+
+	// Let the out buffer fill, then cancel.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	// Drain remaining chunks.
+	for range rawCh {
+	}
+
+	if stream.Err() == nil {
+		t.Fatal("expected non-nil Err()")
+	}
+	if !errors.Is(stream.Err(), context.Canceled) {
+		t.Errorf("Err() = %v, want context.Canceled", stream.Err())
+	}
+}
+
+// TestStreamText_ToolLoop_HookOrdering verifies the sequence of hook calls
+// for a 2-step tool loop including OnToolCallStart:
+// OnRequest -> OnResponse -> OnStepFinish -> OnToolCallStart -> OnToolCall -> OnRequest -> ...
+func TestStreamText_ToolLoop_HookOrdering(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	var mu sync.Mutex
+	var sequence []string
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnRequest(func(_ RequestInfo) {
+			mu.Lock()
+			sequence = append(sequence, "OnRequest")
+			mu.Unlock()
+		}),
+		WithOnResponse(func(_ ResponseInfo) {
+			mu.Lock()
+			sequence = append(sequence, "OnResponse")
+			mu.Unlock()
+		}),
+		WithOnStepFinish(func(_ StepResult) {
+			mu.Lock()
+			sequence = append(sequence, "OnStepFinish")
+			mu.Unlock()
+		}),
+		WithOnToolCallStart(func(_ ToolCallStartInfo) {
+			mu.Lock()
+			sequence = append(sequence, "OnToolCallStart")
+			mu.Unlock()
+		}),
+		WithOnToolCall(func(_ ToolCallInfo) {
+			mu.Lock()
+			sequence = append(sequence, "OnToolCall")
+			mu.Unlock()
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Consume fully.
+	result := stream.Result()
+	_ = result
+
+	// Expected: drain -> OnResponse -> OnStepFinish -> OnToolCallStart -> OnToolCall -> next step
+	want := []string{
+		"OnRequest", "OnResponse", "OnStepFinish", "OnToolCallStart", "OnToolCall", // step 1
+		"OnRequest", "OnResponse", "OnStepFinish", // step 2
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sequence) != len(want) {
+		t.Fatalf("sequence = %v, want %v", sequence, want)
+	}
+	for i := range want {
+		if sequence[i] != want[i] {
+			t.Errorf("sequence[%d] = %q, want %q", i, sequence[i], want[i])
+		}
+	}
+}
+
+// TestStreamText_ToolLoop_ToolError verifies that a tool returning an error
+// passes the error message to the model and the loop continues.
+func TestStreamText_ToolLoop_ToolError(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "fail", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			// Verify the error was passed as tool result.
+			for _, msg := range params.Messages {
+				for _, p := range msg.Content {
+					if p.Type == provider.PartToolResult && p.ToolOutput == "error: something went wrong" {
+						return streamFromChunks(
+							provider.StreamChunk{Type: provider.ChunkText, Text: "handled error"},
+							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 3}},
+						), nil
+					}
+				}
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "no error found"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "fail",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "", fmt.Errorf("something went wrong")
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if !strings.Contains(result.Text, "handled error") {
+		t.Errorf("Text = %q, want containing 'handled error'", result.Text)
+	}
+}
+
+// TestStreamText_ToolLoop_ResultAccumulation verifies multi-step Result()
+// accumulation: Steps length, per-step text/usage, and aggregated TotalUsage.
+func TestStreamText_ToolLoop_ResultAccumulation(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "Step1."},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "Step2."},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 8}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	if result.Steps[0].Number != 1 {
+		t.Errorf("Steps[0].Number = %d, want 1", result.Steps[0].Number)
+	}
+	if result.Steps[1].Number != 2 {
+		t.Errorf("Steps[1].Number = %d, want 2", result.Steps[1].Number)
+	}
+	if result.Steps[0].Text != "Step1." {
+		t.Errorf("Steps[0].Text = %q, want %q", result.Steps[0].Text, "Step1.")
+	}
+	if result.Steps[1].Text != "Step2." {
+		t.Errorf("Steps[1].Text = %q, want %q", result.Steps[1].Text, "Step2.")
+	}
+	if result.Steps[0].Usage.InputTokens != 10 || result.Steps[0].Usage.OutputTokens != 5 {
+		t.Errorf("Steps[0].Usage = %+v", result.Steps[0].Usage)
+	}
+	if result.Steps[1].Usage.InputTokens != 20 || result.Steps[1].Usage.OutputTokens != 8 {
+		t.Errorf("Steps[1].Usage = %+v", result.Steps[1].Usage)
+	}
+	if result.TotalUsage.InputTokens != 30 || result.TotalUsage.OutputTokens != 13 {
+		t.Errorf("TotalUsage = %+v, want InputTokens=30, OutputTokens=13", result.TotalUsage)
+	}
+	if result.Text != "Step1.Step2." {
+		t.Errorf("Text = %q, want %q", result.Text, "Step1.Step2.")
+	}
+}
+
+// TestStreamText_ToolLoop_TextStreamPath verifies consuming via TextStream()
+// flows text from all steps and Result() returns correct data afterward.
+func TestStreamText_ToolLoop_TextStreamPath(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "A"},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 5, OutputTokens: 3}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "B"},
+				provider.StreamChunk{Type: provider.ChunkText, Text: "C"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var texts []string
+	for text := range stream.TextStream() {
+		texts = append(texts, text)
+	}
+
+	// Text from both steps should flow through.
+	joined := strings.Join(texts, "")
+	if joined != "ABC" {
+		t.Errorf("TextStream joined = %q, want %q", joined, "ABC")
+	}
+
+	result := stream.Result()
+	if result.Text != "ABC" {
+		t.Errorf("Result().Text = %q, want %q", result.Text, "ABC")
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	if result.TotalUsage.InputTokens != 15 {
+		t.Errorf("TotalUsage.InputTokens = %d, want 15", result.TotalUsage.InputTokens)
+	}
+}
+
+// TestStreamText_ToolLoop_ToolPanic verifies that a panicking tool Execute
+// does not crash the process and an error appears in the tool result message.
+func TestStreamText_ToolLoop_ToolPanic(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "panicker", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			// Verify panic was captured in tool result message.
+			for _, msg := range params.Messages {
+				for _, p := range msg.Content {
+					if p.Type == provider.PartToolResult && strings.Contains(p.ToolOutput, "panicked") {
+						return streamFromChunks(
+							provider.StreamChunk{Type: provider.ChunkText, Text: "panic handled"},
+							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 3}},
+						), nil
+					}
+				}
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "no panic found"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "panicker",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				panic("tool exploded")
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if !strings.Contains(result.Text, "panic handled") {
+		t.Errorf("Text = %q, want containing 'panic handled'", result.Text)
+	}
+}
+
+// TestStreamText_ToolLoop_UnknownTool verifies that a tool call referencing
+// an unknown tool fires OnToolCall with ErrUnknownTool.
+func TestStreamText_ToolLoop_UnknownTool(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "nonexistent", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			// Check tool result has unknown tool error.
+			for _, msg := range params.Messages {
+				for _, p := range msg.Content {
+					if p.Type == provider.PartToolResult && p.ToolOutput == "error: goai: unknown tool" {
+						return streamFromChunks(
+							provider.StreamChunk{Type: provider.ChunkText, Text: "ok"},
+							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+						), nil
+					}
+				}
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "unexpected"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	var capturedInfo ToolCallInfo
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "known",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnToolCall(func(info ToolCallInfo) {
+			capturedInfo = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "ok")
+	}
+	if capturedInfo.ToolName != "nonexistent" {
+		t.Errorf("ToolCallInfo.ToolName = %q, want %q", capturedInfo.ToolName, "nonexistent")
+	}
+	if !errors.Is(capturedInfo.Error, ErrUnknownTool) {
+		t.Errorf("ToolCallInfo.Error = %v, want ErrUnknownTool", capturedInfo.Error)
+	}
+}
+
+// TestStreamText_ToolLoop_ToolChoiceReset verifies that ToolChoice is cleared
+// after step 1 so the model can freely respond on subsequent steps.
+func TestStreamText_ToolLoop_ToolChoiceReset(t *testing.T) {
+	var mu sync.Mutex
+	var capturedToolChoices []string
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			mu.Lock()
+			capturedToolChoices = append(capturedToolChoices, params.ToolChoice)
+			mu.Unlock()
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "echo", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 15, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithToolChoice("required"),
+		WithTools(Tool{
+			Name:    "echo",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	_ = result
+	mu.Lock()
+	defer mu.Unlock()
+	if len(capturedToolChoices) != 2 {
+		t.Fatalf("steps = %d, want 2", len(capturedToolChoices))
+	}
+	if capturedToolChoices[0] != "required" {
+		t.Errorf("step 1 tool_choice = %q, want required", capturedToolChoices[0])
+	}
+	if capturedToolChoices[1] != "" {
+		t.Errorf("step 2 tool_choice = %q, want empty (reset)", capturedToolChoices[1])
+	}
+}
+
+// TestStreamText_ToolLoop_Step1DoStreamFailure verifies that when DoStream
+// fails on step 1, StreamText returns (nil, error).
+func TestStreamText_ToolLoop_Step1DoStreamFailure(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return nil, &APIError{Message: "bad request", StatusCode: 400}
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if stream != nil {
+		t.Error("expected nil stream on step 1 failure")
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 400 {
+		t.Errorf("StatusCode = %d, want 400", apiErr.StatusCode)
+	}
+}
+
+// TestStreamText_ToolLoop_SingleStepDispatch verifies that MaxSteps=1 with
+// executable tools dispatches to the single-step path and tools are NOT executed.
+func TestStreamText_ToolLoop_SingleStepDispatch(t *testing.T) {
+	var execCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(1),
+		WithTools(Tool{
+			Name: "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				execCount.Add(1)
+				return "ok", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if execCount.Load() != 0 {
+		t.Errorf("tool executed %d times, want 0 (single-step, no loop)", execCount.Load())
+	}
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	if result.ToolCalls[0].Name != "tool" {
+		t.Errorf("ToolCalls[0].Name = %q, want %q", result.ToolCalls[0].Name, "tool")
+	}
+}
+
+// TestStreamText_ToolLoop_OnToolCallStart verifies that OnToolCallStart fires
+// before Execute with correct fields.
+func TestStreamText_ToolLoop_OnToolCallStart(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "myTool", ToolInput: `{"key":"val"}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 15, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	var startInfo ToolCallStartInfo
+	var startFiredBeforeExec atomic.Bool
+	var execFired atomic.Bool
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "myTool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				if !execFired.Load() {
+					// Check if OnToolCallStart already fired.
+					startFiredBeforeExec.Store(startInfo.ToolCallID != "")
+				}
+				execFired.Store(true)
+				return "result", nil
+			},
+		}),
+		WithOnToolCallStart(func(info ToolCallStartInfo) {
+			startInfo = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = stream.Result()
+	if startInfo.ToolCallID != "tc1" {
+		t.Errorf("ToolCallID = %q, want tc1", startInfo.ToolCallID)
+	}
+	if startInfo.ToolName != "myTool" {
+		t.Errorf("ToolName = %q, want myTool", startInfo.ToolName)
+	}
+	if startInfo.Step != 1 {
+		t.Errorf("Step = %d, want 1", startInfo.Step)
+	}
+	if string(startInfo.Input) != `{"key":"val"}` {
+		t.Errorf("Input = %q, want %q", string(startInfo.Input), `{"key":"val"}`)
+	}
+	if !startFiredBeforeExec.Load() {
+		t.Error("OnToolCallStart did not fire before Execute")
+	}
+}
+
+// TestStreamText_ToolLoop_ChunkStepFinishDisambiguation verifies that
+// provider-internal ChunkStepFinish (without stepSource=goai) IS forwarded
+// to the consumer and does NOT have Metadata["stepSource"]="goai".
+func TestStreamText_ToolLoop_ChunkStepFinishDisambiguation(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "thinking..."},
+					// Provider-internal step finish (e.g., Anthropic thinking step)
+					provider.StreamChunk{Type: provider.ChunkStepFinish, FinishReason: provider.FinishStop,
+						Metadata: map[string]any{"internal": true}},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 15, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var providerStepFinishes []provider.StreamChunk
+	var goaiStepFinishes []provider.StreamChunk
+	for chunk := range stream.Stream() {
+		if chunk.Type == provider.ChunkStepFinish {
+			if stepSource, _ := chunk.Metadata["stepSource"].(string); stepSource == "goai" {
+				goaiStepFinishes = append(goaiStepFinishes, chunk)
+			} else {
+				providerStepFinishes = append(providerStepFinishes, chunk)
+			}
+		}
+	}
+
+	// Provider step finish should be forwarded (1 from step 1 provider stream).
+	if len(providerStepFinishes) != 1 {
+		t.Errorf("provider ChunkStepFinish count = %d, want 1", len(providerStepFinishes))
+	}
+	if providerStepFinishes[0].Metadata["internal"] != true {
+		t.Error("provider ChunkStepFinish missing internal metadata")
+	}
+
+	// GoAI step finishes: 2 (one per step in the loop).
+	if len(goaiStepFinishes) != 2 {
+		t.Errorf("goai ChunkStepFinish count = %d, want 2", len(goaiStepFinishes))
+	}
+}
+
+// TestStreamText_ToolLoop_ReasoningExclusion verifies that ChunkReasoning
+// content is included in Result().Text (backward compat) but excluded from
+// Result().Steps[n].Text.
+func TestStreamText_ToolLoop_ReasoningExclusion(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkReasoning, Text: "thinking..."},
+					provider.StreamChunk{Type: provider.ChunkText, Text: "answer"},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "final"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	// Global text includes reasoning (backward compat).
+	if result.Text != "thinking...answerfinal" {
+		t.Errorf("Text = %q, want %q", result.Text, "thinking...answerfinal")
+	}
+	// Step text excludes reasoning.
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	if result.Steps[0].Text != "answer" {
+		t.Errorf("Steps[0].Text = %q, want %q (reasoning excluded)", result.Steps[0].Text, "answer")
+	}
+	if result.Steps[1].Text != "final" {
+		t.Errorf("Steps[1].Text = %q, want %q", result.Steps[1].Text, "final")
+	}
+}
+
+// TestStreamText_ToolLoop_PartialStepsOnError verifies that when DoStream
+// fails on step 2, Result().Steps has step 1 data and Err() returns the error.
+func TestStreamText_ToolLoop_PartialStepsOnError(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "step1"},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return nil, &APIError{Message: "server error", StatusCode: 500}
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithMaxRetries(0),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if stream.Err() == nil {
+		t.Fatal("expected non-nil Err()")
+	}
+	var apiErr *APIError
+	if !errors.As(stream.Err(), &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", stream.Err(), stream.Err())
+	}
+	if apiErr.StatusCode != 500 {
+		t.Errorf("StatusCode = %d, want 500", apiErr.StatusCode)
+	}
+	// Step 1 data should still be present.
+	if len(result.Steps) < 1 {
+		t.Fatal("expected at least 1 step in partial result")
+	}
+	if result.Steps[0].Text != "step1" {
+		t.Errorf("Steps[0].Text = %q, want %q", result.Steps[0].Text, "step1")
+	}
+}
+
+// TestStreamText_ToolLoop_NoExecuteNoLoop verifies that tools without Execute
+// functions + MaxSteps=3 dispatches to the single-step path.
+func TestStreamText_ToolLoop_NoExecuteNoLoop(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			callCount.Add(1)
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "read", ToolInput: `{}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:        "read",
+			Description: "Read a file",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			// No Execute: definition only.
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if callCount.Load() != 1 {
+		t.Errorf("model called %d times, want 1 (no loop without Execute)", callCount.Load())
+	}
+	if len(result.ToolCalls) != 1 {
+		t.Errorf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+}
+
+// TestStreamText_SingleStep_ReasoningExclusion verifies that in the single-step
+// path (MaxSteps=1, no tool loop), ChunkReasoning is included in Result().Text
+// but excluded from Steps[0].Text and OnStepFinish's StepResult.Text.
+func TestStreamText_SingleStep_ReasoningExclusion(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkReasoning, Text: "thinking..."},
+				provider.StreamChunk{Type: provider.ChunkText, Text: "answer"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+			), nil
+		},
+	}
+
+	var hookStepText string
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithOnStepFinish(func(step StepResult) {
+			hookStepText = step.Text
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	// Global text includes reasoning (backward compat).
+	if result.Text != "thinking...answer" {
+		t.Errorf("Text = %q, want %q", result.Text, "thinking...answer")
+	}
+	// Step text excludes reasoning.
+	if len(result.Steps) != 1 {
+		t.Fatalf("Steps = %d, want 1", len(result.Steps))
+	}
+	if result.Steps[0].Text != "answer" {
+		t.Errorf("Steps[0].Text = %q, want %q (reasoning excluded)", result.Steps[0].Text, "answer")
+	}
+	// OnStepFinish hook also excludes reasoning.
+	if hookStepText != "answer" {
+		t.Errorf("OnStepFinish Text = %q, want %q (reasoning excluded)", hookStepText, "answer")
+	}
+}
+
+// TestStreamText_ToolLoop_OnToolCallStartPanic verifies that a panicking
+// OnToolCallStart hook is safely recovered: the process does not crash, the
+// tool result message contains the panic error, OnToolCall does NOT fire
+// (because Execute never ran), and the model can respond on step 2.
+func TestStreamText_ToolLoop_OnToolCallStartPanic(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "boom", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			// Step 2: verify the tool result contains the panic error.
+			for _, msg := range params.Messages {
+				for _, p := range msg.Content {
+					if p.Type == provider.PartToolResult && strings.Contains(p.ToolOutput, "OnToolCallStart hook") && strings.Contains(p.ToolOutput, "panicked") {
+						return streamFromChunks(
+							provider.StreamChunk{Type: provider.ChunkText, Text: "recovered from hook panic"},
+							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 5}},
+						), nil
+					}
+				}
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "no panic found"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	var onToolCallFired atomic.Bool
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "boom",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "should not run", nil
+			},
+		}),
+		WithOnToolCallStart(func(_ ToolCallStartInfo) {
+			panic("hook exploded")
+		}),
+		WithOnToolCall(func(_ ToolCallInfo) {
+			onToolCallFired.Store(true)
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatalf("unexpected stream error: %v", err)
+	}
+	if !strings.Contains(result.Text, "recovered from hook panic") {
+		t.Errorf("Text = %q, want containing 'recovered from hook panic'", result.Text)
+	}
+	if onToolCallFired.Load() {
+		t.Error("OnToolCall should NOT fire when OnToolCallStart panics (Execute never ran)")
+	}
+}
+
+// TestStreamText_ToolLoop_Step2Retry verifies that withRetry works on step 2+
+// DoStream calls: step 1 succeeds with a tool call, step 2 fails once with a
+// retryable 500 error then succeeds on retry.
+func TestStreamText_ToolLoop_Step2Retry(t *testing.T) {
+	var doStreamCalls atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := doStreamCalls.Add(1)
+			switch n {
+			case 1:
+				// Step 1: tool call.
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "myTool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			case 2:
+				// Step 2, attempt 1: retryable error.
+				return nil, &APIError{StatusCode: 500, Message: "server error", IsRetryable: true}
+			default:
+				// Step 2, attempt 2 (retry): success.
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "step2 ok"},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 3}},
+				), nil
+			}
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithMaxRetries(1),
+		WithTools(Tool{
+			Name: "myTool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "tool result", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatalf("unexpected stream error: %v", err)
+	}
+	if result.Text != "step2 ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "step2 ok")
+	}
+	if got := doStreamCalls.Load(); got != 3 {
+		t.Errorf("DoStream call count = %d, want 3 (step1 + step2 fail + step2 retry)", got)
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	if result.FinishReason != provider.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", result.FinishReason)
+	}
+}
+
+// TestStreamText_ToolLoop_UnknownToolOnToolCallStartPanic verifies that when
+// an unknown tool's OnToolCallStart hook panics, it is silently recovered and
+// OnToolCall still fires with ErrUnknownTool (independent recover wrapping for
+// unknown tools).
+func TestStreamText_ToolLoop_UnknownToolOnToolCallStartPanic(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "nonexistent_tool", ToolInput: `{"x":1}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			// Step 2: the model sees the error and responds.
+			for _, msg := range params.Messages {
+				for _, p := range msg.Content {
+					if p.Type == provider.PartToolResult {
+						return streamFromChunks(
+							provider.StreamChunk{Type: provider.ChunkText, Text: "handled"},
+							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+						), nil
+					}
+				}
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "unexpected"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	var onToolCallFired atomic.Bool
+	var capturedInfo ToolCallInfo
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "other_tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnToolCallStart(func(_ ToolCallStartInfo) {
+			panic("start hook boom")
+		}),
+		WithOnToolCall(func(info ToolCallInfo) {
+			onToolCallFired.Store(true)
+			capturedInfo = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatalf("unexpected stream error: %v", err)
+	}
+	if result.Text != "handled" {
+		t.Errorf("Text = %q, want %q", result.Text, "handled")
+	}
+	if !onToolCallFired.Load() {
+		t.Fatal("OnToolCall did not fire for unknown tool (expected it to fire even after OnToolCallStart panic)")
+	}
+	if !errors.Is(capturedInfo.Error, ErrUnknownTool) {
+		t.Errorf("ToolCallInfo.Error = %v, want ErrUnknownTool", capturedInfo.Error)
+	}
+}
+
+// TestGenerateText_ToolLoop_OnToolCallStart verifies that OnToolCallStart fires
+// correctly in GenerateText (non-streaming) tool loop with correct fields and
+// fires before Execute.
+func TestGenerateText_ToolLoop_OnToolCallStart(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "myTool", Input: json.RawMessage(`{"key":"val"}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	var startInfo ToolCallStartInfo
+	var startFiredBeforeExec atomic.Bool
+	var execFired atomic.Bool
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "myTool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				if !execFired.Load() {
+					// Check if OnToolCallStart already fired.
+					startFiredBeforeExec.Store(startInfo.ToolCallID != "")
+				}
+				execFired.Store(true)
+				return "result", nil
+			},
+		}),
+		WithOnToolCallStart(func(info ToolCallStartInfo) {
+			startInfo = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want %q", result.Text, "done")
+	}
+	if startInfo.ToolCallID != "tc1" {
+		t.Errorf("ToolCallID = %q, want tc1", startInfo.ToolCallID)
+	}
+	if startInfo.ToolName != "myTool" {
+		t.Errorf("ToolName = %q, want myTool", startInfo.ToolName)
+	}
+	if startInfo.Step != 1 {
+		t.Errorf("Step = %d, want 1", startInfo.Step)
+	}
+	if string(startInfo.Input) != `{"key":"val"}` {
+		t.Errorf("Input = %q, want %q", string(startInfo.Input), `{"key":"val"}`)
+	}
+	if !startFiredBeforeExec.Load() {
+		t.Error("OnToolCallStart did not fire before Execute")
+	}
+}
+
+// TestStreamText_ToolLoop_ChunkToolCallDeltaForwarded verifies that
+// ChunkToolCallStreamStart and ChunkToolCallDelta chunks are forwarded to the
+// consumer, and that drainStep only accumulates the final ChunkToolCall (not deltas).
+func TestStreamText_ToolLoop_ChunkToolCallDeltaForwarded(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCallStreamStart, ToolCallID: "tc1", ToolName: "myTool"},
+					provider.StreamChunk{Type: provider.ChunkToolCallDelta, ToolCallID: "tc1", ToolInput: `{"key":`},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "myTool", ToolInput: `{"key":"val"}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 15, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "myTool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "result", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var chunkTypes []provider.StreamChunkType
+	for chunk := range stream.Stream() {
+		chunkTypes = append(chunkTypes, chunk.Type)
+	}
+
+	// Expected: StreamStart, Delta, ToolCall, StepFinish(goai), Text, StepFinish(goai), Finish
+	want := []provider.StreamChunkType{
+		provider.ChunkToolCallStreamStart,
+		provider.ChunkToolCallDelta,
+		provider.ChunkToolCall,
+		provider.ChunkStepFinish,
+		provider.ChunkText,
+		provider.ChunkStepFinish,
+		provider.ChunkFinish,
+	}
+	if len(chunkTypes) != len(want) {
+		t.Fatalf("chunk types = %v, want %v", chunkTypes, want)
+	}
+	for i := range want {
+		if chunkTypes[i] != want[i] {
+			t.Errorf("chunkTypes[%d] = %q, want %q", i, chunkTypes[i], want[i])
+		}
+	}
+
+	result := stream.Result()
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	// drainStep should only accumulate the ChunkToolCall, not the delta.
+	if len(result.Steps[0].ToolCalls) != 1 {
+		t.Fatalf("Steps[0].ToolCalls = %d, want 1", len(result.Steps[0].ToolCalls))
+	}
+	if result.Steps[0].ToolCalls[0].ID != "tc1" {
+		t.Errorf("ToolCalls[0].ID = %q, want tc1", result.Steps[0].ToolCalls[0].ID)
+	}
+	if result.Steps[1].Text != "done" {
+		t.Errorf("Steps[1].Text = %q, want done", result.Steps[1].Text)
+	}
+}
+
+// TestStreamText_ToolLoop_DrainStepMetadata verifies that drainStep correctly
+// extracts sources, providerMetadata, and response providerMetadata from
+// ChunkStepFinish and ChunkFinish metadata during multi-step streaming.
+func TestStreamText_ToolLoop_DrainStepMetadata(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test-meta",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "call"},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{
+						Type:         provider.ChunkStepFinish,
+						FinishReason: provider.FinishToolCalls,
+						Usage:        provider.Usage{InputTokens: 5, OutputTokens: 3},
+						Metadata: map[string]any{
+							"sources":          []provider.Source{{URL: "http://example.com"}},
+							"providerMetadata": map[string]map[string]any{"openai": {"logprobs": true}},
+							"cacheTokens":      42,
+						},
+					},
+					provider.StreamChunk{
+						Type:         provider.ChunkFinish,
+						FinishReason: provider.FinishToolCalls,
+						Usage:        provider.Usage{InputTokens: 5, OutputTokens: 3},
+						Response:     provider.ResponseMetadata{ID: "r1", Model: "m"},
+						Metadata: map[string]any{
+							"sources":          []provider.Source{{URL: "http://example.com"}},
+							"providerMetadata": map[string]map[string]any{"openai": {"logprobs": true}},
+							"cacheTokens":      42,
+						},
+					},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{
+					Type:         provider.ChunkFinish,
+					FinishReason: provider.FinishStop,
+					Usage:        provider.Usage{InputTokens: 10, OutputTokens: 4},
+					Response:     provider.ResponseMetadata{ID: "r2", Model: "m"},
+					Metadata: map[string]any{
+						"sources":          []provider.Source{{URL: "http://example2.com"}},
+						"providerMetadata": map[string]map[string]any{"openai": {"logprobs": false}},
+					},
+				},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if stream.Err() != nil {
+		t.Fatalf("unexpected error: %v", stream.Err())
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+
+	// Step 1: sources from ChunkFinish metadata (last value wins).
+	if len(result.Steps[0].Sources) == 0 {
+		t.Fatal("Steps[0].Sources is empty, want at least one source")
+	}
+	if result.Steps[0].Sources[0].URL != "http://example.com" {
+		t.Errorf("Steps[0].Sources[0].URL = %q, want http://example.com", result.Steps[0].Sources[0].URL)
+	}
+
+	// Step 1: providerMetadata from ChunkFinish metadata.
+	if result.Steps[0].ProviderMetadata == nil {
+		t.Fatal("Steps[0].ProviderMetadata is nil")
+	}
+	if val, ok := result.Steps[0].ProviderMetadata["openai"]["logprobs"].(bool); !ok || !val {
+		t.Errorf("Steps[0].ProviderMetadata[openai][logprobs] = %v, want true", result.Steps[0].ProviderMetadata["openai"]["logprobs"])
+	}
+
+	// Step 1: Response.ProviderMetadata has cacheTokens from flat metadata.
+	if result.Steps[0].Response.ProviderMetadata == nil {
+		t.Fatal("Steps[0].Response.ProviderMetadata is nil")
+	}
+	if ct, ok := result.Steps[0].Response.ProviderMetadata["cacheTokens"].(int); !ok || ct != 42 {
+		t.Errorf("Steps[0].Response.ProviderMetadata[cacheTokens] = %v, want 42", result.Steps[0].Response.ProviderMetadata["cacheTokens"])
+	}
+
+	// Final response has ID from step 2.
+	if result.Response.ID != "r2" {
+		t.Errorf("Response.ID = %q, want r2", result.Response.ID)
+	}
+
+	// Step 2: providerMetadata from ChunkFinish metadata (via drainStep, then
+	// GoAI ChunkStepFinish forwarded to consume).
+	if result.Steps[1].ProviderMetadata == nil {
+		t.Fatal("Steps[1].ProviderMetadata is nil")
+	}
+	if val, ok := result.Steps[1].ProviderMetadata["openai"]["logprobs"].(bool); !ok || val {
+		t.Errorf("Steps[1].ProviderMetadata[openai][logprobs] = %v, want false", result.Steps[1].ProviderMetadata["openai"]["logprobs"])
+	}
+}
+
+// TestStreamText_ToolLoop_EmptyStepGuard verifies that the empty step guard
+// (line 570) prevents phantom steps when a provider stream emits only a
+// ChunkError then closes (no text, no tool calls, no finish reason).
+func TestStreamText_ToolLoop_EmptyStepGuard(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test-guard",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				// Step 1: only emits ChunkError then closes (no ChunkFinish with finishReason).
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkError, Error: fmt.Errorf("transient failure")},
+				), nil
+			}
+			// Should never be reached due to empty step guard breaking the loop.
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "should not appear"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Consume the stream.
+	var gotError bool
+	for chunk := range stream.Stream() {
+		if chunk.Type == provider.ChunkError {
+			gotError = true
+		}
+	}
+	if !gotError {
+		t.Error("expected ChunkError in stream")
+	}
+
+	result := stream.Result()
+	// The stream should have the error forwarded but no phantom step.
+	if len(result.Steps) != 0 {
+		t.Errorf("Steps = %d, want 0 (empty step guard should prevent phantom step)", len(result.Steps))
+	}
+	if result.FinishReason != "" {
+		t.Errorf("FinishReason = %q, want empty", result.FinishReason)
+	}
+}
+
+// TestStreamText_ToolLoop_Step2DoStreamErrorWithOnResponse verifies that when
+// step 2 DoStream fails, the OnResponse hook fires with Error and StatusCode,
+// and the stream carries the error.
+func TestStreamText_ToolLoop_Step2DoStreamErrorWithOnResponse(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test-hook-err",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "step1"},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return nil, &APIError{StatusCode: 429, Message: "rate limited"}
+		},
+	}
+
+	var mu sync.Mutex
+	var capturedResp []ResponseInfo
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithMaxRetries(0),
+		WithOnResponse(func(info ResponseInfo) {
+			mu.Lock()
+			capturedResp = append(capturedResp, info)
+			mu.Unlock()
+		}),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Consume stream.
+	for range stream.Stream() {
+	}
+
+	if stream.Err() == nil {
+		t.Fatal("expected non-nil Err()")
+	}
+	var apiErr *APIError
+	if !errors.As(stream.Err(), &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", stream.Err(), stream.Err())
+	}
+	if apiErr.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", apiErr.StatusCode)
+	}
+
+	// OnResponse should have fired at least twice: once for step 1 success, once for step 2 error.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(capturedResp) < 2 {
+		t.Fatalf("OnResponse fired %d times, want >= 2", len(capturedResp))
+	}
+	// Find the error response.
+	var foundErr bool
+	for _, r := range capturedResp {
+		if r.Error != nil && r.StatusCode == 429 {
+			foundErr = true
+			break
+		}
+	}
+	if !foundErr {
+		t.Error("OnResponse never fired with Error and StatusCode=429")
+	}
+
+	// Step 1 data should still be present.
+	result := stream.Result()
+	if len(result.Steps) < 1 {
+		t.Fatal("expected at least 1 step in partial result")
+	}
+	if result.Steps[0].Text != "step1" {
+		t.Errorf("Steps[0].Text = %q, want step1", result.Steps[0].Text)
+	}
+}
+
+// TestStreamText_ToolLoop_DrainStepChunkReasoningSource verifies that
+// ChunkReasoning with a source in its Metadata is captured by drainStep.
+func TestStreamText_ToolLoop_DrainStepChunkReasoningSource(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test-reasoning-src",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{
+						Type: provider.ChunkReasoning,
+						Text: "thinking about it",
+						Metadata: map[string]any{
+							"source": provider.Source{URL: "http://reasoning-source.com", Type: "url"},
+						},
+					},
+					provider.StreamChunk{Type: provider.ChunkText, Text: "answer"},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 15, OutputTokens: 3}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := stream.Result()
+	if stream.Err() != nil {
+		t.Fatalf("unexpected error: %v", stream.Err())
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+
+	// Step 1 should have the reasoning source.
+	if len(result.Steps[0].Sources) == 0 {
+		t.Fatal("Steps[0].Sources is empty, want reasoning source")
+	}
+	foundReasoningSrc := false
+	for _, s := range result.Steps[0].Sources {
+		if s.URL == "http://reasoning-source.com" {
+			foundReasoningSrc = true
+			break
+		}
+	}
+	if !foundReasoningSrc {
+		t.Errorf("Steps[0].Sources = %v, want source with URL http://reasoning-source.com", result.Steps[0].Sources)
+	}
+
+	// Reasoning text should NOT be in Step text.
+	if strings.Contains(result.Steps[0].Text, "thinking") {
+		t.Errorf("Steps[0].Text = %q, should not contain reasoning text", result.Steps[0].Text)
+	}
+	if result.Steps[0].Text != "answer" {
+		t.Errorf("Steps[0].Text = %q, want answer", result.Steps[0].Text)
 	}
 }

--- a/hooks.go
+++ b/hooks.go
@@ -39,7 +39,8 @@ type ResponseInfo struct {
 	// FinishReason indicates why generation stopped.
 	FinishReason provider.FinishReason
 
-	// Error is non-nil if the call failed.
+	// Error is non-nil if the API call itself failed (DoGenerate/DoStream returned error).
+	// Mid-stream errors (ChunkError) are not reported here; use stream.Err().
 	Error error
 
 	// StatusCode is the HTTP status code (0 if not applicable).
@@ -47,6 +48,8 @@ type ResponseInfo struct {
 }
 
 // ToolCallInfo is passed to the OnToolCall hook after a tool executes.
+// It contains the full tool Input and Output, which may include sensitive data.
+// Consumers that log or export hook data should sanitize accordingly.
 type ToolCallInfo struct {
 	// ToolCallID is the provider-assigned identifier for this tool call.
 	ToolCallID string
@@ -99,4 +102,24 @@ func WithOnResponse(fn func(ResponseInfo)) Option {
 // WithOnToolCall sets a callback invoked after each tool execution.
 func WithOnToolCall(fn func(ToolCallInfo)) Option {
 	return func(o *options) { o.OnToolCall = fn }
+}
+
+// ToolCallStartInfo is passed to the OnToolCallStart hook before a tool executes.
+type ToolCallStartInfo struct {
+	// ToolCallID is the provider-assigned identifier for this tool call.
+	ToolCallID string
+
+	// ToolName is the name of the tool about to execute.
+	ToolName string
+
+	// Step is the 1-based index of the generation step in which this tool was called.
+	Step int
+
+	// Input is the raw JSON arguments that will be passed to the tool.
+	Input json.RawMessage
+}
+
+// WithOnToolCallStart sets a callback invoked before each tool execution.
+func WithOnToolCallStart(fn func(ToolCallStartInfo)) Option {
+	return func(o *options) { o.OnToolCallStart = fn }
 }

--- a/object.go
+++ b/object.go
@@ -313,7 +313,10 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		totalUsage = addUsage(totalUsage, result.Usage)
 
 		if o.OnStepFinish != nil {
-			o.OnStepFinish(stepResult)
+			func() {
+				defer func() { _ = recover() }()
+				o.OnStepFinish(stepResult)
+			}()
 		}
 
 		// If no tools have Execute functions, skip the tool loop regardless of MaxSteps.
@@ -345,8 +348,8 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		// Clear tool_choice after the first tool step so the model can freely
 		// produce structured output on subsequent steps.
 		params.ToolChoice = ""
-		toolMessages := executeTools(ctx, result.ToolCalls, toolMap, step, o.OnToolCall)
-		params.Messages = appendToolRoundTrip(params.Messages, result, toolMessages)
+		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, o.OnToolCallStart, o.OnToolCall)
+		params.Messages = appendToolRoundTrip(params.Messages, result.Text, result.ToolCalls, toolMessages)
 	}
 
 	// MaxSteps exhausted with tool calls still pending — no structured output produced.

--- a/object_test.go
+++ b/object_test.go
@@ -1840,3 +1840,70 @@ func TestStreamObject_ProviderMetadata_BothConventions(t *testing.T) {
 		t.Error("providerMetadata key should not leak into Response.ProviderMetadata")
 	}
 }
+
+// TestGenerateObject_ToolLoop_OnToolCallStart verifies that OnToolCallStart fires
+// before tool execution in GenerateObject's tool loop with correct metadata.
+func TestGenerateObject_ToolLoop_OnToolCallStart(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					FinishReason: provider.FinishToolCalls,
+					ToolCalls: []provider.ToolCall{
+						{ID: "tc1", Name: "get_weather", Input: json.RawMessage(`{"city":"NYC"}`)},
+					},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         `{"name":"Alice","age":30}`,
+				FinishReason: provider.FinishStop,
+			}, nil
+		},
+	}
+
+	var startInfos []ToolCallStartInfo
+	toolExecuted := false
+
+	_, err := GenerateObject[simpleObject](t.Context(), model,
+		WithPrompt("weather then generate"),
+		WithMaxSteps(3),
+		WithOnToolCallStart(func(info ToolCallStartInfo) {
+			if toolExecuted {
+				t.Error("OnToolCallStart fired after tool execution")
+			}
+			startInfos = append(startInfos, info)
+		}),
+		WithTools(Tool{
+			Name:        "get_weather",
+			Description: "get weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				toolExecuted = true
+				return `{"temp":72}`, nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(startInfos) != 1 {
+		t.Fatalf("OnToolCallStart called %d times, want 1", len(startInfos))
+	}
+	info := startInfos[0]
+	if info.ToolCallID != "tc1" {
+		t.Errorf("ToolCallID = %q, want tc1", info.ToolCallID)
+	}
+	if info.ToolName != "get_weather" {
+		t.Errorf("ToolName = %q, want get_weather", info.ToolName)
+	}
+	if info.Step != 1 {
+		t.Errorf("Step = %d, want 1", info.Step)
+	}
+	if string(info.Input) != `{"city":"NYC"}` {
+		t.Errorf("Input = %s, want {\"city\":\"NYC\"}", info.Input)
+	}
+}

--- a/observability/langfuse/langfuse.go
+++ b/observability/langfuse/langfuse.go
@@ -141,6 +141,8 @@ func (h *Hooks) Run() []goai.Option {
 	// end is declared before opts so WithOnStepFinish can reference it.
 	var end func(result any)
 
+	// OnToolCallStart is intentionally not registered here because
+	// OnToolCall.StartTime already provides accurate timing for tool spans.
 	opts := []goai.Option{
 		goai.WithOnRequest(func(info goai.RequestInfo) {
 			input := messagesToInput(info.Messages)

--- a/observability/langfuse/langfuse_test.go
+++ b/observability/langfuse/langfuse_test.go
@@ -18,17 +18,31 @@ import (
 type mockModel struct {
 	id         string
 	generateFn func(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error)
+	streamFn   func(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error)
 }
 
 func (m *mockModel) ModelID() string { return m.id }
 func (m *mockModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
 	return m.generateFn(ctx, params)
 }
-func (m *mockModel) DoStream(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+func (m *mockModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+	if m.streamFn != nil {
+		return m.streamFn(ctx, params)
+	}
 	return nil, nil
 }
 func (m *mockModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{}
+}
+
+// streamFromChunks creates a StreamResult from pre-built chunks.
+func streamFromChunks(chunks ...provider.StreamChunk) *provider.StreamResult {
+	ch := make(chan provider.StreamChunk, len(chunks))
+	for _, c := range chunks {
+		ch <- c
+	}
+	close(ch)
+	return &provider.StreamResult{Stream: ch}
 }
 
 // newCaptureServer starts an httptest.Server that captures all ingestion events.
@@ -1062,5 +1076,161 @@ func TestRun_BaseURLEnvVar(t *testing.T) {
 
 	if len(getEvents()) == 0 {
 		t.Error("no events received - LANGFUSE_BASE_URL fallback did not work")
+	}
+}
+
+func TestStreamText_SingleStep(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	h := newHooks(t, srv, Config{TraceName: "stream-single"})
+
+	model := &mockModel{
+		id: "gpt-4o",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hello"},
+				provider.StreamChunk{Type: provider.ChunkText, Text: " world"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+			), nil
+		},
+	}
+
+	stream, err := goai.StreamText(t.Context(), model, append(h.Run(), goai.WithPrompt("hi"))...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain stream.
+	for range stream.TextStream() {
+	}
+	if stream.Err() != nil {
+		t.Fatal(stream.Err())
+	}
+
+	events := getEvents()
+	if len(events) != 3 {
+		t.Fatalf("event count = %d, want 3; types: %v", len(events), eventTypes(events))
+	}
+
+	counts := map[string]int{}
+	for _, tp := range eventTypes(events) {
+		counts[tp]++
+	}
+	if counts[eventTrace] != 1 {
+		t.Errorf("trace events = %d, want 1", counts[eventTrace])
+	}
+	if counts[eventSpan] != 1 {
+		t.Errorf("span events = %d, want 1", counts[eventSpan])
+	}
+	if counts[eventGeneration] != 1 {
+		t.Errorf("generation events = %d, want 1", counts[eventGeneration])
+	}
+
+	genBody := bodyOf(t, events, eventGeneration)
+	if genBody["model"] != "gpt-4o" {
+		t.Errorf("generation model = %q, want %q", genBody["model"], "gpt-4o")
+	}
+	usage, ok := genBody["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("generation usage missing or wrong type: %T", genBody["usage"])
+	}
+	if usage["input"] != float64(10) {
+		t.Errorf("usage.input = %v, want 10", usage["input"])
+	}
+	if usage["output"] != float64(5) {
+		t.Errorf("usage.output = %v, want 5", usage["output"])
+	}
+}
+
+func TestStreamText_MultiStep_WithToolCalls(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	h := newHooks(t, srv, Config{TraceName: "stream-multi-step"})
+
+	callCount := 0
+	model := &mockModel{
+		id: "gpt-4o",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			callCount++
+			if callCount == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "calling tool"},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "my_tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 8}},
+			), nil
+		},
+	}
+
+	opts := append(h.Run(),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(goai.Tool{
+			Name:    "my_tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "tool result", nil },
+		}),
+	)
+	stream, err := goai.StreamText(t.Context(), model, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain stream.
+	for range stream.TextStream() {
+	}
+	if stream.Err() != nil {
+		t.Fatal(stream.Err())
+	}
+
+	events := getEvents()
+	// Expect: trace-create, span-create (agent), generation-create (step-1),
+	// span-create (tool), generation-create (step-2) = 5 events.
+	if len(events) != 5 {
+		t.Fatalf("event count = %d, want 5; types: %v", len(events), eventTypes(events))
+	}
+
+	counts := map[string]int{}
+	for _, tp := range eventTypes(events) {
+		counts[tp]++
+	}
+	if counts[eventTrace] != 1 {
+		t.Errorf("trace events = %d, want 1", counts[eventTrace])
+	}
+	if counts[eventSpan] != 2 {
+		t.Errorf("span events = %d, want 2 (agent span + tool span)", counts[eventSpan])
+	}
+	if counts[eventGeneration] != 2 {
+		t.Errorf("generation events = %d, want 2", counts[eventGeneration])
+	}
+
+	// Find tool span.
+	var toolSpan map[string]any
+	for _, e := range events {
+		if e["type"] == eventSpan {
+			b, ok := e["body"].(map[string]any)
+			if !ok {
+				continue
+			}
+			if b["name"] == "my_tool" {
+				toolSpan = b
+				break
+			}
+		}
+	}
+	if toolSpan == nil {
+		t.Fatal("tool span not found")
+	}
+	if toolSpan["name"] != "my_tool" {
+		t.Errorf("tool span name = %q, want %q", toolSpan["name"], "my_tool")
+	}
+
+	// Verify trace output.
+	traceBody := bodyOf(t, events, eventTrace)
+	if traceBody["name"] != "stream-multi-step" {
+		t.Errorf("trace name = %q, want %q", traceBody["name"], "stream-multi-step")
 	}
 }

--- a/options.go
+++ b/options.go
@@ -82,6 +82,9 @@ type options struct {
 	// OnToolCall is called after each tool execution.
 	OnToolCall func(ToolCallInfo)
 
+	// OnToolCallStart is called before each tool execution.
+	OnToolCallStart func(ToolCallStartInfo)
+
 	// ExplicitSchema overrides auto-generated JSON Schema for GenerateObject/StreamObject.
 	ExplicitSchema json.RawMessage
 

--- a/types.go
+++ b/types.go
@@ -28,5 +28,8 @@ type Tool struct {
 	ProviderDefinedOptions map[string]any
 
 	// Execute runs the tool with the given JSON input and returns the result text.
+	// Both the return value and error string are forwarded to the model as a tool
+	// result message. Do not include sensitive data (credentials, internal paths)
+	// in error messages as they will be sent to the LLM provider's API.
 	Execute func(ctx context.Context, input json.RawMessage) (string, error)
 }


### PR DESCRIPTION
## Summary
- StreamText now supports multi-step tool loops via `WithMaxSteps`, matching GenerateText behavior
- `executeToolsParallel` replaces sequential `executeTools` with goroutine-per-tool parallel execution, panic recovery, and `OnToolCallStart`/`OnToolCall` hooks
- New `WithOnToolCallStart` hook fires before each tool execution for real-time observability
- Langfuse integration updated for streaming multi-step scenarios

## Test plan
- [x] 25 new test functions covering all tool loop paths (two-step, max steps, parallel, context cancel, hook ordering, panic recovery, retry, reasoning exclusion, unknown tool, etc.)
- [x] 94.6% statement coverage (target: 90%)
- [x] Race detector clean (`go test . -race`)
- [x] All 30 packages pass (`go test ./...`)
- [x] Zero lint issues (`golangci-lint run .`)
- [x] Backward compatible: single-step StreamText (MaxSteps=1) behavior unchanged