### PR TITLE
feat: Ctx/Input override, Metadata, StepsExhausted, sequential execution

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -104,6 +104,18 @@ Set to 2 or higher to enable multi-step auto loops. For example, `WithMaxSteps(2
 
 With `GenerateText`, tools with `Execute` can still be executed at step 1 if the model requests them. With `MaxSteps(1)`, GoAI executes those tools and returns without a follow-up generation step.
 
+### WithSequentialToolExecution
+
+Forces tool calls to execute one at a time instead of in parallel.
+
+```go
+func WithSequentialToolExecution() Option
+```
+
+**Default:** `false` (parallel execution).
+
+Useful when tools share non-thread-safe resources or when execution order matters.
+
 ### WithToolChoice
 
 Controls how the model selects tools.
@@ -341,7 +353,7 @@ goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeTo
 })
 ```
 
-Called before each tool's Execute function. Can skip execution for permission checks, rate limiting, or doom-loop detection. `info.Ctx` carries the tool execution context (with tool call ID injected). Only one callback supported (replaces previous). Panic-recovered: a panic skips the tool with an error result.
+Called before each tool's Execute function. Can skip execution for permission checks, rate limiting, or doom-loop detection. `info.Ctx` carries the tool execution context (with tool call ID injected). Only one callback supported (replaces previous). Panic-recovered: a panic skips the tool with an error result. The returned `Ctx` and `Input` fields can override the context and input passed to `Execute` (nil = no override).
 
 ### WithOnAfterToolExecute
 
@@ -352,7 +364,7 @@ goai.WithOnAfterToolExecute(func(info goai.AfterToolExecuteInfo) goai.AfterToolE
 })
 ```
 
-Called after each tool's Execute function, before the result is sent to the LLM. Can modify output for secret scanning, truncation, or transformation. `info.Ctx` carries the same tool execution context as `OnBeforeToolExecute`. Only one callback supported. Panic-recovered: preserves original result.
+Called after each tool's Execute function, before the result is sent to the LLM. Can modify output for secret scanning, truncation, or transformation. `info.Ctx` carries the same tool execution context as `OnBeforeToolExecute`. Only one callback supported. Panic-recovered: preserves original result. The returned `Metadata` field is passed through to `ToolCallInfo.Metadata` for downstream observability hooks.
 
 ### WithOnBeforeStep
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -28,6 +28,7 @@ type TextResult struct {
     ProviderMetadata map[string]map[string]any    // Provider-specific response data.
     Sources          []provider.Source            // Citations/references from all steps.
     ResponseMessages []provider.Message           // Assistant + tool messages for multi-turn continuation.
+    StepsExhausted   bool                         // True when MaxSteps was reached with tool calls still pending.
 }
 ```
 
@@ -244,6 +245,7 @@ type ToolCallInfo struct {
     Duration     time.Duration   // How long execution took.
     Skipped      bool            // True when execution was skipped by OnBeforeToolExecute.
     Error        error           // Non-nil if execution failed.
+    Metadata     map[string]any  // Consumer metadata from OnAfterToolExecute (nil if not set).
 }
 ```
 
@@ -280,9 +282,11 @@ Controls what happens after `OnBeforeToolExecute` runs.
 
 ```go
 type BeforeToolExecuteResult struct {
-    Skip   bool   // Prevent Execute from running; use Result as synthetic output.
-    Result string // Synthetic tool output when Skip is true.
-    Error  error  // Tool error when Skip is true.
+    Skip   bool            // Prevent Execute from running; use Result as synthetic output.
+    Result string          // Synthetic tool output when Skip is true.
+    Error  error           // Tool error when Skip is true.
+    Ctx    context.Context // Replaces tool context (nil = use default).
+    Input  json.RawMessage // Replaces tool input (nil = use original).
 }
 ```
 
@@ -308,8 +312,9 @@ Controls tool output modification before it reaches the LLM.
 
 ```go
 type AfterToolExecuteResult struct {
-    Output string // Replaces tool output (empty = preserve original).
-    Error  error  // Replaces tool error (nil = preserve original).
+    Output   string         // Replaces tool output (empty = preserve original).
+    Error    error          // Replaces tool error (nil = preserve original).
+    Metadata map[string]any // Opaque consumer data, passed to ToolCallInfo.Metadata.
 }
 ```
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -42,7 +42,7 @@ Step 2+ --Transition and next LLM call:
   ... (same pattern as Step 1)
 ```
 
-Note: "step" = one LLM call. Tool execution happens between steps --results feed into the next step's messages.
+Note: "step" = one LLM call. Tool execution happens between steps -- results feed into the next step's messages. By default, tools within a step execute in parallel. Use `WithSequentialToolExecution()` to force one-at-a-time execution when tools share non-thread-safe resources or when execution order matters.
 
 ## Interceptor Hooks
 
@@ -73,6 +73,8 @@ result, _ := goai.GenerateText(ctx, model,
 - `Skip: true, Error: err` --error message sent to LLM (Result is ignored)
 - `Skip: true` (no Result or Error) --empty string sent to LLM
 - Not called for unknown tools (which fail with `ErrUnknownTool`)
+
+The hook can also override the context and input passed to `Execute` via the result's `Ctx` and `Input` fields (nil = no override). This is useful for injecting tracing context or rewriting tool arguments before execution.
 
 **Observability:** When a tool is skipped, `OnToolCall` still fires with `Skipped: true` so observers can track it. `OnAfterToolExecute` does NOT fire for skipped tools.
 

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -84,6 +84,8 @@ func main() {
 				}
 			}
 			fmt.Printf("[PERMISSION] Allowed: %s\n", info.ToolName)
+			// Can also override context or input before Execute:
+			//   return goai.BeforeToolExecuteResult{Ctx: customCtx, Input: rewrittenInput}
 			return goai.BeforeToolExecuteResult{} // proceed normally
 		}),
 
@@ -98,7 +100,11 @@ func main() {
 				redacted = strings.ReplaceAll(redacted, "sk-secret-12345", "sk-***REDACTED***")
 				fmt.Printf("[REDACT] Masked secret in %s output\n", info.ToolName)
 			}
-			return goai.AfterToolExecuteResult{Output: redacted}
+			return goai.AfterToolExecuteResult{
+				Output: redacted,
+				// Metadata flows to OnToolCall for observability (e.g., display title).
+				Metadata: map[string]any{"redacted": true},
+			}
 		}),
 
 		// Hook 3: Loop control -- fires before step 2+ only (not step 1).

--- a/generate.go
+++ b/generate.go
@@ -60,6 +60,11 @@ type TextResult struct {
 	// Sources contains citations/references extracted from the response.
 	Sources []provider.Source
 
+	// StepsExhausted is true when the tool loop terminated because MaxSteps was reached
+	// while the model still requested tool calls. This distinguishes "model finished
+	// naturally" (StepsExhausted=false) from "loop was cut short" (StepsExhausted=true).
+	StepsExhausted bool
+
 	// ResponseMessages contains the assistant and tool messages from all generation steps.
 	// For multi-turn conversations, append these to your message history:
 	//   messages = append(messages, result.ResponseMessages...)
@@ -150,6 +155,8 @@ type TextStream struct {
 
 	// responseMessages is set by the streamWithToolLoop goroutine before doneCh closes.
 	responseMessages []provider.Message
+	// stepsExhausted is set by the streamWithToolLoop goroutine when MaxSteps was reached.
+	stepsExhausted bool
 }
 
 func newTextStream(ctx context.Context, source <-chan provider.StreamChunk) *TextStream {
@@ -472,6 +479,9 @@ func (ts *TextStream) buildResult() *TextResult {
 	}
 	// No data: Steps is nil.
 
+	// Set StepsExhausted from streamWithToolLoop goroutine.
+	result.StepsExhausted = ts.stepsExhausted
+
 	// Populate ResponseMessages.
 	if ts.responseMessages != nil {
 		// Multi-step: set by streamWithToolLoop goroutine.
@@ -599,6 +609,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		var lastResponse provider.ResponseMetadata
 		var lastReasoning []provider.Part
 		var steps []StepResult
+		var stepsExhausted bool
 		firstStep := true       // true only for step 1 (already have firstResult)
 		stepStart := step1Start // goroutine-local start time per step
 
@@ -776,6 +787,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 
 			// --- Execute tools in parallel ---
 			toolMsgs := executeToolsParallel(ctx, ds.toolCalls, toolMap, step, toolHooks{
+				sequential:      o.SequentialTools,
 				onToolCallStart: o.OnToolCallStart,
 				onToolCall:      o.OnToolCall,
 				onBeforeExecute: o.OnBeforeToolExecute,
@@ -789,8 +801,16 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			params.ToolChoice = ""
 		}
 
+		// StepsExhausted: true only when MaxSteps was reached AND the last step
+		// still had tool calls pending (model wanted to continue but was cut short).
+		// If the last step finished naturally (no tool calls), it's not exhausted.
+		if len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
+			stepsExhausted = true
+		}
+
 		// Set responseMessages before emitting ChunkFinish (safe: ts.buildResult reads
 		// responseMessages only after doneCh closes, which happens after out is closed).
+		ts.stepsExhausted = stepsExhausted
 		ts.responseMessages = buildResponseMessages(params.Messages[originalLen:], steps, lastReasoning)
 
 		// Emit final ChunkFinish with total usage and last step Response metadata.
@@ -1011,6 +1031,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// produce a text response on subsequent steps.
 		params.ToolChoice = ""
 		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
+			sequential:      o.SequentialTools,
 			onToolCallStart: o.OnToolCallStart,
 			onToolCall:      o.OnToolCall,
 			onBeforeExecute: o.OnBeforeToolExecute,
@@ -1021,8 +1042,11 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		params.Messages = appendToolRoundTrip(params.Messages, result.Text, nil, result.ToolCalls, toolMessages)
 	}
 
-	// MaxSteps reached.
+	// MaxSteps reached. This path is only reachable when the last step had tool calls
+	// (if it had no tool calls, the early return at line ~1023 would have fired).
+	// Set StepsExhausted = true -- the model wanted to continue but was cut short.
 	tr := buildTextResult(steps, totalUsage)
+	tr.StepsExhausted = true
 	tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
 	return tr, nil
 }
@@ -1069,8 +1093,9 @@ type toolOutput struct {
 	err    error
 }
 
-// toolHooks bundles the hook functions passed to executeToolsParallel.
+// toolHooks bundles the hook functions and options passed to executeToolsParallel.
 type toolHooks struct {
+	sequential         bool // when true, execute tools one at a time
 	onToolCallStart    []func(ToolCallStartInfo)
 	onToolCall         []func(ToolCallInfo)
 	onBeforeExecute    func(BeforeToolExecuteInfo) BeforeToolExecuteResult
@@ -1129,9 +1154,10 @@ func executeToolsParallel(
 			continue
 		}
 
-		wg.Add(1)
-		go func(i int, tc provider.ToolCall, tool Tool) {
-			defer wg.Done()
+		toolFn := func(i int, tc provider.ToolCall, tool Tool) {
+			if !hooks.sequential {
+				defer wg.Done()
+			}
 			var hookFired bool // true after OnToolCallStart completes (before Execute)
 			var executed bool  // tracks whether Execute ran (for panic recovery)
 			defer func() {
@@ -1232,6 +1258,13 @@ func executeToolsParallel(
 					}
 					return
 				}
+				// Apply hook overrides for non-skipped tools.
+				if beforeResult.Ctx != nil {
+					toolCtx = beforeResult.Ctx
+				}
+				if beforeResult.Input != nil {
+					tc.Input = beforeResult.Input
+				}
 			}
 
 			start := time.Now()
@@ -1239,6 +1272,7 @@ func executeToolsParallel(
 			executed = true
 
 			// OnAfterToolExecute: can modify output (secret scanning, truncation, etc.).
+			var afterMetadata map[string]any
 			if hooks.onAfterExecute != nil {
 				func() {
 					defer func() {
@@ -1262,6 +1296,7 @@ func executeToolsParallel(
 					if afterResult.Error != nil {
 						err = afterResult.Error
 					}
+					afterMetadata = afterResult.Metadata
 				}()
 			}
 
@@ -1284,6 +1319,7 @@ func executeToolsParallel(
 						StartTime:  start,
 						Duration:   time.Since(start),
 						Error:      err,
+						Metadata:   afterMetadata,
 					}
 					var parsed any
 					if err == nil && json.Unmarshal([]byte(output), &parsed) == nil {
@@ -1292,10 +1328,18 @@ func executeToolsParallel(
 					f(info)
 				}(fn)
 			}
-		}(i, tc, tool)
+		}
+		if hooks.sequential {
+			toolFn(i, tc, tool)
+		} else {
+			wg.Add(1)
+			go toolFn(i, tc, tool)
+		}
 	}
 
-	wg.Wait()
+	if !hooks.sequential {
+		wg.Wait()
+	}
 	return buildToolMessages(calls, results)
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -101,6 +101,11 @@ type ToolCallInfo struct {
 
 	// Error is non-nil if the tool execution failed.
 	Error error
+
+	// Metadata is opaque consumer data set by OnAfterToolExecute.
+	// Nil if no OnAfterToolExecute hook is registered or if the hook
+	// returned nil Metadata.
+	Metadata map[string]any
 }
 
 // WithOnStepFinish adds a callback invoked after each generation step completes.
@@ -203,6 +208,19 @@ type BeforeToolExecuteResult struct {
 	// Result is ignored when Error is set --the LLM receives "error: <message>".
 	// Ignored when Skip is false.
 	Error error
+
+	// Ctx, when non-nil, replaces the context passed to tool.Execute.
+	// Use this to inject per-tool values (auth tokens, session IDs, timeouts)
+	// or to wrap the context with context.WithTimeout for per-tool deadlines.
+	// Nil means use the default toolCtx (parent ctx + tool call ID).
+	// Ignored when Skip is true.
+	Ctx context.Context
+
+	// Input, when non-nil, replaces the tool arguments passed to Execute.
+	// Use for input normalization, PII redaction, or secret injection.
+	// Nil means use the original input from the LLM.
+	// Ignored when Skip is true.
+	Input json.RawMessage
 }
 
 // WithOnBeforeToolExecute adds a callback invoked before each known tool's Execute function.
@@ -250,6 +268,13 @@ type AfterToolExecuteResult struct {
 	// Error, when non-nil, replaces the tool's original error.
 	// A nil value preserves the original error (cannot clear an error to nil).
 	Error error
+
+	// Metadata is opaque consumer data attached to the tool call result.
+	// Passed through to ToolCallInfo.Metadata in the OnToolCall hook.
+	// Use for tool titles, display tags, scanner flags, or any consumer-specific
+	// data that should travel alongside the tool result.
+	// Nil means no metadata.
+	Metadata map[string]any
 }
 
 // WithOnAfterToolExecute adds a callback invoked after each tool's Execute function,

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/zendev-sh/goai/provider"
@@ -1871,5 +1873,291 @@ func TestWithOnRequest_SystemMessageInMessages(t *testing.T) {
 	}
 	if captured.Messages[1].Role != provider.RoleUser {
 		t.Errorf("Messages[1].Role = %q, want user", captured.Messages[1].Role)
+	}
+}
+
+// --- Gap 1: BeforeToolExecuteResult.Ctx replaces tool context ---
+
+type ctxKeyForTest struct{}
+
+func TestOnBeforeToolExecute_CtxOverride(t *testing.T) {
+	// Hook returns a custom Ctx with a marker value.
+	// Tool Execute checks it received the overridden context.
+	var toolSawValue any
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "checker", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "checker",
+			Execute: func(ctx context.Context, _ json.RawMessage) (string, error) {
+				toolSawValue = ctx.Value(ctxKeyForTest{})
+				return "ok", nil
+			},
+		}),
+		WithOnBeforeToolExecute(func(info BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{
+				Ctx: context.WithValue(info.Ctx, ctxKeyForTest{}, "overridden"),
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if toolSawValue != "overridden" {
+		t.Errorf("tool ctx value = %v, want \"overridden\"", toolSawValue)
+	}
+}
+
+// --- Gap 2: BeforeToolExecuteResult.Input replaces tool input ---
+
+func TestOnBeforeToolExecute_InputOverride(t *testing.T) {
+	// Hook rewrites input from /secret/file to /safe/file.
+	// Tool Execute receives the rewritten input.
+	var receivedInput json.RawMessage
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "read", Input: json.RawMessage(`{"path":"/secret/file"}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, input json.RawMessage) (string, error) {
+				receivedInput = input
+				return "safe contents", nil
+			},
+		}),
+		WithOnBeforeToolExecute(func(info BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{
+				Input: json.RawMessage(`{"path":"/safe/file"}`),
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(receivedInput) != `{"path":"/safe/file"}` {
+		t.Errorf("tool received input = %s, want {\"path\":\"/safe/file\"}", receivedInput)
+	}
+}
+
+// --- Gap 3: AfterToolExecuteResult.Metadata flows to ToolCallInfo.Metadata ---
+
+func TestOnAfterToolExecute_Metadata(t *testing.T) {
+	// After hook sets Metadata. OnToolCall receives it.
+	var capturedMeta map[string]any
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "read", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name: "read",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				return "file contents", nil
+			},
+		}),
+		WithOnAfterToolExecute(func(_ AfterToolExecuteInfo) AfterToolExecuteResult {
+			return AfterToolExecuteResult{
+				Metadata: map[string]any{"title": "Read file"},
+			}
+		}),
+		WithOnToolCall(func(info ToolCallInfo) {
+			capturedMeta = info.Metadata
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedMeta == nil {
+		t.Fatal("OnToolCall Metadata was nil, want non-nil")
+	}
+	if capturedMeta["title"] != "Read file" {
+		t.Errorf("Metadata[\"title\"] = %v, want \"Read file\"", capturedMeta["title"])
+	}
+}
+
+// --- Gap 4: TextResult.StepsExhausted ---
+
+func TestStepsExhausted_True(t *testing.T) {
+	// MaxSteps=2, model always requests tool calls. Result.StepsExhausted should be true.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", callCount), Name: "noop", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+			}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(2),
+		WithTools(Tool{
+			Name:    "noop",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.StepsExhausted {
+		t.Error("StepsExhausted = false, want true (model never stopped requesting tools)")
+	}
+	if callCount != 2 {
+		t.Errorf("callCount = %d, want 2 (both MaxSteps consumed)", callCount)
+	}
+}
+
+func TestStepsExhausted_False(t *testing.T) {
+	// MaxSteps=3, model stops after 2 steps. Result.StepsExhausted should be false.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "noop", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "noop",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.StepsExhausted {
+		t.Error("StepsExhausted = true, want false (model stopped naturally)")
+	}
+}
+
+// --- Gap 5: WithSequentialToolExecution ---
+
+func TestSequentialToolExecution(t *testing.T) {
+	// Structural proof: track max concurrent executions.
+	// With sequential mode, maxConcurrent must be exactly 1.
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	var order []string
+	var mu sync.Mutex
+
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls: []provider.ToolCall{
+						{ID: "tc1", Name: "a", Input: json.RawMessage(`{}`)},
+						{ID: "tc2", Name: "b", Input: json.RawMessage(`{}`)},
+						{ID: "tc3", Name: "c", Input: json.RawMessage(`{}`)},
+					},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	makeTool := func(name string) Tool {
+		return Tool{
+			Name: name,
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+				cur := concurrent.Add(1)
+				// Track peak concurrency.
+				for {
+					old := maxConcurrent.Load()
+					if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				// Record execution order.
+				mu.Lock()
+				order = append(order, name)
+				mu.Unlock()
+				concurrent.Add(-1)
+				return name + " done", nil
+			},
+		}
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(makeTool("a"), makeTool("b"), makeTool("c")),
+		WithSequentialToolExecution(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Structural proof: max concurrency must be 1 (sequential).
+	if mc := maxConcurrent.Load(); mc != 1 {
+		t.Errorf("maxConcurrent = %d, want 1 (sequential execution)", mc)
+	}
+	// Order must be deterministic: a, b, c (matches tool call order).
+	if len(order) != 3 {
+		t.Fatalf("order len = %d, want 3", len(order))
+	}
+	expected := []string{"a", "b", "c"}
+	for i, name := range expected {
+		if order[i] != name {
+			t.Errorf("order[%d] = %q, want %q (full order: %v)", i, order[i], name, order)
+		}
 	}
 }

--- a/object.go
+++ b/object.go
@@ -415,6 +415,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		// produce structured output on subsequent steps.
 		params.ToolChoice = ""
 		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
+			sequential:      o.SequentialTools,
 			onToolCallStart: o.OnToolCallStart,
 			onToolCall:      o.OnToolCall,
 			onBeforeExecute: o.OnBeforeToolExecute,

--- a/options.go
+++ b/options.go
@@ -64,6 +64,11 @@ type options struct {
 	// MaxSteps is the maximum number of auto tool loop iterations (default 1 = no loop).
 	MaxSteps int
 
+	// SequentialTools, when true, forces tool calls to execute one at a time
+	// instead of in parallel. Useful when tools share non-thread-safe resources
+	// or when execution order matters.
+	SequentialTools bool
+
 	// MaxRetries is the retry count for transient errors (default 2).
 	MaxRetries int
 
@@ -201,6 +206,12 @@ func WithSeed(s int) Option {
 // WithStopSequences sets stop sequences.
 func WithStopSequences(seqs ...string) Option {
 	return func(o *options) { o.StopSequences = seqs }
+}
+
+// WithSequentialToolExecution forces tool calls to execute one at a time
+// instead of in parallel. Useful when tools share non-thread-safe resources.
+func WithSequentialToolExecution() Option {
+	return func(o *options) { o.SequentialTools = true }
 }
 
 // WithMaxSteps sets the maximum auto tool loop iterations.


### PR DESCRIPTION
## Summary

Five new capabilities for the lifecycle hooks system, closing all SDK gaps identified during zenflow/zencode integration analysis:

1. **`BeforeToolExecuteResult.Ctx`** -- override context passed to Execute (per-tool timeout, auth injection)
2. **`BeforeToolExecuteResult.Input`** -- rewrite tool arguments before Execute (PII redaction, normalization)
3. **`AfterToolExecuteResult.Metadata`** -- opaque consumer data flowing to `ToolCallInfo.Metadata` (tool titles, scanner flags)
4. **`TextResult.StepsExhausted`** -- true when MaxSteps reached with pending tool calls (truncated vs natural finish)
5. **`WithSequentialToolExecution()`** -- force one-at-a-time tool execution for non-thread-safe resources

## Bug fix

- StreamText `StepsExhausted` false positive: was triggering when last step finished naturally at MaxSteps boundary. Now also checks `len(lastStep.ToolCalls) > 0`.

## Test plan

- [x] 6 new tests (45 total hook tests): CtxOverride, InputOverride, Metadata flow, StepsExhausted true/false, SequentialExecution
- [x] Sequential test uses atomic max-concurrent counter (structural proof, no sleep)
- [x] All 29 packages pass, coverage >= 90%
- [x] Multiple deep-review rounds converged to 0 findings