### PR TITLE
fix: normalize finish_reason when tool calls present, add ToolCallIDFromContext

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -18,6 +18,19 @@ import (
 // ErrUnknownTool is returned when a tool call references a tool not in the tool map.
 var ErrUnknownTool = errors.New("goai: unknown tool")
 
+// toolCallIDKey is the context key for the current tool call ID.
+type toolCallIDKey struct{}
+
+// ToolCallIDFromContext returns the tool call ID from the context.
+// This is available inside a Tool's Execute function to identify which
+// tool call is being executed.
+func ToolCallIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(toolCallIDKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
 // TextResult is the final result of a text generation call.
 type TextResult struct {
 	// Text is the accumulated generated text across all steps.
@@ -645,6 +658,13 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				}(fn)
 			}
 
+			// Normalize: providers that send empty/wrong finish_reason with tool calls
+			// (MiniMax, Azure MaaS deepseek, etc.) would cause the loop to exit early.
+			// The presence of tool calls is authoritative.
+			if len(ds.toolCalls) > 0 && ds.finishReason != provider.FinishToolCalls {
+				ds.finishReason = provider.FinishToolCalls
+			}
+
 			// --- Emit ChunkStepFinish ---
 			// Set Response directly on the chunk (StreamChunk.Response is a plain struct
 			// field with no restriction on who sets it). ProviderMetadata goes in Metadata
@@ -850,6 +870,13 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// This allows callers to provide tool definitions for the model's awareness
 		// without requiring executable tools.
 		// No empty-step guard needed (unlike streaming): DoGenerate returns content or error.
+		// Normalize: providers that send empty/wrong finish_reason with tool calls
+		// (MiniMax, Azure MaaS deepseek, etc.) would cause the loop to exit early.
+		// The presence of tool calls is authoritative.
+		if len(result.ToolCalls) > 0 && result.FinishReason != provider.FinishToolCalls {
+			result.FinishReason = provider.FinishToolCalls
+		}
+
 		if result.FinishReason != provider.FinishToolCalls || len(result.ToolCalls) == 0 || len(toolMap) == 0 {
 			return buildTextResult(steps, totalUsage), nil
 		}
@@ -1014,7 +1041,8 @@ func executeToolsParallel(
 			}
 
 			start := time.Now()
-			output, err := tool.Execute(ctx, tc.Input)
+			toolCtx := context.WithValue(ctx, toolCallIDKey{}, tc.ID)
+			output, err := tool.Execute(toolCtx, tc.Input)
 			executed = true
 			results[i] = toolOutput{index: i, result: output, err: err}
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -4469,3 +4469,226 @@ func TestStreamText_ToolLoop_OnStepFinishPanic(t *testing.T) {
 		t.Errorf("Text = %q, want containing 'final'", result.Text)
 	}
 }
+
+// TestGenerateText_ToolLoop_EmptyFinishReason verifies that tool calls with
+// empty finish_reason (common in MiniMax, Azure MaaS deepseek) are still executed.
+func TestGenerateText_ToolLoop_EmptyFinishReason(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls: []provider.ToolCall{{
+						ID:    "tc1",
+						Name:  "get_weather",
+						Input: json.RawMessage(`{"city":"NYC"}`),
+					}},
+					FinishReason: "", // Bug: provider sends empty instead of "tool-calls"
+					Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "Sunny in NYC",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 20, OutputTokens: 10},
+			}, nil
+		},
+	}
+
+	toolExecuted := false
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("weather?"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:        "get_weather",
+			Description: "Get weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			Execute: func(_ context.Context, input json.RawMessage) (string, error) {
+				toolExecuted = true
+				return "Sunny", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !toolExecuted {
+		t.Error("tool was not executed despite tool calls being present")
+	}
+	if callCount != 2 {
+		t.Errorf("model called %d times, want 2", callCount)
+	}
+	if result.Text != "Sunny in NYC" {
+		t.Errorf("Text = %q, want %q", result.Text, "Sunny in NYC")
+	}
+}
+
+// TestGenerateText_ToolLoop_StopFinishReason verifies that tool calls with
+// finish_reason="stop" (instead of "tool-calls") are still executed.
+func TestGenerateText_ToolLoop_StopFinishReason(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls: []provider.ToolCall{{
+						ID:    "tc1",
+						Name:  "get_weather",
+						Input: json.RawMessage(`{"city":"NYC"}`),
+					}},
+					FinishReason: provider.FinishStop, // Bug: provider sends "stop" instead of "tool-calls"
+					Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "Done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 20, OutputTokens: 10},
+			}, nil
+		},
+	}
+
+	toolExecuted := false
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("weather?"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:        "get_weather",
+			Description: "Get weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			Execute: func(_ context.Context, input json.RawMessage) (string, error) {
+				toolExecuted = true
+				return "Sunny", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !toolExecuted {
+		t.Error("tool was not executed despite tool calls being present")
+	}
+	if callCount != 2 {
+		t.Errorf("model called %d times, want 2", callCount)
+	}
+	if result.Text != "Done" {
+		t.Errorf("Text = %q", result.Text)
+	}
+}
+
+// TestStreamText_ToolLoop_EmptyFinishReason verifies that streaming tool calls
+// with empty finish_reason are still executed.
+func TestStreamText_ToolLoop_EmptyFinishReason(t *testing.T) {
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test-stream",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: "Looking up..."},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "get_weather", ToolInput: `{"city":"NYC"}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: "", Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}}, // empty finish_reason
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "Sunny in NYC"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 20, OutputTokens: 8}},
+			), nil
+		},
+	}
+
+	toolExecuted := false
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("weather?"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:        "get_weather",
+			Description: "Get weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+			Execute: func(_ context.Context, input json.RawMessage) (string, error) {
+				toolExecuted = true
+				return "Sunny", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for range stream.Stream() {
+	}
+
+	if !toolExecuted {
+		t.Error("tool was not executed despite tool calls being present in stream")
+	}
+	result := stream.Result()
+	if len(result.Steps) != 2 {
+		t.Fatalf("Steps = %d, want 2", len(result.Steps))
+	}
+	if !strings.Contains(result.Text, "Sunny in NYC") {
+		t.Errorf("Text = %q, want containing %q", result.Text, "Sunny in NYC")
+	}
+}
+
+// TestToolCallIDFromContext verifies that the tool call ID is available
+// inside the Execute function via ToolCallIDFromContext.
+func TestToolCallIDFromContext(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls: []provider.ToolCall{{
+						ID:    "call_abc123",
+						Name:  "my_tool",
+						Input: json.RawMessage(`{}`),
+					}},
+					FinishReason: provider.FinishToolCalls,
+					Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "Done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 20, OutputTokens: 10},
+			}, nil
+		},
+	}
+
+	var capturedID string
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("test"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:        "my_tool",
+			Description: "A test tool",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Execute: func(ctx context.Context, _ json.RawMessage) (string, error) {
+				capturedID = ToolCallIDFromContext(ctx)
+				return "ok", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedID != "call_abc123" {
+		t.Errorf("ToolCallIDFromContext = %q, want %q", capturedID, "call_abc123")
+	}
+}
+
+// TestToolCallIDFromContext_Empty verifies that ToolCallIDFromContext
+// returns empty string when called outside of tool execution.
+func TestToolCallIDFromContext_Empty(t *testing.T) {
+	id := ToolCallIDFromContext(t.Context())
+	if id != "" {
+		t.Errorf("ToolCallIDFromContext = %q, want empty", id)
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize `finishReason` to `FinishToolCalls` when tool calls are present, regardless of what the provider sent (fixes MiniMax, Azure MaaS deepseek, and other OpenAI-compat providers that send empty or "stop" finish_reason with tool calls)
- Add `ToolCallIDFromContext(ctx)` so tool `Execute` functions can identify which tool call is being executed
- Normalization happens before `ChunkStepFinish` emission so stream consumers also see the correct finish reason

## Test plan
- [x] `TestGenerateText_ToolLoop_EmptyFinishReason` — empty finish_reason with tool calls
- [x] `TestGenerateText_ToolLoop_StopFinishReason` — "stop" finish_reason with tool calls
- [x] `TestStreamText_ToolLoop_EmptyFinishReason` — streaming variant
- [x] `TestToolCallIDFromContext` — verifies ID available inside Execute
- [x] `TestToolCallIDFromContext_Empty` — returns "" outside tool execution
- [x] Full test suite passes, coverage thresholds met