### PR TITLE
fix(azure,google,openai): multi-endpoint routing, ToolCall metadata, retryable errors

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -287,7 +287,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 			}
 
 		case provider.ChunkToolCall:
-			tc := provider.ToolCall{ID: chunk.ToolCallID, Name: chunk.ToolName, Input: json.RawMessage(chunk.ToolInput)}
+			tc := provider.ToolCall{ID: chunk.ToolCallID, Name: chunk.ToolName, Input: json.RawMessage(chunk.ToolInput), Metadata: chunk.Metadata}
 			ts.toolCalls = append(ts.toolCalls, tc)
 			ts.stepToolCalls = append(ts.stepToolCalls, tc)
 
@@ -1113,10 +1113,11 @@ func appendToolRoundTrip(
 	}
 	for _, tc := range toolCalls {
 		parts = append(parts, provider.Part{
-			Type:       provider.PartToolCall,
-			ToolCallID: tc.ID,
-			ToolName:   tc.Name,
-			ToolInput:  tc.Input,
+			Type:            provider.PartToolCall,
+			ToolCallID:      tc.ID,
+			ToolName:        tc.Name,
+			ToolInput:       tc.Input,
+			ProviderOptions: tc.Metadata,
 		})
 	}
 	msgs = append(msgs, provider.Message{Role: provider.RoleAssistant, Content: parts})
@@ -1211,9 +1212,10 @@ func drainStep(
 			}
 		case provider.ChunkToolCall:
 			dr.toolCalls = append(dr.toolCalls, provider.ToolCall{
-				ID:    chunk.ToolCallID,
-				Name:  chunk.ToolName,
-				Input: json.RawMessage(chunk.ToolInput),
+				ID:       chunk.ToolCallID,
+				Name:     chunk.ToolName,
+				Input:    json.RawMessage(chunk.ToolInput),
+				Metadata: chunk.Metadata,
 			})
 		case provider.ChunkStepFinish:
 			// Provider-internal step boundary (e.g., Anthropic extended thinking).

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -33,7 +33,7 @@ var (
 	_ provider.CapableModel  = (*chatCompletionsModel)(nil)
 )
 
-const defaultAPIVersion = "v1"
+const defaultAPIVersion = "2025-03-01-preview"
 
 // Option configures the Azure OpenAI provider.
 type Option func(*options)
@@ -84,7 +84,7 @@ func WithHTTPClient(c *http.Client) Option {
 }
 
 // WithAPIVersion sets the Azure OpenAI API version used in the api-version
-// query parameter. Defaults to "v1". Matches Vercel AI SDK's apiVersion option.
+// query parameter. Defaults to "2025-03-01-preview".
 func WithAPIVersion(v string) Option {
 	return func(o *options) {
 		o.apiVersion = v
@@ -177,6 +177,13 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 		return buildAIServicesModel(&o, modelID)
 	}
 
+	// Codex and pro model variants only work via Responses API on the
+	// cognitiveservices endpoint (deployment-based Chat Completions returns
+	// "unsupported operation"). Route them separately.
+	if o.useDeploymentBasedURLs && isResponsesOnlyModel(modelID) {
+		return buildCognitiveServicesModel(&o, modelID)
+	}
+
 	httpClient := buildHTTPClient(&o, modelID)
 
 	// Delegate to openai.Chat which handles Chat Completions vs Responses API routing.
@@ -189,7 +196,15 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 		openai.WithBaseURL("https://azure-placeholder"),
 	}
 
-	return openai.Chat(modelID, openaiOpts...)
+	model := openai.Chat(modelID, openaiOpts...)
+
+	// Deployment-based URLs don't support the Responses API on most Azure
+	// resources (returns 404). Force Chat Completions to avoid silent failures.
+	if o.useDeploymentBasedURLs {
+		return &chatCompletionsModel{inner: model}
+	}
+
+	return model
 }
 
 // isOpenAIModel returns true if the model ID is an OpenAI-native model
@@ -251,6 +266,9 @@ func forceChatCompletions(params *provider.GenerateParams) {
 		newOpts = make(map[string]any, 1)
 	}
 	newOpts["useResponsesAPI"] = false
+	// Strip Responses-API-only parameters that Chat Completions rejects.
+	delete(newOpts, "reasoning_summary")
+	delete(newOpts, "text_verbosity")
 	params.ProviderOptions = newOpts
 }
 
@@ -325,6 +343,43 @@ func buildAIServicesModel(o *options, modelID string) provider.LanguageModel {
 
 	model := openai.Chat(modelID, openaiOpts...)
 	return &chatCompletionsModel{inner: model}
+}
+
+// isResponsesOnlyModel returns true for Azure model variants that only work via
+// the Responses API on cognitiveservices.azure.com. These models return
+// "unsupported operation" on deployment-based Chat Completions.
+func isResponsesOnlyModel(modelID string) bool {
+	id := strings.ToLower(modelID)
+	return strings.Contains(id, "-codex") || strings.HasSuffix(id, "-pro")
+}
+
+// cognitiveServicesAPIVersion is used for the cognitiveservices.azure.com Responses API.
+const cognitiveServicesAPIVersion = "2025-04-01-preview"
+
+// buildCognitiveServicesModel creates an OpenAI model pointing at the Azure
+// Cognitive Services endpoint: https://{resource}.cognitiveservices.azure.com/openai
+// Codex/pro models only support Responses API, not Chat Completions.
+func buildCognitiveServicesModel(o *options, modelID string) provider.LanguageModel {
+	resourceName := extractResourceName(o)
+	baseURL := fmt.Sprintf("https://%s.cognitiveservices.azure.com/openai", resourceName)
+
+	baseTransport := http.DefaultTransport
+	if o.httpClient != nil && o.httpClient.Transport != nil {
+		baseTransport = o.httpClient.Transport
+	}
+
+	transport := &aiServicesRoundTripper{
+		base:        baseTransport,
+		apiKey:      o.apiKey,
+		tokenSource: o.tokenSource,
+		headers:     o.headers,
+		apiVersion:  cognitiveServicesAPIVersion,
+	}
+
+	httpClient := &http.Client{Transport: transport}
+
+	// openai.Chat defaults to Responses API which is what codex/pro models need.
+	return openai.Chat(modelID, openai.WithHTTPClient(httpClient), openai.WithAPIKey("azure-delegated"), openai.WithBaseURL(baseURL))
 }
 
 // aiServicesRoundTripper injects Azure auth headers and api-version query parameter

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -1226,3 +1226,110 @@ func TestChat_PromptCachingIgnored(t *testing.T) {
 		t.Errorf("DoStream texts = %v, want [ok]", texts)
 	}
 }
+
+// TestCognitiveServicesModel_CodexRouting verifies codex/pro models route
+// to cognitiveservices.azure.com via Responses API when deployment-based URLs enabled.
+func TestCognitiveServicesModel_CodexRouting(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, okResponsesJSON)
+	}))
+	defer server.Close()
+
+	models := []string{"gpt-5-codex", "gpt-5.2-codex", "gpt-5-pro", "gpt-5.4-pro"}
+	for _, modelID := range models {
+		t.Run(modelID, func(t *testing.T) {
+			t.Setenv("AZURE_RESOURCE_NAME", "testresource")
+			// Override endpoint via env so buildCognitiveServicesModel resolves correctly.
+			// We use WithEndpoint to provide the test server URL, but cognitiveservices
+			// builds its own URL from resource name. To intercept, we patch via httpClient.
+			model := Chat(modelID,
+				WithAPIKey("k"),
+				WithDeploymentBasedURLs(true),
+				WithHTTPClient(&http.Client{Transport: &rewriteTransport{target: server.URL}}),
+			)
+			_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+				Messages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Responses API path: /responses (not /chat/completions, not /deployments/...)
+			if !strings.Contains(capturedPath, "/responses") {
+				t.Errorf("expected Responses API path, got %s", capturedPath)
+			}
+		})
+	}
+}
+
+// TestCognitiveServicesModel_NonCodexNotRouted verifies non-codex OpenAI models
+// use deployment-based Chat Completions, not cognitiveservices.
+func TestCognitiveServicesModel_NonCodexNotRouted(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, okChatJSON)
+	}))
+	defer server.Close()
+
+	for _, modelID := range []string{"gpt-4.1", "gpt-5.4", "o3"} {
+		t.Run(modelID, func(t *testing.T) {
+			model := Chat(modelID, WithAPIKey("k"), WithEndpoint(server.URL), WithDeploymentBasedURLs(true))
+			_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+				Messages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Should use deployment-based Chat Completions path
+			if strings.Contains(capturedPath, "/responses") {
+				t.Errorf("expected Chat Completions path, got %s (Responses API should not be used for %s)", capturedPath, modelID)
+			}
+		})
+	}
+}
+
+// TestIsResponsesOnlyModel verifies the detection logic.
+func TestIsResponsesOnlyModel(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"gpt-5-codex", true},
+		{"gpt-5.2-codex", true},
+		{"gpt-5-pro", true},
+		{"gpt-5.4-pro", true},
+		{"gpt-4.1", false},
+		{"gpt-5.4", false},
+		{"o3", false},
+		{"codex-mini", false}, // codex CLI model, not -codex suffix
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := isResponsesOnlyModel(tt.id); got != tt.want {
+				t.Errorf("isResponsesOnlyModel(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+// rewriteTransport rewrites all request URLs to a target server for testing.
+type rewriteTransport struct {
+	target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	newReq := req.Clone(req.Context())
+	parsed, _ := req.URL.Parse(t.target + req.URL.Path)
+	parsed.RawQuery = req.URL.RawQuery
+	newReq.URL = parsed
+	newReq.Host = parsed.Host
+	return http.DefaultTransport.RoundTrip(newReq)
+}

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -366,7 +366,7 @@ func TestAzureURLRewrite(t *testing.T) {
 	if capturedPath != "/openai/v1/responses" {
 		t.Errorf("path = %s, want /openai/v1/responses", capturedPath)
 	}
-	if !strings.Contains(capturedQuery, "api-version=v1") {
+	if !strings.Contains(capturedQuery, "api-version=2025-03-01-preview") {
 		t.Errorf("query = %s", capturedQuery)
 	}
 }
@@ -536,7 +536,7 @@ func TestWithAPIVersion_Default(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// No WithAPIVersion -- should default to "v1".
+	// No WithAPIVersion -- should default to "2025-03-01-preview".
 	model := Chat("gpt-4o", WithAPIKey("k"), WithEndpoint(server.URL))
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
@@ -546,8 +546,8 @@ func TestWithAPIVersion_Default(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(capturedQuery, "api-version=v1") {
-		t.Errorf("query = %s, want api-version=v1", capturedQuery)
+	if !strings.Contains(capturedQuery, "api-version=2025-03-01-preview") {
+		t.Errorf("query = %s, want api-version=2025-03-01-preview", capturedQuery)
 	}
 }
 

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -828,11 +828,19 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 		if part.FunctionCall != nil {
 			callID := fmt.Sprintf("call_%s_%d", part.FunctionCall.Name, callIndex)
 			callIndex++
-			result.ToolCalls = append(result.ToolCalls, provider.ToolCall{
+			tc := provider.ToolCall{
 				ID:    callID,
 				Name:  part.FunctionCall.Name,
 				Input: part.FunctionCall.Args,
-			})
+			}
+			if part.ThoughtSignature != "" {
+				tc.Metadata = map[string]any{
+					"google": map[string]any{
+						"thoughtSignature": part.ThoughtSignature,
+					},
+				}
+			}
+			result.ToolCalls = append(result.ToolCalls, tc)
 		} else if !part.Thought && part.Text != "" {
 			textParts = append(textParts, part.Text)
 		}

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -460,6 +460,44 @@ func TestChat_Generate_ToolCall(t *testing.T) {
 	}
 }
 
+func TestChat_Generate_ToolCallWithThoughtSignature(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"candidates":[{"content":{"parts":[
+				{"functionCall":{"name":"bash","args":{"cmd":"ls"}},"thoughtSignature":"sig_abc123"}
+			]},"finishReason":"STOP"}],
+			"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}
+		}`)
+	}))
+	defer server.Close()
+
+	model := Chat("gemini-2.5-flash", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "run"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	tc := result.ToolCalls[0]
+	if tc.Metadata == nil {
+		t.Fatal("ToolCall.Metadata is nil, expected thoughtSignature")
+	}
+	google, ok := tc.Metadata["google"].(map[string]any)
+	if !ok {
+		t.Fatalf("Metadata[google] type = %T, want map[string]any", tc.Metadata["google"])
+	}
+	if sig, ok := google["thoughtSignature"].(string); !ok || sig != "sig_abc123" {
+		t.Errorf("thoughtSignature = %v, want sig_abc123", google["thoughtSignature"])
+	}
+}
+
 func TestChat_Generate_ErrorResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -1543,6 +1543,42 @@ func TestStreamResponses_ServerErrorRetryable(t *testing.T) {
 	t.Error("expected retryable APIError for server_error")
 }
 
+func TestStreamResponses_NumericCodeRetryable(t *testing.T) {
+	for _, code := range []string{"429", "500", "502", "503"} {
+		t.Run(code, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = fmt.Fprint(w, "event: response.failed\n")
+				_, _ = fmt.Fprintf(w, `data: {"response":{"error":{"message":"err","code":"%s"}}}`+"\n\n", code)
+			}))
+			defer server.Close()
+
+			model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+			result, err := model.DoStream(t.Context(), provider.GenerateParams{
+				Messages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for chunk := range result.Stream {
+				if chunk.Type == provider.ChunkError {
+					var apiErr *goai.APIError
+					if errors.As(chunk.Error, &apiErr) {
+						if !apiErr.IsRetryable {
+							t.Errorf("code %s should be retryable", code)
+						}
+						return
+					}
+				}
+			}
+			t.Errorf("expected retryable error for code %s", code)
+		})
+	}
+}
+
 func TestStreamResponses_ErrorEmptyMessage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -1476,6 +1476,73 @@ func TestStreamResponses_FailedEmptyMessage(t *testing.T) {
 	}
 }
 
+func TestStreamResponses_RateLimitRetryable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.failed\n")
+		_, _ = fmt.Fprint(w, `data: {"response":{"error":{"message":"rate limited","code":"rate_limit_exceeded"}}}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
+				if !apiErr.IsRetryable {
+					t.Error("rate_limit_exceeded should be retryable")
+				}
+				if apiErr.StatusCode != 429 {
+					t.Errorf("expected StatusCode=429, got %d", apiErr.StatusCode)
+				}
+				return
+			}
+		}
+	}
+	t.Error("expected retryable APIError for rate_limit_exceeded")
+}
+
+func TestStreamResponses_ServerErrorRetryable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.failed\n")
+		_, _ = fmt.Fprint(w, `data: {"response":{"error":{"message":"internal error","code":"server_error"}}}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
+				if !apiErr.IsRetryable {
+					t.Error("server_error should be retryable")
+				}
+				return
+			}
+		}
+	}
+	t.Error("expected retryable APIError for server_error")
+}
+
 func TestStreamResponses_ErrorEmptyMessage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -713,6 +713,20 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 					}) {
 						return
 					}
+				case "rate_limit_exceeded", "429":
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type:  provider.ChunkError,
+						Error: &goai.APIError{Message: msg, StatusCode: 429, IsRetryable: true},
+					}) {
+						return
+					}
+				case "server_error", "503", "502", "500":
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type:  provider.ChunkError,
+						Error: &goai.APIError{Message: msg, IsRetryable: true},
+					}) {
+						return
+					}
 				default:
 					if !provider.TrySend(ctx, out, provider.StreamChunk{
 						Type:  provider.ChunkError,

--- a/provider/types.go
+++ b/provider/types.go
@@ -289,6 +289,10 @@ type ToolCall struct {
 
 	// Input is the JSON-encoded arguments.
 	Input json.RawMessage
+
+	// Metadata carries provider-specific data that must be preserved across
+	// tool round-trips (e.g., Google's thoughtSignature).
+	Metadata map[string]any
 }
 
 // Usage tracks token consumption for a request.


### PR DESCRIPTION
## Summary
- **Azure**: Fix api-version, deployment-based Chat Completions, cognitiveservices Responses API for codex/pro models, strip unsupported params
- **Google**: Preserve thoughtSignature per ToolCall in non-streaming path
- **OpenAI**: Mark rate_limit/server errors as retryable in Responses API response.failed handler
- **Core**: Add `Metadata` to `ToolCall` struct, carry through tool loop for provider round-trip data (e.g. Gemini thoughtSignature)

## Test plan
- [x] All existing tests pass (90%+ coverage gate)
- [x] PTY tests: azure/gpt-4.1, azure/gpt-5.4, azure/gpt-5.2-codex, azure/grok-3
- [x] PTY test: google/gemini-2.5-flash tool calls (no thought_signature error)
- [x] Curl verified: 17 Azure deployments (9 chat, 4 codex, 4 pro)