### PR TITLE
feat: add lifecycle hooks for tool interception and loop control

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -265,8 +265,10 @@ func WithProviderOptions(opts map[string]any) Option
 
 > **Panic handling:** Hooks use two panic strategies depending on execution context:
 >
-> - **Caller goroutine** (`OnRequest`, `OnResponse`): panics propagate to the caller (not recovered).
+> - **Caller goroutine** (`OnRequest`): panics always propagate to the caller (not recovered).
+> - **Mixed** (`OnResponse`): recovered in `GenerateText` and background goroutines; propagates in `GenerateObject`, `StreamObject` error path, and `StreamText` first-step error path. See per-hook docs below.
 > - **Worker goroutines** (`OnStepFinish`, `OnToolCallStart`, `OnToolCall`): panics are recovered, logged to stderr, and do not propagate.
+> - **Interceptor hooks** (`OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep`): always panic-recovered with hook-specific behavior (skip tool, preserve result, or proceed normally).
 
 ### WithOnRequest
 
@@ -290,7 +292,7 @@ func WithOnResponse(fn func(ResponseInfo)) Option
 
 **Default:** `nil`.
 
-> **Panic behavior:** Panics in `OnResponse` callbacks propagate to the caller and are not recovered.
+> **Panic behavior:** In `GenerateText`, all `StreamText` success paths, and `StreamObject` (success path), panics are individually recovered and logged to stderr. In `GenerateObject`, `StreamObject` (error path), and `StreamText`'s first-step error path, panics propagate to the caller.
 
 ### WithOnStepFinish
 
@@ -329,6 +331,41 @@ func WithOnToolCall(fn func(ToolCallInfo)) Option
 > **Note:** When multiple tools execute in a single step, OnToolCall callbacks fire concurrently from separate goroutines. Order is non-deterministic.
 
 > **Panic behavior:** Panics are recovered and logged to stderr.
+
+### WithOnBeforeToolExecute
+
+```go
+goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+    // Return Skip: true to prevent tool execution
+    return goai.BeforeToolExecuteResult{}
+})
+```
+
+Called before each tool's Execute function. Can skip execution for permission checks, rate limiting, or doom-loop detection. Only one callback supported (replaces previous). Panic-recovered: a panic skips the tool with an error result.
+
+### WithOnAfterToolExecute
+
+```go
+goai.WithOnAfterToolExecute(func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+    // Return modified Output to transform tool results
+    return goai.AfterToolExecuteResult{}
+})
+```
+
+Called after each tool's Execute function, before the result is sent to the LLM. Can modify output for secret scanning, truncation, or transformation. Only one callback supported. Panic-recovered: preserves original result.
+
+### WithOnBeforeStep
+
+```go
+goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+    // Return ExtraMessages to inject, or Stop: true to end loop
+    return goai.BeforeStepResult{}
+})
+```
+
+Called before each LLM call in a multi-step tool loop (step 2+ only, not step 1). Can inject additional messages or stop the loop early. Only one callback supported. Panic-recovered: a panic is logged and the step proceeds normally.
+
+> **Panic handling note:** Interceptor hooks (`OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep`): always panic-recovered with hook-specific behavior (skip tool, preserve result, or proceed normally).
 
 ---
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -205,6 +205,7 @@ Passed to the `OnRequest` hook before a generation call.
 
 ```go
 type RequestInfo struct {
+    Ctx          context.Context    // Caller's context (for span parenting in observability hooks).
     Model        string             // Model ID.
     MessageCount int                // Number of messages in the request.
     ToolCount    int                // Number of tools available.
@@ -241,6 +242,7 @@ type ToolCallInfo struct {
     OutputObject any             // Parsed JSON value of Output when the tool returned valid JSON; nil otherwise.
     StartTime    time.Time       // When the tool execution began.
     Duration     time.Duration   // How long execution took.
+    Skipped      bool            // True when execution was skipped by OnBeforeToolExecute.
     Error        error           // Non-nil if execution failed.
 }
 ```
@@ -255,6 +257,79 @@ type ToolCallStartInfo struct {
     ToolName   string          // Name of the tool called.
     Step       int             // 1-based index of the generation step in which this tool was called.
     Input      json.RawMessage // Raw JSON arguments passed to the tool.
+}
+```
+
+### BeforeToolExecuteInfo
+
+Passed to the `OnBeforeToolExecute` hook before a tool's Execute function runs.
+
+```go
+type BeforeToolExecuteInfo struct {
+    ToolCallID string          // Provider-assigned identifier.
+    ToolName   string          // Name of the tool about to execute.
+    Step       int             // 1-based step index.
+    Input      json.RawMessage // Raw JSON arguments.
+}
+```
+
+### BeforeToolExecuteResult
+
+Controls what happens after `OnBeforeToolExecute` runs.
+
+```go
+type BeforeToolExecuteResult struct {
+    Skip   bool   // Prevent Execute from running; use Result as synthetic output.
+    Result string // Synthetic tool output when Skip is true.
+    Error  error  // Tool error when Skip is true.
+}
+```
+
+### AfterToolExecuteInfo
+
+Passed to the `OnAfterToolExecute` hook after a tool's Execute function completes.
+
+```go
+type AfterToolExecuteInfo struct {
+    ToolCallID string          // Provider-assigned identifier.
+    ToolName   string          // Name of the tool that executed.
+    Step       int             // 1-based step index.
+    Input      json.RawMessage // Raw JSON arguments.
+    Output     string          // Tool output.
+    Error      error           // Non-nil if Execute failed.
+}
+```
+
+### AfterToolExecuteResult
+
+Controls tool output modification before it reaches the LLM.
+
+```go
+type AfterToolExecuteResult struct {
+    Output string // Replaces tool output (empty = preserve original).
+    Error  error  // Replaces tool error (nil = preserve original).
+}
+```
+
+### BeforeStepInfo
+
+Passed to the `OnBeforeStep` hook before each LLM call in a multi-step tool loop (step 2+).
+
+```go
+type BeforeStepInfo struct {
+    Step     int                // 1-based step number.
+    Messages []provider.Message // Current conversation history (shallow clone).
+}
+```
+
+### BeforeStepResult
+
+Controls behavior before the next LLM call.
+
+```go
+type BeforeStepResult struct {
+    ExtraMessages []provider.Message // Appended before LLM call. Ignored when Stop is true.
+    Stop          bool               // Terminate tool loop. ExtraMessages are ignored.
 }
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,7 +188,7 @@ User calls goai.GenerateText(ctx, model, opts...)
   │   │       └─ Return {Text, ToolCalls, Usage, FinishReason, Sources}
   │   ├─ OnResponse callback
   │   ├─ if FinishReason == ToolCalls:
-  │   │   ├─ executeToolsParallel(ctx, calls, toolMap, step, OnToolCallStart, OnToolCall)
+  │   │   ├─ executeToolsParallel(ctx, calls, toolMap, step, toolHooks{...})
   │   │   └─ appendToolRoundTrip(msgs, text, toolCalls, toolMsgs)
   │   └─ else: return buildTextResult(steps, totalUsage)
   │
@@ -217,7 +217,7 @@ User calls goai.StreamText(ctx, model, opts...)
   │       │   │   ├─ model.DoStream(ctx, params)
   │       │   │   ├─ drainStep: forward chunks to unified output channel
   │       │   │   ├─ if FinishReason == ToolCalls:
-  │       │   │   │   ├─ executeToolsParallel(ctx, calls, toolMap, step, OnToolCallStart, OnToolCall)
+  │       │   │   │   ├─ executeToolsParallel(ctx, calls, toolMap, step, toolHooks{...})
   │       │   │   │   └─ appendToolRoundTrip(msgs, text, toolCalls, toolMsgs)
   │       │   │   └─ else: break
   │       │   └─ close unified output channel

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -1,0 +1,195 @@
+---
+title: Lifecycle Hooks
+description: "Intercept and control GoAI's tool loop with lifecycle hooks. Permission gates, secret scanning, output transformation, and loop control."
+---
+
+# Lifecycle Hooks
+
+GoAI provides eight lifecycle hooks that let you observe, intercept, and control the generation process without modifying core SDK code.
+
+## Hook Categories
+
+Hooks fall into two categories:
+
+| Category | Hooks | Callbacks | Purpose |
+|----------|-------|-----------|---------|
+| **Observability** | `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish` | Multiple (append) | Logging, metrics, tracing |
+| **Interceptor** | `OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep` | Single (replace) | Permission, transformation, control flow |
+
+Observability hooks are fire-and-forget: they receive data but cannot change behavior. Interceptor hooks return values that control execution.
+
+## Execution Order
+
+During a multi-step tool loop, hooks fire in this order:
+
+```
+Step 1 --LLM call:
+  OnRequest            → before LLM call
+  LLM DoGenerate/DoStream
+  OnResponse           → after LLM call
+  OnStepFinish         → step result ready (includes ToolCalls from LLM)
+
+Step 1 --Tool execution (if LLM requested tools):
+  OnToolCallStart      → before each tool (parallel)
+  OnBeforeToolExecute  → can skip tool
+  tool.Execute()       → actual execution
+  OnAfterToolExecute   → can modify output
+  OnToolCall           → after each tool (parallel)
+
+Step 2+ --Transition and next LLM call:
+  OnBeforeStep         → can inject messages or stop loop
+  OnRequest            → before LLM call
+  ... (same pattern as Step 1)
+```
+
+Note: "step" = one LLM call. Tool execution happens between steps --results feed into the next step's messages.
+
+## Interceptor Hooks
+
+### OnBeforeToolExecute --Permission Gate
+
+Runs before each tool's `Execute` function. Can skip execution entirely.
+
+```go
+result, _ := goai.GenerateText(ctx, model,
+    goai.WithPrompt("Delete the temp files and read the config"),
+    goai.WithMaxSteps(5),
+    goai.WithTools(readFile, deleteFile),
+    goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+        // Block dangerous tools
+        if info.ToolName == "delete_file" {
+            return goai.BeforeToolExecuteResult{
+                Skip:   true,
+                Result: "Permission denied: delete operations are not allowed.",
+            }
+        }
+        return goai.BeforeToolExecuteResult{} // allow
+    }),
+)
+```
+
+**Skip behavior:**
+- `Skip: true, Result: "..."` --synthetic result sent to LLM
+- `Skip: true, Error: err` --error message sent to LLM (Result is ignored)
+- `Skip: true` (no Result or Error) --empty string sent to LLM
+- Not called for unknown tools (which fail with `ErrUnknownTool`)
+
+**Observability:** When a tool is skipped, `OnToolCall` still fires with `Skipped: true` so observers can track it. `OnAfterToolExecute` does NOT fire for skipped tools.
+
+### OnAfterToolExecute --Output Transformation
+
+Runs after each tool's `Execute` function, before the result reaches the LLM. Can modify the output.
+
+```go
+goai.WithOnAfterToolExecute(func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+    if info.Error != nil {
+        return goai.AfterToolExecuteResult{} // don't modify errors
+    }
+    // Redact secrets from tool output
+    redacted := secretScanner.Scan(info.Output)
+    if redacted != info.Output {
+        return goai.AfterToolExecuteResult{Output: redacted}
+    }
+    return goai.AfterToolExecuteResult{} // no change
+}),
+```
+
+**Modification rules:**
+- `Output: "..."` --replaces the tool's output
+- `Output: ""` --preserves original output (use `" "` to force empty)
+- `Error: err` --replaces the tool's error (nil preserves original; cannot clear an error to nil)
+- Not called for skipped or unknown tools
+
+### OnBeforeStep --Loop Control
+
+Runs before each LLM call in a multi-step tool loop (step 2+ only, not step 1). Can inject messages or stop the loop.
+
+```go
+goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+    // Inject context from external sources between steps
+    if hasNewMessages() {
+        return goai.BeforeStepResult{
+            ExtraMessages: []provider.Message{
+                goai.UserMessage("[System] New context available: " + getContext()),
+            },
+        }
+    }
+    // Or stop the loop early
+    if shouldStop() {
+        return goai.BeforeStepResult{Stop: true}
+    }
+    return goai.BeforeStepResult{}
+}),
+```
+
+**Behavior:**
+- `Stop: true` --terminates the loop; accumulated result returned as-is
+- `ExtraMessages: [...]` --appended to conversation before the next LLM call
+- When `Stop` is true, `ExtraMessages` are ignored (Stop takes precedence)
+- `Messages` field is a shallow clone --safe to read, do not mutate Content directly
+
+## Observability Hooks
+
+These hooks support multiple callbacks (each `WithOn*` call appends, not replaces).
+
+### OnRequest / OnResponse
+
+```go
+goai.WithOnRequest(func(info goai.RequestInfo) {
+    log.Printf("LLM call: model=%s messages=%d tools=%d", info.Model, info.MessageCount, info.ToolCount)
+}),
+goai.WithOnResponse(func(info goai.ResponseInfo) {
+    log.Printf("LLM response: latency=%s tokens=%d finish=%s", info.Latency, info.Usage.InputTokens, info.FinishReason)
+}),
+```
+
+### OnToolCallStart / OnToolCall
+
+```go
+goai.WithOnToolCallStart(func(info goai.ToolCallStartInfo) {
+    log.Printf("Tool starting: %s (call %s)", info.ToolName, info.ToolCallID)
+}),
+goai.WithOnToolCall(func(info goai.ToolCallInfo) {
+    status := "OK"
+    if info.Skipped {
+        status = "SKIPPED"
+    } else if info.Error != nil {
+        status = "ERROR"
+    }
+    log.Printf("Tool done: %s %s (%s)", info.ToolName, status, info.Duration)
+}),
+```
+
+### OnStepFinish
+
+```go
+goai.WithOnStepFinish(func(step goai.StepResult) {
+    log.Printf("Step %d: %s (tools=%d, tokens=%d)",
+        step.Number, step.FinishReason, len(step.ToolCalls), step.Usage.InputTokens)
+}),
+```
+
+## Panic Recovery
+
+Hook panics are recovered in most paths. "Propagates" = crashes the caller. "Recovered" = caught, logged to stderr, execution continues.
+
+| Hook | GenerateText | StreamText (step 1)* | StreamText (step 2+) | GenerateObject |
+|------|-------------|---------------------|---------------------|----------------|
+| OnRequest | Propagates | Propagates | Recovered | Propagates |
+| OnResponse | Recovered | Propagates (error) | Recovered | Propagates |
+| OnToolCallStart | Recovered | Recovered | Recovered | Recovered |
+| OnToolCall | Recovered | Recovered | Recovered | Recovered |
+| OnStepFinish | Recovered | Recovered | Recovered | Recovered |
+| OnBeforeToolExecute | Recovered (skips tool) | Recovered (skips tool) | Recovered (skips tool) | Recovered (skips tool) |
+| OnAfterToolExecute | Recovered (preserves result) | Recovered (preserves result) | Recovered (preserves result) | Recovered (preserves result) |
+| OnBeforeStep | Recovered (proceeds) | N/A | Recovered (proceeds) | Recovered (proceeds) |
+
+*\* StreamText step 1 runs synchronously in the caller's goroutine (before the background goroutine starts). Step 2+ runs in a background goroutine where all panics are recovered. StreamObject OnRequest propagates like GenerateObject. StreamObject OnResponse propagates on the error path but is recovered on the success path (consume goroutine).*
+
+## Complete Example
+
+See [`examples/hooks/main.go`](https://github.com/zendev-sh/goai/blob/main/examples/hooks/main.go) for a runnable example combining permission gates, secret scanning, and loop control.
+
+## Integration with Observability Providers
+
+GoAI's [OpenTelemetry](observability.md#opentelemetry) and [Langfuse](observability.md#langfuse) integrations use the observability hooks internally. The interceptor hooks are not yet integrated into these providers --use them directly in your application code.

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -5,7 +5,7 @@ description: "Trace LLM calls, tool executions, and agent runs in GoAI. Plug-in 
 
 # Observability
 
-GoAI's observability is built on five lifecycle hooks: `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, and `OnStepFinish`. Any observability provider can plug into these hooks to trace LLM calls, tool executions, and multi-step agent runs.
+GoAI's observability is built on eight lifecycle hooks: `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish`, `OnBeforeToolExecute`, `OnAfterToolExecute`, and `OnBeforeStep`. Any observability provider can plug into these hooks to trace LLM calls, tool executions, and multi-step agent runs.
 
 ## How It Works
 
@@ -29,6 +29,11 @@ Each hook fires at a specific point in the request lifecycle:
 | `OnToolCallStart` | Before each tool execution | Tool call ID, tool name, step, input        |
 | `OnToolCall`      | After each tool execution  | Tool name, input/output, duration, errors   |
 | `OnStepFinish`    | After each step completes  | Step number, finish reason, tool calls      |
+| `OnBeforeToolExecute`* | Before each tool's Execute function | Tool call ID, tool name, step, input; can skip execution |
+| `OnAfterToolExecute`*  | After each tool's Execute function  | Tool call ID, tool name, output, error; can modify output |
+| `OnBeforeStep`*        | Before each LLM call (step 2+)     | Step number, messages; can inject messages or stop loop   |
+
+*\* Interceptor hooks: only one callback supported per hook (setting a second replaces the first). The first five hooks support multiple callbacks.*
 
 This design means observability never touches the core SDK. Providers are optional imports with zero impact on non-instrumented code.
 

--- a/generate.go
+++ b/generate.go
@@ -610,6 +610,28 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				result = firstResult
 				firstStep = false
 			} else {
+				// Steps 2+: OnBeforeStep hook (can inject messages or stop loop).
+				if o.OnBeforeStep != nil {
+					var bsr BeforeStepResult
+					func() {
+						defer func() {
+							if r := recover(); r != nil {
+								fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeStep hook: %v\n", r)
+							}
+						}()
+						bsr = o.OnBeforeStep(BeforeStepInfo{
+							Step:     step,
+							Messages: slices.Clone(params.Messages),
+						})
+					}()
+					if bsr.Stop {
+						break
+					}
+					if len(bsr.ExtraMessages) > 0 {
+						params.Messages = append(params.Messages, bsr.ExtraMessages...)
+					}
+				}
+
 				// Steps 2+: DoStream inside goroutine.
 				for _, fn := range o.OnRequest {
 					func(f func(RequestInfo)) {
@@ -752,7 +774,12 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			}
 
 			// --- Execute tools in parallel ---
-			toolMsgs := executeToolsParallel(ctx, ds.toolCalls, toolMap, step, o.OnToolCallStart, o.OnToolCall)
+			toolMsgs := executeToolsParallel(ctx, ds.toolCalls, toolMap, step, toolHooks{
+				onToolCallStart: o.OnToolCallStart,
+				onToolCall:      o.OnToolCall,
+				onBeforeExecute: o.OnBeforeToolExecute,
+				onAfterExecute:  o.OnAfterToolExecute,
+			})
 
 			// --- Append messages for next step ---
 			params.Messages = appendToolRoundTrip(params.Messages, ds.text, ds.reasoning, ds.toolCalls, toolMsgs)
@@ -874,6 +901,28 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	var totalUsage provider.Usage
 
 	for step := 1; step <= o.MaxSteps; step++ {
+		// OnBeforeStep: step 2+ only (step 1 has no prior tool results to act on).
+		if step > 1 && o.OnBeforeStep != nil {
+			var bsr BeforeStepResult
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeStep hook: %v\n", r)
+					}
+				}()
+				bsr = o.OnBeforeStep(BeforeStepInfo{
+					Step:     step,
+					Messages: slices.Clone(params.Messages),
+				})
+			}()
+			if bsr.Stop {
+				break
+			}
+			if len(bsr.ExtraMessages) > 0 {
+				params.Messages = append(params.Messages, bsr.ExtraMessages...)
+			}
+		}
+
 		for _, fn := range o.OnRequest {
 			fn(RequestInfo{
 				Ctx:          ctx,
@@ -959,7 +1008,12 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// Clear tool_choice after the first tool step so the model can freely
 		// produce a text response on subsequent steps.
 		params.ToolChoice = ""
-		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, o.OnToolCallStart, o.OnToolCall)
+		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
+			onToolCallStart: o.OnToolCallStart,
+			onToolCall:      o.OnToolCall,
+			onBeforeExecute: o.OnBeforeToolExecute,
+			onAfterExecute:  o.OnAfterToolExecute,
+		})
 
 		// Append assistant message with tool calls + tool result messages.
 		params.Messages = appendToolRoundTrip(params.Messages, result.Text, nil, result.ToolCalls, toolMessages)
@@ -1013,13 +1067,20 @@ type toolOutput struct {
 	err    error
 }
 
+// toolHooks bundles the hook functions passed to executeToolsParallel.
+type toolHooks struct {
+	onToolCallStart    []func(ToolCallStartInfo)
+	onToolCall         []func(ToolCallInfo)
+	onBeforeExecute    func(BeforeToolExecuteInfo) BeforeToolExecuteResult
+	onAfterExecute     func(AfterToolExecuteInfo) AfterToolExecuteResult
+}
+
 func executeToolsParallel(
 	ctx context.Context,
 	calls []provider.ToolCall,
 	toolMap map[string]Tool,
 	step int,
-	onToolCallStart []func(ToolCallStartInfo),
-	onToolCall []func(ToolCallInfo),
+	hooks toolHooks,
 ) []provider.Message {
 
 	results := make([]toolOutput, len(calls))
@@ -1037,17 +1098,17 @@ func executeToolsParallel(
 			// pre-hook crashed). For unknown tools, Execute never runs anyway, so both
 			// hooks fire independently for observability completeness.
 			results[i] = toolOutput{index: i, err: ErrUnknownTool}
-			for _, fn := range onToolCallStart {
+			for _, fn := range hooks.onToolCallStart {
 				func(f func(ToolCallStartInfo)) {
 					defer func() {
 						if r := recover(); r != nil {
 							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
 						}
 					}()
-					f(ToolCallStartInfo{ToolCallID: tc.ID, ToolName: tc.Name, Step: step + 1, Input: tc.Input})
+					f(ToolCallStartInfo{ToolCallID: tc.ID, ToolName: tc.Name, Step: step, Input: tc.Input})
 				}(fn)
 			}
-			for _, fn := range onToolCall {
+			for _, fn := range hooks.onToolCall {
 				func(f func(ToolCallInfo)) {
 					defer func() {
 						if r := recover(); r != nil {
@@ -1093,7 +1154,7 @@ func executeToolsParallel(
 
 			// OnToolCallStart: pre-execution (each independently recover-wrapped).
 			var hookPanicked bool
-			for _, fn := range onToolCallStart {
+			for _, fn := range hooks.onToolCallStart {
 				func(f func(ToolCallStartInfo)) {
 					defer func() {
 						if r := recover(); r != nil {
@@ -1116,14 +1177,92 @@ func executeToolsParallel(
 				return
 			}
 
+			// OnBeforeToolExecute: can skip execution (permission, doom loop, etc.).
+			if hooks.onBeforeExecute != nil {
+				var beforeResult BeforeToolExecuteResult
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeToolExecute hook: %v\n", r)
+							beforeResult = BeforeToolExecuteResult{
+								Skip:  true,
+								Error: fmt.Errorf("goai: OnBeforeToolExecute hook panicked: %v", r),
+							}
+						}
+					}()
+					beforeResult = hooks.onBeforeExecute(BeforeToolExecuteInfo{
+						ToolCallID: tc.ID,
+						ToolName:   tc.Name,
+						Step:       step,
+						Input:      tc.Input,
+					})
+				}()
+				if beforeResult.Skip {
+					executed = true // prevent outer panic handler from overwriting
+					if beforeResult.Error != nil {
+						results[i] = toolOutput{index: i, result: beforeResult.Result, err: beforeResult.Error}
+					} else {
+						results[i] = toolOutput{index: i, result: beforeResult.Result}
+					}
+					// Fire OnToolCall with skipped result for observability.
+					for _, fn := range hooks.onToolCall {
+						func(f func(ToolCallInfo)) {
+							defer func() {
+								if r := recover(); r != nil {
+									fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
+								}
+							}()
+							f(ToolCallInfo{
+								ToolCallID: tc.ID,
+								ToolName:   tc.Name,
+								Step:       step,
+								Input:      tc.Input,
+								Output:     beforeResult.Result,
+								StartTime:  time.Now(),
+								Skipped:    true,
+								Error:      beforeResult.Error,
+							})
+						}(fn)
+					}
+					return
+				}
+			}
+
 			start := time.Now()
 			toolCtx := context.WithValue(ctx, toolCallIDKey{}, tc.ID)
 			output, err := tool.Execute(toolCtx, tc.Input)
 			executed = true
+
+			// OnAfterToolExecute: can modify output (secret scanning, truncation, etc.).
+			if hooks.onAfterExecute != nil {
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							fmt.Fprintf(os.Stderr, "goai: recovered panic in OnAfterToolExecute hook: %v\n", r)
+							// Preserve original result on panic.
+						}
+					}()
+					afterResult := hooks.onAfterExecute(AfterToolExecuteInfo{
+						ToolCallID: tc.ID,
+						ToolName:   tc.Name,
+						Step:       step,
+						Input:      tc.Input,
+						Output:     output,
+						Error:      err,
+					})
+					if afterResult.Output != "" {
+						output = afterResult.Output
+					}
+					if afterResult.Error != nil {
+						err = afterResult.Error
+					}
+				}()
+			}
+
 			results[i] = toolOutput{index: i, result: output, err: err}
 
 			// OnToolCall: post-execution (each independently recover-wrapped).
-			for _, fn := range onToolCall {
+			for _, fn := range hooks.onToolCall {
 				func(f func(ToolCallInfo)) {
 					defer func() {
 						if r := recover(); r != nil {

--- a/generate_test.go
+++ b/generate_test.go
@@ -1797,7 +1797,7 @@ func TestExecuteToolsParallel_ContextCancelled(t *testing.T) {
 
 	// With parallel execution, all tools run via goroutines and complete.
 	// The cancelled context is passed to Execute, but the tool ignores it.
-	msgs := executeToolsParallel(ctx, calls, toolMap, 1, nil, nil)
+	msgs := executeToolsParallel(ctx, calls, toolMap, 1, toolHooks{})
 	if len(msgs) != 2 {
 		t.Errorf("expected 2 messages (parallel execution completes all), got %d", len(msgs))
 	}

--- a/hooks.go
+++ b/hooks.go
@@ -67,11 +67,15 @@ type ToolCallInfo struct {
 	Step int
 
 	// Input is the raw JSON arguments passed to the tool.
-	// Replaces the former InputSize int field — use len(Input) for byte size.
+	// Replaces the former InputSize int field --use len(Input) for byte size.
 	Input json.RawMessage
 
 	// Output is the string result returned by the tool.
-	// Empty if the tool returned an error or was not found.
+	// Typically empty when Error is non-nil, but tools may return both output and error
+	// (e.g., partial output on timeout). Empty for unknown tools (ErrUnknownTool).
+	// Note: when OnBeforeToolExecute skips with both Result and Error set,
+	// Output contains the Result string but the LLM receives "error: <message>"
+	// (Error takes precedence in the message sent to the model).
 	Output string
 
 	// OutputObject is the parsed JSON value of Output when the tool returned valid JSON.
@@ -81,10 +85,17 @@ type ToolCallInfo struct {
 	OutputObject any
 
 	// StartTime is when the tool execution began.
+	// Zero for unknown tools (ErrUnknownTool). For skipped tools (Skipped=true),
+	// reflects when the skip decision was made, not execution start.
 	StartTime time.Time
 
 	// Duration is how long the tool execution took.
 	Duration time.Duration
+
+	// Skipped is true when the tool execution was skipped by OnBeforeToolExecute.
+	// When Skipped is true, StartTime reflects when the skip decision was made
+	// (not when execution started) and Duration is zero.
+	Skipped bool
 
 	// Error is non-nil if the tool execution failed.
 	Error error
@@ -108,9 +119,11 @@ func WithOnRequest(fn func(RequestInfo)) Option {
 
 // WithOnResponse adds a callback invoked after each model call completes.
 // Multiple callbacks are called in registration order.
-// Each callback is individually panic-recovered in the GenerateText multi-step loop
-// and in streaming consume paths (panics logged to stderr, do not crash the caller).
-// In single-step error paths and GenerateObject, panics propagate to the caller.
+// Each callback is individually panic-recovered in GenerateText (all steps),
+// all StreamText success paths (single-step consume goroutine and multi-step goroutine),
+// and StreamObject's success path (consume goroutine).
+// In GenerateObject, StreamObject's error path, and StreamText's first-step error path,
+// panics propagate to the caller.
 func WithOnResponse(fn func(ResponseInfo)) Option {
 	return func(o *options) { o.OnResponse = append(o.OnResponse, fn) }
 }
@@ -143,4 +156,134 @@ type ToolCallStartInfo struct {
 // panics, the tool does not execute.
 func WithOnToolCallStart(fn func(ToolCallStartInfo)) Option {
 	return func(o *options) { o.OnToolCallStart = append(o.OnToolCallStart, fn) }
+}
+
+// BeforeToolExecuteInfo is passed to the OnBeforeToolExecute hook before a tool's
+// Execute function runs. The hook can inspect the call and optionally skip execution.
+type BeforeToolExecuteInfo struct {
+	// ToolCallID is the provider-assigned identifier for this tool call.
+	ToolCallID string
+
+	// ToolName is the name of the tool about to execute.
+	ToolName string
+
+	// Step is the 1-based index of the generation step.
+	Step int
+
+	// Input is the raw JSON arguments that will be passed to the tool.
+	Input json.RawMessage
+}
+
+// BeforeToolExecuteResult controls what happens after OnBeforeToolExecute runs.
+type BeforeToolExecuteResult struct {
+	// Skip, when true, prevents the tool's Execute function from running.
+	// The Result string is used as the tool output sent back to the LLM.
+	// If Error is also set, it is reported as a tool error instead.
+	Skip bool
+
+	// Result is the synthetic tool output when Skip is true.
+	// Ignored when Skip is false.
+	// When Error is also non-nil, Result is ignored for the LLM message --only the
+	// error is sent (as "error: <message>"). However, OnToolCall still receives Result
+	// in its Output field for observability.
+	// When Skip is true and both Result and Error are empty/nil, an empty string
+	// is sent as the tool output to the LLM. Set Result to a meaningful string
+	// to signal the skip reason to the model.
+	Result string
+
+	// Error, when non-nil and Skip is true, is reported as the tool error.
+	// Result is ignored when Error is set --the LLM receives "error: <message>".
+	// Ignored when Skip is false.
+	Error error
+}
+
+// WithOnBeforeToolExecute adds a callback invoked before each known tool's Execute function.
+// Not called for unknown tools (which always fail with ErrUnknownTool).
+// The callback can inspect the tool call and return a BeforeToolExecuteResult to skip
+// execution (e.g., for permission checks, rate limiting, or doom-loop detection).
+// Only one callback is supported; setting a second replaces the first.
+// The callback is panic-recovered; a panic skips the tool with an error result.
+func WithOnBeforeToolExecute(fn func(BeforeToolExecuteInfo) BeforeToolExecuteResult) Option {
+	return func(o *options) { o.OnBeforeToolExecute = fn }
+}
+
+// AfterToolExecuteInfo is passed to the OnAfterToolExecute hook after a tool's
+// Execute function completes, before the result is sent to the LLM.
+type AfterToolExecuteInfo struct {
+	// ToolCallID is the provider-assigned identifier for this tool call.
+	ToolCallID string
+
+	// ToolName is the name of the tool that executed.
+	ToolName string
+
+	// Step is the 1-based index of the generation step.
+	Step int
+
+	// Input is the raw JSON arguments passed to the tool.
+	Input json.RawMessage
+
+	// Output is the string result returned by the tool's Execute function.
+	Output string
+
+	// Error is non-nil if the tool's Execute function returned an error.
+	Error error
+}
+
+// AfterToolExecuteResult allows the hook to modify the tool output before it
+// is sent to the LLM.
+type AfterToolExecuteResult struct {
+	// Output replaces the tool's original output. If empty and the original
+	// output was non-empty, the original is preserved (use a space to force empty).
+	Output string
+
+	// Error, when non-nil, replaces the tool's original error.
+	// A nil value preserves the original error (cannot clear an error to nil).
+	Error error
+}
+
+// WithOnAfterToolExecute adds a callback invoked after each tool's Execute function,
+// before the result is sent to the LLM. The callback can modify the output
+// (e.g., for secret scanning, truncation, or output transformation).
+// Not called when OnBeforeToolExecute skips execution or for unknown tools.
+// Use OnToolCall with Skipped=true to observe skipped tool results.
+// Only one callback is supported; setting a second replaces the first.
+// The callback is panic-recovered; a panic preserves the original tool result.
+func WithOnAfterToolExecute(fn func(AfterToolExecuteInfo) AfterToolExecuteResult) Option {
+	return func(o *options) { o.OnAfterToolExecute = fn }
+}
+
+// BeforeStepInfo is passed to the OnBeforeStep hook before each LLM call in
+// a multi-step tool loop (step 2+). It is NOT called before step 1.
+type BeforeStepInfo struct {
+	// Step is the 1-based step number about to execute.
+	Step int
+
+	// Messages is the current conversation history that will be sent to the LLM.
+	// This is a shallow clone of the internal messages slice --the slice header is
+	// independent but Message fields containing reference types (e.g., Content []Part)
+	// share the underlying arrays with the live conversation. Do not mutate message
+	// Content directly; use ExtraMessages to inject new messages.
+	Messages []provider.Message
+}
+
+// BeforeStepResult controls what happens before the next LLM call.
+type BeforeStepResult struct {
+	// ExtraMessages are appended to the conversation before the LLM call.
+	// Use this to inject inter-agent messages, context updates, etc.
+	// Ignored when Stop is true.
+	ExtraMessages []provider.Message
+
+	// Stop, when true, terminates the tool loop before the next LLM call.
+	// The current accumulated result is returned as-is.
+	// When Stop is true, ExtraMessages are ignored (Stop takes precedence).
+	Stop bool
+}
+
+// WithOnBeforeStep adds a callback invoked before each LLM call in a multi-step
+// tool loop (step 2+, after tool execution). The callback can inject additional
+// messages or stop the loop early.
+// Only one callback is supported; setting a second replaces the first.
+// The callback is panic-recovered; a panic is logged and the step proceeds normally.
+func WithOnBeforeStep(fn func(BeforeStepInfo) BeforeStepResult) Option {
+	return func(o *options) { o.OnBeforeStep = fn }
 }

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -1309,6 +1309,152 @@ func TestOnBeforeStep_GenerateObject(t *testing.T) {
 	}
 }
 
+func TestOnBeforeStep_GenerateObject_Stop(t *testing.T) {
+	// OnBeforeStep Stop=true in GenerateObject terminates the loop.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         `{"name":"stopped","value":0}`,
+				FinishReason: provider.FinishStop,
+			}, nil
+		},
+	}
+
+	type TestObj struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	_, err := GenerateObject[TestObj](t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			return BeforeStepResult{Stop: true}
+		}),
+	)
+	// Stop before step 2 means no structured output produced -- expect MaxSteps error.
+	if err == nil {
+		t.Fatal("expected error when Stop prevents structured output")
+	}
+	if callCount != 1 {
+		t.Errorf("LLM called %d times, want 1 (Stop before step 2)", callCount)
+	}
+}
+
+func TestOnBeforeStep_GenerateObject_InjectMessages(t *testing.T) {
+	// OnBeforeStep injects messages in GenerateObject.
+	callCount := 0
+	var step2MsgCount int
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			step2MsgCount = len(p.Messages)
+			return &provider.GenerateResult{
+				Text:         `{"name":"injected","value":99}`,
+				FinishReason: provider.FinishStop,
+			}, nil
+		},
+	}
+
+	type TestObj struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	result, err := GenerateObject[TestObj](t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			return BeforeStepResult{
+				ExtraMessages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "extra context"}}},
+				},
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Object.Name != "injected" {
+		t.Errorf("Object.Name = %q, want injected", result.Object.Name)
+	}
+	// Step 2 should have more messages than step 1 (original + assistant + tool + injected).
+	if step2MsgCount < 4 {
+		t.Errorf("step 2 message count = %d, want >= 4 (with injected message)", step2MsgCount)
+	}
+}
+
+func TestOnBeforeStep_GenerateObject_PanicRecovery(t *testing.T) {
+	// OnBeforeStep panics in GenerateObject -- recovered, step proceeds.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         `{"name":"recovered","value":1}`,
+				FinishReason: provider.FinishStop,
+			}, nil
+		},
+	}
+
+	type TestObj struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	result, err := GenerateObject[TestObj](t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			panic("object step panic!")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount != 2 {
+		t.Errorf("LLM called %d times, want 2 (panic recovered)", callCount)
+	}
+	if result.Object.Name != "recovered" {
+		t.Errorf("Object.Name = %q, want recovered", result.Object.Name)
+	}
+}
+
 // --- Finding 5: Skip=true with both Result and Error set ---
 
 func TestOnBeforeToolExecute_SkipWithResultAndError(t *testing.T) {

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/zendev-sh/goai/provider"
@@ -338,6 +339,1083 @@ func TestHooks_MultipleSteps(t *testing.T) {
 	}
 	if toolCount != 1 {
 		t.Errorf("OnToolCall called %d times, want 1", toolCount)
+	}
+}
+
+// --- OnBeforeToolExecute tests ---
+
+func TestOnBeforeToolExecute_PassThrough(t *testing.T) {
+	// Hook returns Skip=false → tool executes normally.
+	var hookCalled bool
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "read", Input: json.RawMessage(`{"path":"a.txt"}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "file contents", nil
+			},
+		}),
+		WithOnBeforeToolExecute(func(info BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			hookCalled = true
+			if info.ToolName != "read" {
+				t.Errorf("ToolName = %q, want read", info.ToolName)
+			}
+			if info.ToolCallID != "tc1" {
+				t.Errorf("ToolCallID = %q, want tc1", info.ToolCallID)
+			}
+			return BeforeToolExecuteResult{} // Skip=false
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hookCalled {
+		t.Error("OnBeforeToolExecute was not called")
+	}
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want done", result.Text)
+	}
+}
+
+func TestOnBeforeToolExecute_Skip(t *testing.T) {
+	// Hook returns Skip=true → tool does NOT execute, synthetic result used.
+	toolExecuted := false
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "bash", Input: json.RawMessage(`{"cmd":"rm -rf /"}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Step 2: verify the tool result contains the synthetic "permission denied".
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult && part.ToolOutput == "permission denied" {
+						return &provider.GenerateResult{Text: "ok, I won't do that", FinishReason: provider.FinishStop}, nil
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "unexpected", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "bash",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				toolExecuted = true
+				return "executed!", nil
+			},
+		}),
+		WithOnBeforeToolExecute(func(_ BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{Skip: true, Result: "permission denied"}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if toolExecuted {
+		t.Error("tool should NOT have executed when Skip=true")
+	}
+	if result.Text != "ok, I won't do that" {
+		t.Errorf("Text = %q, want 'ok, I won't do that'", result.Text)
+	}
+}
+
+func TestOnBeforeToolExecute_SkipWithError(t *testing.T) {
+	// Hook returns Skip=true with Error → tool result is an error message.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "write", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Check the tool result contains error.
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult && part.ToolOutput == "error: doom loop detected" {
+						return &provider.GenerateResult{Text: "stopped", FinishReason: provider.FinishStop}, nil
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "unexpected", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "write",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeToolExecute(func(_ BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{Skip: true, Error: fmt.Errorf("doom loop detected")}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "stopped" {
+		t.Errorf("Text = %q, want stopped", result.Text)
+	}
+}
+
+// --- OnAfterToolExecute tests ---
+
+func TestOnAfterToolExecute_ModifyOutput(t *testing.T) {
+	// Hook modifies tool output (e.g., secret scanning).
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "read", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Check the tool result was modified by hook.
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult && part.ToolOutput == "REDACTED" {
+						return &provider.GenerateResult{Text: "got redacted", FinishReason: provider.FinishStop}, nil
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "unexpected", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "secret-api-key-12345", nil
+			},
+		}),
+		WithOnAfterToolExecute(func(info AfterToolExecuteInfo) AfterToolExecuteResult {
+			if info.ToolName != "read" {
+				t.Errorf("ToolName = %q, want read", info.ToolName)
+			}
+			if info.Output != "secret-api-key-12345" {
+				t.Errorf("Output = %q, want original", info.Output)
+			}
+			return AfterToolExecuteResult{Output: "REDACTED"}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "got redacted" {
+		t.Errorf("Text = %q, want 'got redacted'", result.Text)
+	}
+}
+
+func TestOnAfterToolExecute_NoModify(t *testing.T) {
+	// Hook returns empty result → original output preserved.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "read", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult && part.ToolOutput == "original output" {
+						return &provider.GenerateResult{Text: "preserved", FinishReason: provider.FinishStop}, nil
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "unexpected", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "original output", nil
+			},
+		}),
+		WithOnAfterToolExecute(func(_ AfterToolExecuteInfo) AfterToolExecuteResult {
+			return AfterToolExecuteResult{} // empty → no change
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "preserved" {
+		t.Errorf("Text = %q, want preserved", result.Text)
+	}
+}
+
+// --- OnBeforeStep tests ---
+
+func TestOnBeforeStep_InjectMessages(t *testing.T) {
+	// Hook injects extra user messages before step 2.
+	callCount := 0
+	var step2Messages []provider.Message
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			step2Messages = p.Messages
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(info BeforeStepInfo) BeforeStepResult {
+			if info.Step != 2 {
+				t.Errorf("Step = %d, want 2", info.Step)
+			}
+			return BeforeStepResult{
+				ExtraMessages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "injected message"}}},
+				},
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify injected message is in the conversation.
+	found := false
+	for _, msg := range step2Messages {
+		for _, part := range msg.Content {
+			if part.Type == provider.PartText && part.Text == "injected message" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("injected message not found in step 2 messages")
+	}
+}
+
+func TestOnBeforeStep_Stop(t *testing.T) {
+	// Hook returns Stop=true → loop terminates before step 2 LLM call.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "should not reach", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			return BeforeStepResult{Stop: true}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount != 1 {
+		t.Errorf("LLM called %d times, want 1 (stop before step 2)", callCount)
+	}
+	// Result should have the tool calls from step 1.
+	if len(result.ToolCalls) != 1 {
+		t.Errorf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+}
+
+func TestOnBeforeStep_NotCalledOnStep1(t *testing.T) {
+	// OnBeforeStep is only called for step 2+, NOT step 1.
+	hookCalled := false
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{Text: "hello", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			hookCalled = true
+			return BeforeStepResult{}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hookCalled {
+		t.Error("OnBeforeStep should NOT be called when there's only 1 step")
+	}
+}
+
+// --- StreamText variants ---
+
+func TestOnBeforeToolExecute_StreamText(t *testing.T) {
+	// Same as GenerateText skip test but via StreamText.
+	toolExecuted := false
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			callCount++
+			if callCount == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "bash", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "skipped"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "bash",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				toolExecuted = true
+				return "ran", nil
+			},
+		}),
+		WithOnBeforeToolExecute(func(_ BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{Skip: true, Result: "denied"}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := stream.Result()
+	if toolExecuted {
+		t.Error("tool should NOT have executed")
+	}
+	if result.Text != "skipped" {
+		t.Errorf("Text = %q, want skipped", result.Text)
+	}
+}
+
+func TestOnBeforeStep_StreamText_Stop(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			callCount++
+			if callCount == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "should not reach"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			return BeforeStepResult{Stop: true}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream.Result() // consume
+	if callCount != 1 {
+		t.Errorf("LLM called %d times, want 1", callCount)
+	}
+}
+
+// --- Test 7: Multiple parallel tool calls with partial skip ---
+
+func TestOnBeforeToolExecute_PartialSkip(t *testing.T) {
+	// Model returns 2 tool calls in step 1. Hook skips "dangerous" but allows "safe".
+	// Verify: "dangerous" NOT executed, "safe" IS executed, LLM receives both results.
+	dangerousExecuted := false
+	safeExecuted := false
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls: []provider.ToolCall{
+						{ID: "tc1", Name: "dangerous", Input: json.RawMessage(`{}`)},
+						{ID: "tc2", Name: "safe", Input: json.RawMessage(`{}`)},
+					},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Step 2: verify both tool results are in messages.
+			var foundDenied, foundSafeOutput bool
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult {
+						if part.ToolOutput == "permission denied" {
+							foundDenied = true
+						}
+						if part.ToolOutput == "safe result" {
+							foundSafeOutput = true
+						}
+					}
+				}
+			}
+			if !foundDenied {
+				t.Error("step 2: expected 'permission denied' tool result for dangerous")
+			}
+			if !foundSafeOutput {
+				t.Error("step 2: expected 'safe result' tool result for safe")
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(
+			Tool{
+				Name: "dangerous",
+				Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+					dangerousExecuted = true
+					return "dangerous output", nil
+				},
+			},
+			Tool{
+				Name: "safe",
+				Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+					safeExecuted = true
+					return "safe result", nil
+				},
+			},
+		),
+		WithOnBeforeToolExecute(func(info BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			if info.ToolName == "dangerous" {
+				return BeforeToolExecuteResult{Skip: true, Result: "permission denied"}
+			}
+			return BeforeToolExecuteResult{} // pass-through
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dangerousExecuted {
+		t.Error("dangerous tool should NOT have executed")
+	}
+	if !safeExecuted {
+		t.Error("safe tool should have executed")
+	}
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want done", result.Text)
+	}
+}
+
+// --- Test 8: OnAfterToolExecute when tool returns error ---
+
+func TestOnAfterToolExecute_ToolError(t *testing.T) {
+	// Tool returns error. Hook receives the error in info.Error.
+	// Hook returns AfterToolExecuteResult{Output: "modified error output"}.
+	var capturedInfo AfterToolExecuteInfo
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "flaky", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Step 2: check the tool result contains the modified error output.
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult && part.ToolOutput == "error: timeout" {
+						return &provider.GenerateResult{Text: "handled error", FinishReason: provider.FinishStop}, nil
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "unexpected", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "flaky",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "partial output", fmt.Errorf("timeout")
+			},
+		}),
+		WithOnAfterToolExecute(func(info AfterToolExecuteInfo) AfterToolExecuteResult {
+			capturedInfo = info
+			return AfterToolExecuteResult{} // don't modify --let the error pass through
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify hook received the error and partial output.
+	if capturedInfo.Error == nil {
+		t.Error("hook should have received non-nil Error")
+	} else if capturedInfo.Error.Error() != "timeout" {
+		t.Errorf("hook Error = %q, want 'timeout'", capturedInfo.Error)
+	}
+	if capturedInfo.Output != "partial output" {
+		t.Errorf("hook Output = %q, want 'partial output'", capturedInfo.Output)
+	}
+	if result.Text != "handled error" {
+		t.Errorf("Text = %q, want 'handled error'", result.Text)
+	}
+}
+
+// --- Test 9: OnBeforeToolExecute panic recovery ---
+
+func TestOnBeforeToolExecute_PanicRecovery(t *testing.T) {
+	// Hook panics. Tool should NOT execute. Error result sent to LLM.
+	toolExecuted := false
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "read", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Step 2: check that the tool result contains "panicked".
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult {
+						if strings.Contains(part.ToolOutput, "panicked") {
+							return &provider.GenerateResult{Text: "recovered", FinishReason: provider.FinishStop}, nil
+						}
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "unexpected", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				toolExecuted = true
+				return "should not run", nil
+			},
+		}),
+		WithOnBeforeToolExecute(func(_ BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			panic("kaboom")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if toolExecuted {
+		t.Error("tool should NOT have executed when hook panicked")
+	}
+	if result.Text != "recovered" {
+		t.Errorf("Text = %q, want 'recovered'", result.Text)
+	}
+}
+
+// --- Test 10: OnAfterToolExecute in StreamText ---
+
+func TestOnAfterToolExecute_StreamText(t *testing.T) {
+	// Same as GenerateText test but via StreamText. Verify output modification works.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, p provider.GenerateParams) (*provider.StreamResult, error) {
+			callCount++
+			if callCount == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "read", ToolInput: "{}"},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
+				), nil
+			}
+			// Step 2: check tool result contains "REDACTED".
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult && part.ToolOutput == "REDACTED" {
+						return streamFromChunks(
+							provider.StreamChunk{Type: provider.ChunkText, Text: "redacted ok"},
+							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+						), nil
+					}
+				}
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "unexpected"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "secret-data", nil
+			},
+		}),
+		WithOnAfterToolExecute(func(info AfterToolExecuteInfo) AfterToolExecuteResult {
+			if info.Output == "secret-data" {
+				return AfterToolExecuteResult{Output: "REDACTED"}
+			}
+			return AfterToolExecuteResult{}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := stream.Result()
+	if result.Text != "redacted ok" {
+		t.Errorf("Text = %q, want 'redacted ok'", result.Text)
+	}
+}
+
+// --- Test 11: OnBeforeToolExecute skip fires OnToolCall with Skipped=true ---
+
+func TestOnBeforeToolExecute_SkipFiresOnToolCallWithSkipped(t *testing.T) {
+	// When hook skips, OnToolCall still fires with Skipped=true.
+	var captured []ToolCallInfo
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "blocked", Input: json.RawMessage(`{"x":1}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "blocked",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				t.Error("tool should NOT have executed")
+				return "nope", nil
+			},
+		}),
+		WithOnBeforeToolExecute(func(_ BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{Skip: true, Result: "skipped by policy"}
+		}),
+		WithOnToolCall(func(info ToolCallInfo) {
+			captured = append(captured, info)
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(captured) != 1 {
+		t.Fatalf("OnToolCall called %d times, want 1", len(captured))
+	}
+	if !captured[0].Skipped {
+		t.Error("Skipped should be true")
+	}
+	if captured[0].ToolCallID != "tc1" {
+		t.Errorf("ToolCallID = %q, want tc1", captured[0].ToolCallID)
+	}
+	if captured[0].ToolName != "blocked" {
+		t.Errorf("ToolName = %q, want blocked", captured[0].ToolName)
+	}
+	if captured[0].Output != "skipped by policy" {
+		t.Errorf("Output = %q, want 'skipped by policy'", captured[0].Output)
+	}
+	if captured[0].StartTime.IsZero() {
+		t.Error("StartTime should be non-zero")
+	}
+}
+
+// --- Finding 7: OnBeforeStep panic recovery ---
+
+func TestOnBeforeStep_PanicRecovery_GenerateText(t *testing.T) {
+	// OnBeforeStep panics --should be recovered, step proceeds normally.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done after panic", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			panic("step panic!")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount != 2 {
+		t.Errorf("LLM called %d times, want 2 (panic recovered, step proceeded)", callCount)
+	}
+	if result.Text != "done after panic" {
+		t.Errorf("Text = %q, want 'done after panic'", result.Text)
+	}
+}
+
+func TestOnBeforeStep_PanicRecovery_StreamText(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			callCount++
+			if callCount == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "recovered"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			panic("stream step panic!")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := stream.Result()
+	if callCount != 2 {
+		t.Errorf("LLM called %d times, want 2", callCount)
+	}
+	if result.Text != "recovered" {
+		t.Errorf("Text = %q, want recovered", result.Text)
+	}
+}
+
+// --- Finding 8: OnAfterToolExecute panic recovery ---
+
+func TestOnAfterToolExecute_PanicRecovery(t *testing.T) {
+	// OnAfterToolExecute panics --original tool result preserved.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "read", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Check the original tool output survived the panic.
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult && part.ToolOutput == "original output" {
+						return &provider.GenerateResult{Text: "preserved", FinishReason: provider.FinishStop}, nil
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "lost", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "original output", nil
+			},
+		}),
+		WithOnAfterToolExecute(func(_ AfterToolExecuteInfo) AfterToolExecuteResult {
+			panic("after-execute panic!")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "preserved" {
+		t.Errorf("Text = %q, want preserved (original output should survive panic)", result.Text)
+	}
+}
+
+// --- Finding 9: OnBeforeStep in GenerateObject ---
+
+func TestOnBeforeStep_GenerateObject(t *testing.T) {
+	// Verify OnBeforeStep fires in GenerateObject's tool loop.
+	var hookCalled bool
+	var hookStep int
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         `{"name":"test","value":42}`,
+				FinishReason: provider.FinishStop,
+			}, nil
+		},
+	}
+
+	type TestObj struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	result, err := GenerateObject[TestObj](t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(info BeforeStepInfo) BeforeStepResult {
+			hookCalled = true
+			hookStep = info.Step
+			return BeforeStepResult{}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hookCalled {
+		t.Error("OnBeforeStep was not called in GenerateObject")
+	}
+	if hookStep != 2 {
+		t.Errorf("Step = %d, want 2", hookStep)
+	}
+	if result.Object.Name != "test" {
+		t.Errorf("Object.Name = %q, want test", result.Object.Name)
+	}
+}
+
+// --- Finding 5: Skip=true with both Result and Error set ---
+
+func TestOnBeforeToolExecute_SkipWithResultAndError(t *testing.T) {
+	// When Skip=true with both Result and Error, Error takes precedence.
+	// Result is ignored --LLM receives "error: <message>".
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			// Verify the tool result is the error, not the Result string.
+			for _, msg := range p.Messages {
+				for _, part := range msg.Content {
+					if part.Type == provider.PartToolResult {
+						if part.ToolOutput == "error: access denied" {
+							return &provider.GenerateResult{Text: "error wins", FinishReason: provider.FinishStop}, nil
+						}
+						if part.ToolOutput == "some context" {
+							t.Error("Result string should be ignored when Error is set, but it was sent to LLM")
+						}
+					}
+				}
+			}
+			return &provider.GenerateResult{Text: "unexpected", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "should not run", nil },
+		}),
+		WithOnBeforeToolExecute(func(_ BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{
+				Skip:   true,
+				Result: "some context",            // should be ignored
+				Error:  fmt.Errorf("access denied"), // should win
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "error wins" {
+		t.Errorf("Text = %q, want 'error wins'", result.Text)
+	}
+}
+
+// --- Finding D: Stop=true + ExtraMessages → ExtraMessages ignored ---
+
+func TestOnBeforeStep_StopIgnoresExtraMessages(t *testing.T) {
+	// When Stop=true and ExtraMessages are set, ExtraMessages are ignored.
+	callCount := 0
+	var step2Messages []provider.Message
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			step2Messages = p.Messages
+			return &provider.GenerateResult{Text: "step2", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			return BeforeStepResult{
+				Stop: true,
+				ExtraMessages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "should be ignored"}}},
+				},
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Stop=true → loop should have stopped before step 2, LLM called only once.
+	if callCount != 1 {
+		t.Errorf("LLM called %d times, want 1 (Stop=true should prevent step 2)", callCount)
+	}
+	// step2Messages should be nil (never reached step 2).
+	if step2Messages != nil {
+		t.Error("step 2 should not have been reached")
+	}
+	// Result should have tool calls from step 1 (loop stopped before step 2).
+	if len(result.ToolCalls) != 1 {
+		t.Errorf("ToolCalls = %d, want 1", len(result.ToolCalls))
 	}
 }
 

--- a/object.go
+++ b/object.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -303,6 +304,28 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 	var totalUsage provider.Usage
 
 	for step := 1; step <= o.MaxSteps; step++ {
+		// OnBeforeStep: step 2+ only (step 1 has no prior tool results to act on).
+		if step > 1 && o.OnBeforeStep != nil {
+			var bsr BeforeStepResult
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeStep hook: %v\n", r)
+					}
+				}()
+				bsr = o.OnBeforeStep(BeforeStepInfo{
+					Step:     step,
+					Messages: slices.Clone(params.Messages),
+				})
+			}()
+			if bsr.Stop {
+				break
+			}
+			if len(bsr.ExtraMessages) > 0 {
+				params.Messages = append(params.Messages, bsr.ExtraMessages...)
+			}
+		}
+
 		for _, fn := range o.OnRequest {
 			fn(RequestInfo{
 				Ctx:          ctx,
@@ -390,7 +413,12 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		// Clear tool_choice after the first tool step so the model can freely
 		// produce structured output on subsequent steps.
 		params.ToolChoice = ""
-		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, o.OnToolCallStart, o.OnToolCall)
+		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
+			onToolCallStart: o.OnToolCallStart,
+			onToolCall:      o.OnToolCall,
+			onBeforeExecute: o.OnBeforeToolExecute,
+			onAfterExecute:  o.OnAfterToolExecute,
+		})
 		params.Messages = appendToolRoundTrip(params.Messages, result.Text, nil, result.ToolCalls, toolMessages)
 	}
 

--- a/observability/langfuse/langfuse.go
+++ b/observability/langfuse/langfuse.go
@@ -239,6 +239,10 @@ func (h *Hooks) Run() []goai.Option {
 
 	// OnToolCallStart is intentionally not registered here because
 	// OnToolCall.StartTime already provides accurate timing for tool spans.
+
+	// TODO: Register OnBeforeToolExecute, OnAfterToolExecute, and OnBeforeStep hooks
+	// to annotate spans with tool skip status, output modifications, and loop termination.
+
 	opts := []goai.Option{
 		goai.WithOnRequest(func(info goai.RequestInfo) {
 			input := messagesToInput(info.Messages)

--- a/observability/otel/otel.go
+++ b/observability/otel/otel.go
@@ -166,6 +166,9 @@ func run(cfg config) []goai.Option {
 	// end is declared before opts so WithOnStepFinish can reference it.
 	var end func(text string, finishReason provider.FinishReason)
 
+	// TODO: Register OnBeforeToolExecute, OnAfterToolExecute, and OnBeforeStep hooks
+	// to annotate spans with tool skip status, output modifications, and loop termination.
+
 	opts := []goai.Option{
 		goai.WithOnRequest(func(info goai.RequestInfo) {
 			step++

--- a/options.go
+++ b/options.go
@@ -97,6 +97,21 @@ type options struct {
 	// OnToolCallStart is called before each tool execution.
 	OnToolCallStart []func(ToolCallStartInfo)
 
+	// OnBeforeToolExecute is called before each tool's Execute function.
+	// Can skip execution (e.g., permission denied, doom loop).
+	// Only one callback supported; setting a second replaces the first.
+	OnBeforeToolExecute func(BeforeToolExecuteInfo) BeforeToolExecuteResult
+
+	// OnAfterToolExecute is called after each tool's Execute function,
+	// before the result is sent to the LLM. Can modify output.
+	// Only one callback supported; setting a second replaces the first.
+	OnAfterToolExecute func(AfterToolExecuteInfo) AfterToolExecuteResult
+
+	// OnBeforeStep is called before each LLM call in a multi-step tool loop (step 2+).
+	// Can inject messages or stop the loop.
+	// Only one callback supported; setting a second replaces the first.
+	OnBeforeStep func(BeforeStepInfo) BeforeStepResult
+
 	// ExplicitSchema overrides auto-generated JSON Schema for GenerateObject/StreamObject.
 	ExplicitSchema json.RawMessage
 


### PR DESCRIPTION
## Summary

- Add 3 interceptor hooks: `OnBeforeToolExecute` (permission gate, skip tools), `OnAfterToolExecute` (secret scanning, output transformation), `OnBeforeStep` (inject messages, stop loop)
- Add `Skipped` field to `ToolCallInfo` for observability when tools are skipped
- Fix pre-existing off-by-one in unknown-tool `OnToolCallStart` Step field
- Refactor `executeToolsParallel` to use `toolHooks` struct (internal)

## New docs

- `docs/concepts/hooks.md` -- comprehensive hooks guide with execution order diagram, panic recovery table (5-column split for StreamText step 1 vs 2+), interceptor vs observability hook reference
- `examples/hooks/` -- runnable example with permission gate, secret scanning, loop control
- Updated `docs/api/types.md`, `docs/api/options.md`, `docs/concepts/observability.md`

## Test plan

- [x] 30 hook-specific tests in `hooks_test.go` (PASS)
- [x] All 29 packages pass `go test ./...`
- [x] Coverage >= 90% on all changed packages (pre-commit verified)
- [x] 7 rounds of red-team review with independent verifiers (converged to zero findings)