### PR TITLE
feat: observability hooks enhancement - OnFinish, wrapper pattern, full D2 taxonomy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,25 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Test observability/langfuse
+        run: cd observability/langfuse && go test -race -coverprofile=coverage-langfuse.out ./...
+
+      - name: Test observability/otel
+        run: cd observability/otel && go test -race -coverprofile=coverage-otel.out ./...
+
       - name: Coverage Summary
         run: |
           total=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}')
-          echo "Coverage: $total"
+          echo "Coverage (core): $total"
+          langfuse=$(cd observability/langfuse && go tool cover -func=coverage-langfuse.out | grep ^total | awk '{print $3}')
+          echo "Coverage (langfuse): $langfuse"
+          otel=$(cd observability/otel && go tool cover -func=coverage-otel.out | grep ^total | awk '{print $3}')
+          echo "Coverage (otel): $otel"
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: coverage.out
+          files: coverage.out,observability/langfuse/coverage-langfuse.out,observability/otel/coverage-otel.out
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ goai/
 ├── caching.go              # Prompt cache control (copies msgs, no mutation)
 ├── types.go                # Tool struct
 ├── messages.go             # Message builders
-├── hooks.go                # Telemetry hooks
+├── hooks.go                # Lifecycle hooks (OnRequest, OnResponse, OnToolCallStart, OnToolCall, OnStepFinish, OnFinish, OnBeforeStep, OnBeforeToolExecute, OnAfterToolExecute + Wrap* helpers)
 ├── partial_json.go         # Partial JSON parser for streaming
 ├── provider/
 │   ├── provider.go         # LanguageModel, EmbeddingModel, ImageModel interfaces
@@ -55,7 +55,7 @@ goai/
 ├── observability/
 │   ├── langfuse/           # Langfuse observability integration (separate go.mod)
 │   └── otel/               # OpenTelemetry tracing and metrics (separate go.mod)
-├── examples/               # 26 runnable examples (including 7 MCP examples)
+├── examples/               # 28 runnable examples (including 7 MCP examples)
 └── bench/                  # Performance benchmarks (GoAI vs Vercel AI SDK)
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 - **Computer use**: Anthropic computer, bash, text editor tools for autonomous desktop interaction
 - **20 provider-defined tools**: Web fetch, file search, image generation, X search, and more - [full list](#provider-defined-tools)
 - **MCP client**: Connect to any MCP server (stdio, HTTP, SSE), auto-convert tools for use with GoAI
-- **Observability**: Built-in Langfuse integration and optional OpenTelemetry (OTel) support, with hooks for request/response/step/tool tracing
-- **Telemetry hooks**: `OnRequest`, `OnResponse`, `OnStepFinish`, `OnToolCall`, `OnToolCallStart` callbacks
+- **Observability**: Built-in Langfuse and OpenTelemetry (OTel) integrations for tracing generations, tools, and multi-step loops
+- **9 lifecycle hooks**: Observability (`OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish`, `OnFinish`) and interceptor (`OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep`) hooks for permission gates, secret scanning, output transformation, and loop control
 - **Retry/backoff**: Automatic retry with exponential backoff on retryable HTTP errors (429/5xx)
 - **Minimal dependencies**: Core depends on `golang.org/x/oauth2` + one indirect (`cloud.google.com/go/compute/metadata`). Optional `observability/otel` submodule uses separate `go.mod` with OTel SDK.
 
@@ -318,20 +318,40 @@ Also supported: Google Imagen (`google.Image("imagen-4.0-generate-001")`) and Ve
 
 ## Observability
 
-Built-in [Langfuse](https://langfuse.com) integration for tracing generations, tool calls, and multi-step loops:
+Built-in [Langfuse](https://langfuse.com) and [OpenTelemetry](https://opentelemetry.io) integrations. Nine lifecycle hooks cover the full generation pipeline -- observability providers use them to trace LLM calls, tool executions, and multi-step agent loops:
 
 ```go
 import "github.com/zendev-sh/goai/observability/langfuse"
 
 // Credentials from env: LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_HOST
-// Or override via langfuse.PublicKey(), langfuse.SecretKey(), langfuse.Host().
 result, err := goai.GenerateText(ctx, model,
     goai.WithPrompt("Hello"),
-    langfuse.WithTracing(), // wires OnRequest, OnResponse, OnStepFinish, OnToolCall
+    goai.WithTools(weatherTool),
+    goai.WithMaxSteps(5),
+    langfuse.WithTracing(langfuse.TraceName("my-agent")),
 )
 ```
 
-See [examples/langfuse](examples/langfuse/) and [observability docs](https://goai.sh/concepts/observability) for details.
+Interceptor hooks let you control tool execution without modifying core code:
+
+```go
+// Permission gate: block dangerous tools
+goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+    if info.ToolName == "delete_file" {
+        return goai.BeforeToolExecuteResult{Skip: true, Result: "Permission denied."}
+    }
+    return goai.BeforeToolExecuteResult{}
+}),
+
+// Detect max-steps exhaustion
+goai.WithOnFinish(func(info goai.FinishInfo) {
+    if info.StepsExhausted {
+        log.Printf("Loop exhausted after %d steps", info.TotalSteps)
+    }
+}),
+```
+
+See [examples/hooks](examples/hooks/), [examples/langfuse](examples/langfuse/), [examples/otel](examples/otel/), and the [observability docs](https://goai.sh/concepts/observability) for details.
 
 ## Providers
 
@@ -534,15 +554,19 @@ fmt.Printf("Model used: %s\n", result.Response.Model)
 | `WithPromptCaching(b)`    | Enable prompt caching                    | false            |
 | `WithToolChoice(tc)`      | "auto", "none", "required", or tool name | -                |
 
-### Telemetry Hooks
+### Lifecycle Hooks
 
-| Option                    | Description                              |
-| ------------------------- | ---------------------------------------- |
-| `WithOnRequest(fn)`       | Called before each API call              |
-| `WithOnResponse(fn)`      | Called after each API call               |
-| `WithOnStepFinish(fn)`    | Called after each tool loop step         |
-| `WithOnToolCall(fn)`      | Called after each tool execution         |
-| `WithOnToolCallStart(fn)` | Called before each tool execution begins |
+| Option                          | Description                                                      |
+| ------------------------------- | ---------------------------------------------------------------- |
+| `WithOnRequest(fn)`             | Called before each API call                                      |
+| `WithOnResponse(fn)`            | Called after each API call                                       |
+| `WithOnToolCallStart(fn)`       | Called before each tool execution begins                         |
+| `WithOnToolCall(fn)`            | Called after each tool execution                                 |
+| `WithOnStepFinish(fn)`          | Called after each tool loop step                                 |
+| `WithOnFinish(fn)`              | Called once after all steps complete (carries `StepsExhausted`)  |
+| `WithOnBeforeToolExecute(fn)`   | Intercept before tool Execute -- can skip, override ctx/input    |
+| `WithOnAfterToolExecute(fn)`    | Intercept after tool Execute -- can modify output/error          |
+| `WithOnBeforeStep(fn)`          | Intercept before step 2+ -- can inject messages or stop loop    |
 
 ### Structured Output Options
 
@@ -728,10 +752,15 @@ See the [examples/](examples/) directory:
 
 - [chat](examples/chat/) - Non-streaming generation
 - [streaming](examples/streaming/) - Real-time text streaming
+- [streaming-tools](examples/streaming-tools/) - Streaming with multi-step tool loops
 - [structured](examples/structured/) - Structured output with Go generics
 - [tools](examples/tools/) - Single tool call
 - [agent-loop](examples/agent-loop/) - Multi-step agent with callbacks
+- [multi-turn](examples/multi-turn/) - Multi-turn conversation with ResponseMessages
 - [citations](examples/citations/) - Accessing sources and citations
+- [hooks](examples/hooks/) - Lifecycle hooks: permission gates, secret scanning, loop control, OnFinish
+- [langfuse](examples/langfuse/) - Langfuse tracing integration
+- [otel](examples/otel/) - OpenTelemetry tracing and metrics
 - [computer-use](examples/computer-use/) - Anthropic computer, bash, and text editor tools
 - [embedding](examples/embedding/) - Embeddings with similarity search
 - [web-search](examples/web-search/) - Web search across providers (OpenAI, Anthropic, Google)

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -35,7 +35,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 2. Calls `model.DoGenerate` with automatic retry on transient errors.
 3. If the model returns tool calls and executable tools are registered, executes them and appends results to the conversation.
 4. Repeats up to `MaxSteps` times (default 1 = single model step; if that step requests executable tools, they can still be executed before returning).
-5. Fires telemetry hooks (`OnRequest`, `OnResponse`, `OnStepFinish`, `OnToolCall`) at appropriate points.
+5. Fires lifecycle hooks at appropriate points: observability hooks (`OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish`, `OnFinish`) and interceptor hooks (`OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep`).
 
 **Example:**
 

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -278,7 +278,7 @@ func WithProviderOptions(opts map[string]any) Option
 > **Panic handling:** Hooks use two panic strategies depending on execution context:
 >
 > - **Caller goroutine** (`OnRequest`): panics propagate in `GenerateText`, `GenerateObject`, and `StreamText` first step. In `StreamText` step 2+ (goroutine), each callback is individually recovered.
-> - **Mixed** (`OnResponse`): recovered in `GenerateText` and background goroutines; propagates in `GenerateObject`, `StreamObject` error path, and `StreamText` first-step error path. See per-hook docs below.
+> - **Mixed** (`OnResponse`): recovered in `GenerateText`, `GenerateObject`, `StreamObject`, and background goroutines; propagates in `StreamText` first-step error path. See per-hook docs below.
 > - **Worker goroutines** (`OnStepFinish`, `OnToolCallStart`, `OnToolCall`): panics are recovered, logged to stderr, and do not propagate.
 > - **Interceptor hooks** (`OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep`): always panic-recovered with hook-specific behavior (skip tool, preserve result, or proceed normally).
 
@@ -304,7 +304,7 @@ func WithOnResponse(fn func(ResponseInfo)) Option
 
 **Default:** `nil`.
 
-> **Panic behavior:** In `GenerateText`, all `StreamText` success paths, and `StreamObject` (success path), panics are individually recovered and logged to stderr. In `GenerateObject`, `StreamObject` (error path), and `StreamText`'s first-step error path, panics propagate to the caller.
+> **Panic behavior:** In `GenerateText`, all `StreamText` success paths, `GenerateObject`, `StreamObject` (success path), and `StreamObject` (error path), panics are individually recovered and logged to stderr. In `StreamText`'s first-step error path, panics propagate to the caller.
 
 ### WithOnStepFinish
 
@@ -378,6 +378,18 @@ goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
 Called before each LLM call in a multi-step tool loop (step 2+ only, not step 1). Can inject additional messages or stop the loop early. `info.Ctx` carries the generation context for cancellation checks or external calls. Only one callback supported. Panic-recovered: a panic is logged and the step proceeds normally.
 
 > **Panic handling note:** Interceptor hooks (`OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep`): always panic-recovered with hook-specific behavior (skip tool, preserve result, or proceed normally).
+
+### WithOnFinish
+
+```go
+goai.WithOnFinish(func(info goai.FinishInfo) {
+    // info.StepsExhausted, info.TotalSteps, info.TotalUsage, info.FinishReason
+})
+```
+
+Called once after all generation steps complete. Fires in all code paths: `GenerateText`, `StreamText`, `GenerateObject` (including max_steps error), and `StreamObject`. Does NOT fire when DoGenerate/DoStream returns a provider error. Multiple callbacks supported (append). Panic-recovered.
+
+`FinishInfo.StepsExhausted` is the authoritative signal for max-steps exhaustion -- it is not available from any per-step hook.
 
 ---
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -241,9 +241,9 @@ type ToolCallInfo struct {
     Input        json.RawMessage // Raw JSON arguments passed to the tool.
     Output       string          // String result returned by the tool.
     OutputObject any             // Parsed JSON value of Output when the tool returned valid JSON; nil otherwise.
-    StartTime    time.Time       // When the tool execution began.
-    Duration     time.Duration   // How long execution took.
-    Skipped      bool            // True when execution was skipped by OnBeforeToolExecute.
+    StartTime    time.Time       // When tool execution began. Zero for unknown tools. For skipped tools, reflects skip decision time.
+    Duration     time.Duration   // Time from before Execute to after OnAfterToolExecute (includes hook overhead). Zero when Skipped.
+    Skipped      bool            // True when skipped by OnBeforeToolExecute. Duration is zero, StartTime reflects skip decision time.
     Error        error           // Non-nil if execution failed.
     Metadata     map[string]any  // Consumer metadata from OnAfterToolExecute (nil if not set).
 }
@@ -338,6 +338,19 @@ Controls behavior before the next LLM call.
 type BeforeStepResult struct {
     ExtraMessages []provider.Message // Appended before LLM call. Ignored when Stop is true.
     Stop          bool               // Terminate tool loop. ExtraMessages are ignored.
+}
+```
+
+### FinishInfo
+
+Passed to the `OnFinish` hook after all generation steps complete.
+
+```go
+type FinishInfo struct {
+    StepsExhausted bool               // True when MaxSteps reached while model still wanted tools.
+    TotalSteps     int                // Number of generation steps executed.
+    TotalUsage     provider.Usage     // Aggregated token usage across all steps.
+    FinishReason   provider.FinishReason // Finish reason from the last step.
 }
 ```
 

--- a/docs/concepts/hooks.md
+++ b/docs/concepts/hooks.md
@@ -5,7 +5,7 @@ description: "Intercept and control GoAI's tool loop with lifecycle hooks. Permi
 
 # Lifecycle Hooks
 
-GoAI provides eight lifecycle hooks that let you observe, intercept, and control the generation process without modifying core SDK code.
+GoAI provides nine lifecycle hooks that let you observe, intercept, and control the generation process without modifying core SDK code.
 
 ## Hook Categories
 
@@ -13,7 +13,7 @@ Hooks fall into two categories:
 
 | Category | Hooks | Callbacks | Purpose |
 |----------|-------|-----------|---------|
-| **Observability** | `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish` | Multiple (append) | Logging, metrics, tracing |
+| **Observability** | `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish`, `OnFinish` | Multiple (append) | Logging, metrics, tracing |
 | **Interceptor** | `OnBeforeToolExecute`, `OnAfterToolExecute`, `OnBeforeStep` | Single (replace) | Permission, transformation, control flow |
 
 Observability hooks are fire-and-forget: they receive data but cannot change behavior. Interceptor hooks return values that control execution.
@@ -40,6 +40,9 @@ Step 2+ --Transition and next LLM call:
   OnBeforeStep         → can inject messages or stop loop
   OnRequest            → before LLM call
   ... (same pattern as Step 1)
+
+After all steps:
+  OnFinish             → once, with StepsExhausted, TotalSteps, TotalUsage
 ```
 
 Note: "step" = one LLM call. Tool execution happens between steps -- results feed into the next step's messages. By default, tools within a step execute in parallel. Use `WithSequentialToolExecution()` to force one-at-a-time execution when tools share non-thread-safe resources or when execution order matters.
@@ -171,6 +174,20 @@ goai.WithOnStepFinish(func(step goai.StepResult) {
 }),
 ```
 
+### OnFinish
+
+```go
+goai.WithOnFinish(func(info goai.FinishInfo) {
+    if info.StepsExhausted {
+        log.Printf("Loop exhausted after %d steps", info.TotalSteps)
+    }
+    log.Printf("Finished: %d steps, %d total tokens, reason=%s",
+        info.TotalSteps, info.TotalUsage.InputTokens+info.TotalUsage.OutputTokens, info.FinishReason)
+}),
+```
+
+Fires once after all generation steps complete. This is the only hook that receives `StepsExhausted`, making it the authoritative signal for "max steps exhaustion" detection.
+
 ## Panic Recovery
 
 Hook panics are recovered in most paths. "Propagates" = crashes the caller. "Recovered" = caught, logged to stderr, execution continues.
@@ -178,15 +195,16 @@ Hook panics are recovered in most paths. "Propagates" = crashes the caller. "Rec
 | Hook | GenerateText | StreamText (step 1)* | StreamText (step 2+) | GenerateObject |
 |------|-------------|---------------------|---------------------|----------------|
 | OnRequest | Propagates | Propagates | Recovered | Propagates |
-| OnResponse | Recovered | Propagates (error) | Recovered | Propagates |
+| OnResponse | Recovered | Propagates (error) | Recovered | Recovered |
 | OnToolCallStart | Recovered | Recovered | Recovered | Recovered |
 | OnToolCall | Recovered | Recovered | Recovered | Recovered |
 | OnStepFinish | Recovered | Recovered | Recovered | Recovered |
 | OnBeforeToolExecute | Recovered (skips tool) | Recovered (skips tool) | Recovered (skips tool) | Recovered (skips tool) |
 | OnAfterToolExecute | Recovered (preserves result) | Recovered (preserves result) | Recovered (preserves result) | Recovered (preserves result) |
 | OnBeforeStep | Recovered (proceeds) | N/A | Recovered (proceeds) | Recovered (proceeds) |
+| OnFinish | Recovered | Recovered | Recovered | Recovered |
 
-*\* StreamText step 1 runs synchronously in the caller's goroutine (before the background goroutine starts). Step 2+ runs in a background goroutine where all panics are recovered. StreamObject OnRequest propagates like GenerateObject. StreamObject OnResponse propagates on the error path but is recovered on the success path (consume goroutine).*
+*\* StreamText step 1 runs synchronously in the caller's goroutine (before the background goroutine starts). Step 2+ runs in a background goroutine where all panics are recovered. StreamObject OnRequest propagates like GenerateObject. StreamObject OnResponse is recovered on both success and error paths.*
 
 ## Complete Example
 
@@ -194,4 +212,4 @@ See [`examples/hooks/main.go`](https://github.com/zendev-sh/goai/blob/main/examp
 
 ## Integration with Observability Providers
 
-GoAI's [OpenTelemetry](observability.md#opentelemetry) and [Langfuse](observability.md#langfuse) integrations use the observability hooks internally. The interceptor hooks are not yet integrated into these providers --use them directly in your application code.
+GoAI's [OpenTelemetry](observability.md#opentelemetry) and [Langfuse](observability.md#langfuse) integrations use the observability hooks internally. The interceptor hooks are integrated via the wrapper pattern (`WrapOnBeforeToolExecute`, `WrapOnAfterToolExecute`, `WrapOnBeforeStep`) -- observability providers wrap user hooks to add annotations without replacing them. Apply `WithTracing` after user hooks for correct wrapping.

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -5,7 +5,7 @@ description: "Trace LLM calls, tool executions, and agent runs in GoAI. Plug-in 
 
 # Observability
 
-GoAI's observability is built on eight lifecycle hooks: `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish`, `OnBeforeToolExecute`, `OnAfterToolExecute`, and `OnBeforeStep`. Any observability provider can plug into these hooks to trace LLM calls, tool executions, and multi-step agent runs.
+GoAI's observability is built on nine lifecycle hooks: `OnRequest`, `OnResponse`, `OnToolCallStart`, `OnToolCall`, `OnStepFinish`, `OnFinish`, `OnBeforeToolExecute`, `OnAfterToolExecute`, and `OnBeforeStep`. Any observability provider can plug into these hooks to trace LLM calls, tool executions, and multi-step agent runs.
 
 ## How It Works
 
@@ -29,11 +29,12 @@ Each hook fires at a specific point in the request lifecycle:
 | `OnToolCallStart` | Before each tool execution | Tool call ID, tool name, step, input        |
 | `OnToolCall`      | After each tool execution  | Tool name, input/output, duration, errors   |
 | `OnStepFinish`    | After each step completes  | Step number, finish reason, tool calls      |
+| `OnFinish`        | After all steps complete   | StepsExhausted, TotalSteps, TotalUsage, FinishReason |
 | `OnBeforeToolExecute`* | Before each tool's Execute function | Tool call ID, tool name, step, input; can skip execution |
 | `OnAfterToolExecute`*  | After each tool's Execute function  | Tool call ID, tool name, output, error; can modify output |
 | `OnBeforeStep`*        | Before each LLM call (step 2+)     | Step number, messages; can inject messages or stop loop   |
 
-*\* Interceptor hooks: only one callback supported per hook (setting a second replaces the first). The first five hooks support multiple callbacks.*
+*\* Interceptor hooks: only one callback supported per hook (setting a second replaces the first). The first six hooks support multiple callbacks.*
 
 This design means observability never touches the core SDK. Providers are optional imports with zero impact on non-instrumented code.
 
@@ -65,6 +66,9 @@ func MyTracer() []goai.Option {
         }),
         goai.WithOnStepFinish(func(step goai.StepResult) {
             // close span, flush
+        }),
+        goai.WithOnFinish(func(info goai.FinishInfo) {
+            // record final status, detect max_steps exhaustion
         }),
     }
 }
@@ -153,8 +157,16 @@ langfuse.WithTracing(
     langfuse.SessionID("session-abc123"),
     langfuse.Tags("prod", "v1"),
     langfuse.Release("2026.04.03"),
+    langfuse.Version("1.0.0"),
     langfuse.Environment("production"),
+    langfuse.Metadata(map[string]any{"key": "value"}),
+    langfuse.PromptName("my-prompt"),
+    langfuse.PromptVersion(1),
+    langfuse.PublicKey("pk-lf-..."),  // override env var
+    langfuse.SecretKey("sk-lf-..."),  // override env var
+    langfuse.Host("https://cloud.langfuse.com"), // override env var
     langfuse.OnFlushError(func(err error) { log.Printf("langfuse flush error: %v", err) }),
+    langfuse.EagerToolSpans(true), // opt-in: real-time tool visibility (extra HTTP per tool)
 )
 ```
 
@@ -227,9 +239,9 @@ Each run creates a structured trace:
 
 ```
 chat (root)
-├── chat {model}      — LLM API call (step 1) with model, usage, finish reason
-├── execute_tool {tool} — tool execution with duration
-└── chat {model}      — LLM API call (step 2)
+├── chat {model}      -- LLM API call (step 1) with model, usage, finish reason
+├── execute_tool {tool} -- tool execution with duration
+└── chat {model}      -- LLM API call (step 2)
 ```
 
 ### Usage Patterns
@@ -292,6 +304,7 @@ _ = err
 | `WithAttributes(attrs...)` | Attach custom `attribute.KeyValue` pairs to the root span |
 | `RecordInputMessages(bool)` | Record full input messages as span events (default: `false`) |
 | `RecordOutputMessages(bool)` | Record full output messages as span events (default: `false`) |
+| `RecordToolIO(bool)` | Record tool input/output as span events (default: `false`) |
 
 ### Semantic Conventions
 
@@ -312,6 +325,21 @@ Spans are annotated with `gen_ai.*` attributes following the OpenTelemetry GenAI
 | `goai.step` | 1-based step index (on LLM call and tool spans) |
 | `gen_ai.tool.name` | Tool name (on tool spans) |
 | `gen_ai.tool.call.id` | Tool call ID (on tool spans) |
+| `goai.request.message_count` | Message count per LLM call |
+| `goai.request.tool_count` | Tool count per LLM call |
+| `goai.tool.skipped` | True when tool was skipped by OnBeforeToolExecute |
+| `goai.tool.input_overridden` | True when tool input was overridden |
+| `goai.tool.context_overridden` | True when tool context was overridden |
+| `goai.tool.output_modified` | True when tool output was modified by OnAfterToolExecute |
+| `goai.tool.metadata.*` | Consumer metadata from OnAfterToolExecute |
+| `goai.stopped_at_step` | Step number where OnBeforeStep stopped the loop |
+| `goai.step.injected_messages` | Number of messages injected by OnBeforeStep |
+| `goai.tool.deadline` | Deadline from overridden tool context (ISO 8601) |
+| `goai.provider_metadata.*` | Provider-specific metadata from StepResult |
+| `goai.termination_reason` | "natural", "max_steps", or "hook_stopped" |
+| `goai.stopped_by_hook` | True when OnBeforeStep stopped the loop |
+| `gen_ai.response.model` | Actual response model (may differ from request) |
+| `gen_ai.response.id` | Provider response ID |
 | `http.response.status_code` | HTTP status code (only if > 0) |
 
 ### Metrics
@@ -323,6 +351,8 @@ When a `MeterProvider` is configured, the following metrics are recorded:
 | `gen_ai.client.token.usage` | Int64 Histogram | Token counts per type (`gen_ai.token.type` = `"input"` / `"output"`) |
 | `gen_ai.client.operation.duration` | Float64 Histogram | LLM call duration in seconds |
 | `goai.tool.duration` | Float64 Histogram | Tool execution duration in seconds (includes `gen_ai.tool.name` attribute) |
+| `goai.loop.early_stop` | Int64 Counter | Loop early stops by OnBeforeStep hook |
+| `goai.conversation.message_count` | Int64 Gauge | Message count per step |
 
 ### Error Handling
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -99,6 +99,32 @@ export GEMINI_API_KEY=...
 go run examples/tools/main.go
 ```
 
+### multi-turn
+
+Multi-turn conversation with tools using `ResponseMessages` to preserve history across turns.
+
+- **Provider:** Google Gemini
+- **Features:** `ResponseMessages`, multi-turn tool context, conversation history management
+- **Source:** [`examples/multi-turn/`](https://github.com/zendev-sh/goai/tree/main/examples/multi-turn)
+
+```bash
+export GEMINI_API_KEY=...
+go run examples/multi-turn/main.go
+```
+
+### streaming-tools
+
+Streaming text generation with multi-step tool loops via `StreamText`.
+
+- **Provider:** OpenAI
+- **Features:** `StreamText`, `WithMaxSteps`, tool execution during streaming, `Stream()` consumption
+- **Source:** [`examples/streaming-tools/`](https://github.com/zendev-sh/goai/tree/main/examples/streaming-tools)
+
+```bash
+export OPENAI_API_KEY=...
+go run examples/streaming-tools/main.go
+```
+
 ### agent-loop
 
 Multi-step agent loop with multiple tools and step/tool-call callbacks.
@@ -342,4 +368,51 @@ MCP client basics without an LLM. Exercises every MCP capability: tools, prompts
 
 ```bash
 go run ./examples/mcp-local/main.go
+```
+
+---
+
+## Observability & Hooks
+
+Lifecycle hooks, Langfuse tracing, and OpenTelemetry integration.
+
+### hooks
+
+Lifecycle hooks for tool interception, output transformation, and loop control.
+
+- **Provider:** Google Gemini
+- **Features:** `OnBeforeToolExecute` (permission gate), `OnAfterToolExecute` (secret scanning), `OnBeforeStep` (loop control), `OnFinish` (max_steps detection)
+- **Source:** [`examples/hooks/`](https://github.com/zendev-sh/goai/tree/main/examples/hooks)
+
+```bash
+export GEMINI_API_KEY=...
+go run examples/hooks/main.go
+```
+
+### langfuse
+
+Langfuse tracing for a multi-step agent with tool calls.
+
+- **Provider:** Google Gemini
+- **Features:** `langfuse.WithTracing`, trace hierarchy (trace → span → generation), token usage, tool spans
+- **Source:** [`examples/langfuse/`](https://github.com/zendev-sh/goai/tree/main/examples/langfuse)
+
+```bash
+export GEMINI_API_KEY=...
+export LANGFUSE_PUBLIC_KEY=pk-lf-...
+export LANGFUSE_SECRET_KEY=sk-lf-...
+go run examples/langfuse/main.go
+```
+
+### otel
+
+OpenTelemetry tracing with stdout exporter for local development.
+
+- **Provider:** Google Gemini
+- **Features:** `otel.WithTracing`, span hierarchy, custom attributes, `RecordInputMessages`, `RecordOutputMessages`
+- **Source:** [`examples/otel/`](https://github.com/zendev-sh/goai/tree/main/examples/otel)
+
+```bash
+export GEMINI_API_KEY=...
+cd examples/otel && go run .
 ```

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -2,10 +2,11 @@
 
 // Example: lifecycle hooks for tool interception, output transformation, and loop control.
 //
-// Demonstrates the three interceptor hooks:
+// Demonstrates the interceptor and observability hooks:
 //   - OnBeforeToolExecute: permission gate (skip dangerous tools)
 //   - OnAfterToolExecute: secret scanning (redact sensitive output)
 //   - OnBeforeStep: inject context between tool loop steps
+//   - OnFinish: detect max_steps exhaustion via StepsExhausted
 //
 // Usage:
 //
@@ -126,6 +127,18 @@ func main() {
 				status = "ERROR"
 			}
 			fmt.Printf("[TOOL] %s: %s (step %d, %s)\n", info.ToolName, status, info.Step, info.Duration)
+		}),
+
+		// Hook 4: OnFinish -- fires once after all steps complete.
+		goai.WithOnFinish(func(info goai.FinishInfo) {
+			status := "natural"
+			if info.StepsExhausted {
+				status = "max_steps"
+			}
+			fmt.Printf("[FINISH] %s: %d steps, %d tokens, reason=%s\n",
+				status, info.TotalSteps,
+				info.TotalUsage.InputTokens+info.TotalUsage.OutputTokens,
+				info.FinishReason)
 		}),
 	)
 	if err != nil {

--- a/examples/langfuse/go.mod
+++ b/examples/langfuse/go.mod
@@ -1,0 +1,15 @@
+module github.com/zendev-sh/goai/examples/langfuse
+
+go 1.25.0
+
+require (
+	github.com/zendev-sh/goai v0.0.0
+	github.com/zendev-sh/goai/observability/langfuse v0.0.0
+)
+
+require github.com/google/uuid v1.6.0 // indirect
+
+replace (
+	github.com/zendev-sh/goai => ../..
+	github.com/zendev-sh/goai/observability/langfuse => ../../observability/langfuse
+)

--- a/examples/langfuse/go.sum
+++ b/examples/langfuse/go.sum
@@ -1,0 +1,1 @@
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/examples/langfuse/main.go
+++ b/examples/langfuse/main.go
@@ -9,11 +9,11 @@
 //
 // Usage:
 //
+//	export GEMINI_API_KEY=...
 //	export LANGFUSE_PUBLIC_KEY=pk-lf-...
 //	export LANGFUSE_SECRET_KEY=sk-lf-...
 //	export LANGFUSE_HOST=https://cloud.langfuse.com   # or your self-hosted URL
-//	export OPENAI_API_KEY=...
-//	go run ./examples/langfuse/
+//	go run examples/langfuse/main.go
 package main
 
 import (
@@ -26,18 +26,11 @@ import (
 
 	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/observability/langfuse"
-	"github.com/zendev-sh/goai/provider/openai"
+	"github.com/zendev-sh/goai/provider/google"
 )
 
-// WeatherReport is the structured output returned by the agent.
-type WeatherReport struct {
-	City        string `json:"city" jsonschema:"description=City name"`
-	Temperature string `json:"temperature" jsonschema:"description=Current temperature with unit"`
-	Summary     string `json:"summary" jsonschema:"description=One-sentence weather summary"`
-}
-
 func main() {
-	model := openai.Chat("gpt-4o-mini", openai.WithAPIKey(os.Getenv("OPENAI_API_KEY")))
+	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	// Tool that simulates fetching weather data.
 	weatherTool := goai.Tool{
@@ -49,7 +42,6 @@ func main() {
 		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
 			var args struct{ City string }
 			_ = json.Unmarshal(input, &args)
-			// Simulate an API call.
 			time.Sleep(50 * time.Millisecond)
 			return fmt.Sprintf(`{"city":%q,"temp":"22°C","condition":"sunny"}`, args.City), nil
 		},
@@ -58,9 +50,8 @@ func main() {
 	ctx := context.Background()
 
 	// --- WithTracing: simple one-liner ---
-	// WithTracing() reads credentials from env vars and returns a single goai.Option.
 	fmt.Println("=== WithTracing (simple) ===")
-	result, err := goai.GenerateObject[WeatherReport](ctx, model,
+	result, err := goai.GenerateText(ctx, model,
 		langfuse.WithTracing(
 			langfuse.TraceName("weather-agent"),
 			langfuse.Version("1.0.0"),
@@ -68,18 +59,18 @@ func main() {
 		goai.WithSystem("You are a weather assistant. Always call get_weather before answering."),
 		goai.WithPrompt("What's the weather in Tokyo?"),
 		goai.WithTools(weatherTool),
-		goai.WithMaxSteps(3),
+		goai.WithMaxSteps(5),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("City: %s\nTemp: %s\nSummary: %s\n", result.Object.City, result.Object.Temperature, result.Object.Summary)
+	fmt.Printf("Result: %s\n", result.Text[:min(120, len(result.Text))])
 	fmt.Printf("Steps: %d | Tokens: %d in / %d out\n\n",
-		len(result.Steps), result.Usage.InputTokens, result.Usage.OutputTokens)
+		len(result.Steps), result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)
 
 	// --- WithTracing: with session, user, and tags ---
-	fmt.Println("\n=== WithTracing (with options) ===")
-	r, err := goai.GenerateObject[WeatherReport](ctx, model,
+	fmt.Println("=== WithTracing (with options) ===")
+	r, err := goai.GenerateText(ctx, model,
 		langfuse.WithTracing(
 			langfuse.TraceName("weather-agent"),
 			langfuse.Version("1.0.0"),
@@ -93,10 +84,10 @@ func main() {
 		goai.WithSystem("You are a weather assistant. Always call get_weather before answering."),
 		goai.WithPrompt("What's the weather in Paris?"),
 		goai.WithTools(weatherTool),
-		goai.WithMaxSteps(3),
+		goai.WithMaxSteps(5),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Paris: %s — %s\n", r.Object.Temperature, r.Object.Summary)
+	fmt.Printf("Paris: %s\n", r.Text[:min(120, len(r.Text))])
 }

--- a/examples/otel/main.go
+++ b/examples/otel/main.go
@@ -7,7 +7,7 @@
 //
 // Usage:
 //
-//	export OPENAI_API_KEY=...
+//	export GEMINI_API_KEY=...
 //	cd examples/otel && go run .
 package main
 
@@ -21,19 +21,12 @@ import (
 
 	"github.com/zendev-sh/goai"
 	goaiotel "github.com/zendev-sh/goai/observability/otel"
-	"github.com/zendev-sh/goai/provider/openai"
+	"github.com/zendev-sh/goai/provider/google"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
-
-// WeatherReport is the structured output returned by the agent.
-type WeatherReport struct {
-	City        string `json:"city" jsonschema:"description=City name"`
-	Temperature string `json:"temperature" jsonschema:"description=Current temperature with unit"`
-	Summary     string `json:"summary" jsonschema:"description=One-sentence weather summary"`
-}
 
 func main() {
 	// --- Exporter setup ---
@@ -60,7 +53,7 @@ func main() {
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 	otel.SetTracerProvider(tp)
 
-	model := openai.Chat("gpt-4o-mini", openai.WithAPIKey(os.Getenv("OPENAI_API_KEY")))
+	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	// Tool that simulates fetching weather data.
 	weatherTool := goai.Tool{
@@ -72,7 +65,6 @@ func main() {
 		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
 			var args struct{ City string }
 			_ = json.Unmarshal(input, &args)
-			// Simulate an API call.
 			time.Sleep(50 * time.Millisecond)
 			return fmt.Sprintf(`{"city":%q,"temp":"22°C","condition":"sunny"}`, args.City), nil
 		},
@@ -82,25 +74,25 @@ func main() {
 
 	// --- WithTracing: uses the global TracerProvider ---
 	fmt.Println("=== WithTracing (simple) ===")
-	result, err := goai.GenerateObject[WeatherReport](ctx, model,
+	result, err := goai.GenerateText(ctx, model,
 		goaiotel.WithTracing(
 			goaiotel.WithSpanName("weather-agent"),
 		),
 		goai.WithSystem("You are a weather assistant. Always call get_weather before answering."),
 		goai.WithPrompt("What's the weather in Tokyo?"),
 		goai.WithTools(weatherTool),
-		goai.WithMaxSteps(3),
+		goai.WithMaxSteps(5),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("City: %s\nTemp: %s\nSummary: %s\n", result.Object.City, result.Object.Temperature, result.Object.Summary)
+	fmt.Printf("\nResult: %s\n", result.Text[:min(120, len(result.Text))])
 	fmt.Printf("Steps: %d | Tokens: %d in / %d out\n\n",
-		len(result.Steps), result.Usage.InputTokens, result.Usage.OutputTokens)
+		len(result.Steps), result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)
 
 	// --- WithTracing: with explicit provider and custom attributes ---
 	fmt.Println("\n=== WithTracing (with options) ===")
-	r, err := goai.GenerateObject[WeatherReport](ctx, model,
+	r, err := goai.GenerateText(ctx, model,
 		goaiotel.WithTracing(
 			goaiotel.WithTracerProvider(tp),
 			goaiotel.WithSpanName("weather-agent"),
@@ -114,10 +106,10 @@ func main() {
 		goai.WithSystem("You are a weather assistant. Always call get_weather before answering."),
 		goai.WithPrompt("What's the weather in Paris?"),
 		goai.WithTools(weatherTool),
-		goai.WithMaxSteps(3),
+		goai.WithMaxSteps(5),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Paris: %s - %s\n", r.Object.Temperature, r.Object.Summary)
+	fmt.Printf("\nParis: %s\n", r.Text[:min(120, len(r.Text))])
 }

--- a/generate.go
+++ b/generate.go
@@ -132,6 +132,7 @@ type TextStream struct {
 	// Hook support.
 	onResponse   []func(ResponseInfo)
 	onStepFinish []func(StepResult)
+	onFinish     []func(FinishInfo)
 	startTime    time.Time
 
 	// Accumulated state (written by consume goroutine, read after doneCh closes).
@@ -234,6 +235,20 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 	}
 	if textOut != nil {
 		defer close(textOut)
+	}
+
+	// Call OnFinish hook when consume finishes (single-step streaming only).
+	// For multi-step streaming (streamWithToolLoop), OnFinish fires inline in the
+	// goroutine and ts.onFinish is nil, so this block is skipped.
+	// Deferred BEFORE OnStepFinish so it runs AFTER it (LIFO order).
+	if len(ts.onFinish) > 0 {
+		defer func() {
+			fireOnFinish(ts.onFinish, FinishInfo{
+				TotalSteps:   1,
+				TotalUsage:   ts.usage,
+				FinishReason: ts.finishReason,
+			})
+		}()
 	}
 
 	// Call OnStepFinish hook when consume finishes (single-step streaming only).
@@ -691,18 +706,39 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 					// when the stream has errors.
 					provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: err})
 					provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: lastFinishReason, Usage: totalUsage})
+					// Fire OnFinish so observability hooks can close spans/flush traces.
+					lastFinish := provider.FinishReason("")
+					if len(steps) > 0 {
+						lastFinish = steps[len(steps)-1].FinishReason
+					}
+					fireOnFinish(o.OnFinish, FinishInfo{
+						TotalSteps:   len(steps),
+						TotalUsage:   totalUsage,
+						FinishReason: lastFinish,
+					})
 					return
 				}
 			}
 
 			ds := drainStep(ctx, result.Stream, out)
 			if ds.err != nil {
-				// responseMessages intentionally not set on error , buildResult falls back to
+				// responseMessages intentionally not set on error -- buildResult falls back to
 				// a minimal assistant message from accumulated text. Intermediate tool round-trip
 				// messages are lost. Callers should check Err() and not rely on ResponseMessages
 				// when the stream has errors.
 				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: ds.err})
 				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, Usage: totalUsage})
+				// Fire OnFinish so observability hooks can close spans/flush traces.
+				// Without this, OTel root spans leak and Langfuse traces are lost.
+				lastFinish := provider.FinishReason("")
+				if len(steps) > 0 {
+					lastFinish = steps[len(steps)-1].FinishReason
+				}
+				fireOnFinish(o.OnFinish, FinishInfo{
+					TotalSteps:   len(steps),
+					TotalUsage:   totalUsage,
+					FinishReason: lastFinish,
+				})
 				return
 			}
 
@@ -813,6 +849,13 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		ts.stepsExhausted = stepsExhausted
 		ts.responseMessages = buildResponseMessages(params.Messages[originalLen:], steps, lastReasoning)
 
+		fireOnFinish(o.OnFinish, FinishInfo{
+			StepsExhausted: stepsExhausted,
+			TotalSteps:     len(steps),
+			TotalUsage:     totalUsage,
+			FinishReason:   lastFinishReason,
+		})
+
 		// Emit final ChunkFinish with total usage and last step Response metadata.
 		provider.TrySend(ctx, out, provider.StreamChunk{
 			Type:         provider.ChunkFinish,
@@ -888,6 +931,7 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	ts.timeoutCancel = timeoutCancel
 	ts.onResponse = o.OnResponse
 	ts.onStepFinish = o.OnStepFinish
+	ts.onFinish = o.OnFinish
 	ts.startTime = start
 	return ts, nil
 }
@@ -982,6 +1026,18 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		}
 
 		if err != nil {
+			// Fire OnFinish so user hooks can observe error termination.
+			// Observability hooks (OTel/Langfuse) already handle this via OnResponse
+			// error -> end(), but user-registered OnFinish hooks need this signal.
+			lastFinish := provider.FinishReason("")
+			if len(steps) > 0 {
+				lastFinish = steps[len(steps)-1].FinishReason
+			}
+			fireOnFinish(o.OnFinish, FinishInfo{
+				TotalSteps:   len(steps),
+				TotalUsage:   totalUsage,
+				FinishReason: lastFinish,
+			})
 			return nil, err
 		}
 
@@ -1023,6 +1079,11 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		if result.FinishReason != provider.FinishToolCalls || len(result.ToolCalls) == 0 || len(toolMap) == 0 {
 			tr := buildTextResult(steps, totalUsage)
 			tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
+			fireOnFinish(o.OnFinish, FinishInfo{
+				TotalSteps:   len(steps),
+				TotalUsage:   totalUsage,
+				FinishReason: tr.FinishReason,
+			})
 			return tr, nil
 		}
 
@@ -1042,13 +1103,37 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		params.Messages = appendToolRoundTrip(params.Messages, result.Text, nil, result.ToolCalls, toolMessages)
 	}
 
-	// MaxSteps reached. This path is only reachable when the last step had tool calls
-	// (if it had no tool calls, the early return at line ~1023 would have fired).
-	// Set StepsExhausted = true -- the model wanted to continue but was cut short.
+	// Post-loop: reachable when MaxSteps was exhausted OR when OnBeforeStep.Stop=true
+	// caused a break. Only set StepsExhausted when MaxSteps was actually reached AND
+	// the last step still had tool calls pending (model wanted to continue but was cut
+	// short). This matches StreamText's conditional logic and correctly distinguishes
+	// "hook stopped" (StepsExhausted=false) from "max steps" (StepsExhausted=true).
 	tr := buildTextResult(steps, totalUsage)
-	tr.StepsExhausted = true
+	if len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
+		tr.StepsExhausted = true
+	}
 	tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
+	fireOnFinish(o.OnFinish, FinishInfo{
+		StepsExhausted: tr.StepsExhausted,
+		TotalSteps:     len(steps),
+		TotalUsage:     totalUsage,
+		FinishReason:   tr.FinishReason,
+	})
 	return tr, nil
+}
+
+// fireOnFinish calls all OnFinish hooks with individual panic recovery.
+func fireOnFinish(hooks []func(FinishInfo), info FinishInfo) {
+	for _, fn := range hooks {
+		func(f func(FinishInfo)) {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "goai: recovered panic in OnFinish hook: %v\n", r)
+				}
+			}()
+			f(info)
+		}(fn)
+	}
 }
 
 // requestMessages returns msgs with a system message prepended when system is non-empty.

--- a/hooks.go
+++ b/hooks.go
@@ -110,10 +110,49 @@ type ToolCallInfo struct {
 
 // WithOnStepFinish adds a callback invoked after each generation step completes.
 // Multiple callbacks are called in registration order. Each callback is individually
-// panic-recovered in all paths (GenerateText, StreamText, GenerateObject).
+// panic-recovered in all paths (GenerateText, StreamText, GenerateObject, StreamObject).
 // A panic in one callback does not prevent subsequent callbacks from firing.
 func WithOnStepFinish(fn func(StepResult)) Option {
 	return func(o *options) { o.OnStepFinish = append(o.OnStepFinish, fn) }
+}
+
+// FinishInfo is passed to the OnFinish hook after all generation steps complete.
+// It fires exactly once per GenerateText/StreamText/GenerateObject/StreamObject call,
+// after the last OnStepFinish. For StreamText/StreamObject, it fires in the
+// stream goroutine.
+type FinishInfo struct {
+	// StepsExhausted is true when MaxSteps was reached while the model still
+	// requested tool calls. This is the authoritative signal for "max_steps"
+	// termination -- it is not available from any per-step hook.
+	StepsExhausted bool
+
+	// TotalSteps is the number of generation steps executed.
+	TotalSteps int
+
+	// TotalUsage is the aggregated token usage across all steps.
+	TotalUsage provider.Usage
+
+	// FinishReason from the last step.
+	FinishReason provider.FinishReason
+}
+
+// WithOnFinish adds a callback invoked once after all generation steps complete.
+// Multiple callbacks are called in registration order. Each callback is individually
+// panic-recovered so a panic in one does not prevent subsequent callbacks from firing.
+//
+// This hook fires in all code paths:
+//   - GenerateText: after the tool loop exits (natural, max_steps, or hook_stopped)
+//   - StreamText: in the stream goroutine, after the tool loop exits
+//   - GenerateObject: after the tool loop exits (including max_steps error path)
+//   - StreamObject: in the consume goroutine, after the stream completes
+//
+// It does NOT fire when DoGenerate/DoStream returns a provider error (API failure,
+// context cancelled). In those cases, the OnResponse hook receives the error.
+// Note: GenerateObject's max_steps error IS a goai-level error, not a provider error,
+// so OnFinish fires before that error is returned.
+// For StreamText/StreamObject, check stream.Err() for definitive error status.
+func WithOnFinish(fn func(FinishInfo)) Option {
+	return func(o *options) { o.OnFinish = append(o.OnFinish, fn) }
 }
 
 // WithOnRequest adds a callback invoked before each model call.
@@ -129,9 +168,9 @@ func WithOnRequest(fn func(RequestInfo)) Option {
 // Multiple callbacks are called in registration order.
 // Each callback is individually panic-recovered in GenerateText (all steps),
 // all StreamText success paths (single-step consume goroutine and multi-step goroutine),
-// and StreamObject's success path (consume goroutine).
-// In GenerateObject, StreamObject's error path, and StreamText's first-step error path,
-// panics propagate to the caller.
+// GenerateObject (all steps), StreamObject's success path (consume goroutine),
+// and StreamObject's error path.
+// In StreamText's first-step error path, panics propagate to the caller.
 func WithOnResponse(fn func(ResponseInfo)) Option {
 	return func(o *options) { o.OnResponse = append(o.OnResponse, fn) }
 }
@@ -326,4 +365,48 @@ type BeforeStepResult struct {
 // The callback is panic-recovered; a panic is logged and the step proceeds normally.
 func WithOnBeforeStep(fn func(BeforeStepInfo) BeforeStepResult) Option {
 	return func(o *options) { o.OnBeforeStep = fn }
+}
+
+// WrapOnBeforeToolExecute returns an Option that wraps the existing OnBeforeToolExecute hook.
+// The wrapper function receives the current hook (may be nil if none is registered) and
+// returns a replacement. This enables observability packages to add side-effects without
+// replacing the user's hook.
+//
+// The wrapper MUST return the user hook's result verbatim when delegating -- accidentally
+// zeroing the struct suppresses tool executions or input overrides. When the existing
+// hook is nil, return a zero BeforeToolExecuteResult (no skip, no override).
+//
+// Ordering hazard: the wrapper captures the existing hook at option-apply time.
+// If a user calls WithOnBeforeToolExecute AFTER this wrapper is applied, the user's
+// hook overwrites the wrapper entirely. Callers using this for observability should
+// apply it after user hooks (e.g., WithTracing should be the last option).
+func WrapOnBeforeToolExecute(wrapper func(existing func(BeforeToolExecuteInfo) BeforeToolExecuteResult) func(BeforeToolExecuteInfo) BeforeToolExecuteResult) Option {
+	return func(o *options) {
+		o.OnBeforeToolExecute = wrapper(o.OnBeforeToolExecute)
+	}
+}
+
+// WrapOnAfterToolExecute returns an Option that wraps the existing OnAfterToolExecute hook.
+// The wrapper function receives the current hook (may be nil) and returns a replacement.
+// The wrapper MUST return the user hook's result verbatim -- an empty AfterToolExecuteResult
+// has special semantics (empty Output preserves original, nil Error preserves original).
+// When the existing hook is nil, return a zero AfterToolExecuteResult.
+//
+// Ordering hazard: same as WrapOnBeforeToolExecute -- apply after user hooks.
+func WrapOnAfterToolExecute(wrapper func(existing func(AfterToolExecuteInfo) AfterToolExecuteResult) func(AfterToolExecuteInfo) AfterToolExecuteResult) Option {
+	return func(o *options) {
+		o.OnAfterToolExecute = wrapper(o.OnAfterToolExecute)
+	}
+}
+
+// WrapOnBeforeStep returns an Option that wraps the existing OnBeforeStep hook.
+// The wrapper function receives the current hook (may be nil) and returns a replacement.
+// The wrapper MUST forward the user hook's Stop and ExtraMessages fields verbatim.
+// When the existing hook is nil, return a zero BeforeStepResult (no stop, no messages).
+//
+// Ordering hazard: same as WrapOnBeforeToolExecute -- apply after user hooks.
+func WrapOnBeforeStep(wrapper func(existing func(BeforeStepInfo) BeforeStepResult) func(BeforeStepInfo) BeforeStepResult) Option {
+	return func(o *options) {
+		o.OnBeforeStep = wrapper(o.OnBeforeStep)
+	}
 }

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -2161,3 +2161,443 @@ func TestSequentialToolExecution(t *testing.T) {
 		}
 	}
 }
+
+// --- OnFinish tests ---
+
+func TestOnFinish_Natural(t *testing.T) {
+	// Single-step GenerateText, model stops naturally.
+	// OnFinish should fire with StepsExhausted=false, TotalSteps=1.
+	var captured FinishInfo
+	var called bool
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "hello",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+			}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("hi"),
+		WithOnFinish(func(info FinishInfo) {
+			called = true
+			captured = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("OnFinish was not called")
+	}
+	if captured.StepsExhausted {
+		t.Error("StepsExhausted = true, want false (natural stop)")
+	}
+	if captured.TotalSteps != 1 {
+		t.Errorf("TotalSteps = %d, want 1", captured.TotalSteps)
+	}
+	if captured.FinishReason != provider.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", captured.FinishReason)
+	}
+	if captured.TotalUsage.InputTokens != 10 {
+		t.Errorf("TotalUsage.InputTokens = %d, want 10", captured.TotalUsage.InputTokens)
+	}
+}
+
+func TestOnFinish_MaxSteps(t *testing.T) {
+	// Model always returns tool calls, MaxSteps=2.
+	// OnFinish should fire with StepsExhausted=true, TotalSteps=2.
+	var captured FinishInfo
+	var called bool
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "my_tool", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+			}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(2),
+		WithTools(Tool{
+			Name:    "my_tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnFinish(func(info FinishInfo) {
+			called = true
+			captured = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("OnFinish was not called")
+	}
+	if !captured.StepsExhausted {
+		t.Error("StepsExhausted = false, want true (MaxSteps reached)")
+	}
+	if captured.TotalSteps != 2 {
+		t.Errorf("TotalSteps = %d, want 2", captured.TotalSteps)
+	}
+	if captured.FinishReason != provider.FinishToolCalls {
+		t.Errorf("FinishReason = %q, want tool_calls", captured.FinishReason)
+	}
+}
+
+func TestOnFinish_HookStopped(t *testing.T) {
+	// OnBeforeStep returns Stop=true. OnFinish should fire with StepsExhausted=false
+	// because the loop was stopped by hook, not by max_steps.
+	var captured FinishInfo
+	var called bool
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", callCount), Name: "tool", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+			}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			return BeforeStepResult{Stop: true}
+		}),
+		WithOnFinish(func(info FinishInfo) {
+			called = true
+			captured = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("OnFinish was not called")
+	}
+	if captured.StepsExhausted {
+		t.Error("StepsExhausted = true, want false (hook stopped, not max_steps)")
+	}
+	if captured.TotalSteps != 1 {
+		t.Errorf("TotalSteps = %d, want 1 (only step 1 executed before hook stopped)", captured.TotalSteps)
+	}
+}
+
+func TestOnFinish_StreamText(t *testing.T) {
+	// StreamText multi-step. OnFinish should fire in the stream goroutine.
+	var captured FinishInfo
+	var called atomic.Bool
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			callCount++
+			if callCount == 1 {
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "tool", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
+				), nil
+			}
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "tool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnFinish(func(info FinishInfo) {
+			called.Store(true)
+			captured = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := stream.Result()
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want done", result.Text)
+	}
+	if !called.Load() {
+		t.Fatal("OnFinish was not called in stream goroutine")
+	}
+	if captured.StepsExhausted {
+		t.Error("StepsExhausted = true, want false (natural stop)")
+	}
+	if captured.TotalSteps != 2 {
+		t.Errorf("TotalSteps = %d, want 2", captured.TotalSteps)
+	}
+}
+
+func TestOnFinish_PanicRecovery(t *testing.T) {
+	// OnFinish panics. Verify no crash and second hook still fires.
+	var secondCalled bool
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "ok",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 5, OutputTokens: 3},
+			}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("hi"),
+		WithOnFinish(func(_ FinishInfo) {
+			panic("kaboom in OnFinish")
+		}),
+		WithOnFinish(func(_ FinishInfo) {
+			secondCalled = true
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !secondCalled {
+		t.Error("second OnFinish hook should fire even when first panics")
+	}
+}
+
+func TestOnFinish_GenerateObject(t *testing.T) {
+	// GenerateObject single-step. OnFinish should fire.
+	var captured FinishInfo
+	var called bool
+	model := &mockModel{
+		id: "test-obj",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         `{"name":"Alice","age":30}`,
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 15, OutputTokens: 8},
+			}, nil
+		},
+	}
+
+	_, err := GenerateObject[simpleObject](t.Context(), model,
+		WithPrompt("generate"),
+		WithOnFinish(func(info FinishInfo) {
+			called = true
+			captured = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("OnFinish was not called for GenerateObject")
+	}
+	if captured.StepsExhausted {
+		t.Error("StepsExhausted = true, want false (single-step GenerateObject)")
+	}
+	if captured.TotalSteps != 1 {
+		t.Errorf("TotalSteps = %d, want 1", captured.TotalSteps)
+	}
+	if captured.FinishReason != provider.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", captured.FinishReason)
+	}
+	if captured.TotalUsage.InputTokens != 15 {
+		t.Errorf("TotalUsage.InputTokens = %d, want 15", captured.TotalUsage.InputTokens)
+	}
+}
+
+func TestWrapOnBeforeToolExecute(t *testing.T) {
+	// User hook skips "dangerous" tool. Wrapper adds observability side-effect.
+	var wrapperCalled bool
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "danger", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop}, nil
+		},
+	}
+	tool := Tool{Name: "danger", Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "boom", nil }}
+
+	result, err := GenerateText(context.Background(), model,
+		WithOnBeforeToolExecute(func(info BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return BeforeToolExecuteResult{Skip: true, Result: "blocked"}
+		}),
+		WrapOnBeforeToolExecute(func(existing func(BeforeToolExecuteInfo) BeforeToolExecuteResult) func(BeforeToolExecuteInfo) BeforeToolExecuteResult {
+			return func(info BeforeToolExecuteInfo) BeforeToolExecuteResult {
+				wrapperCalled = true
+				if existing != nil {
+					return existing(info)
+				}
+				return BeforeToolExecuteResult{}
+			}
+		}),
+		WithPrompt("go"), WithMaxSteps(3), WithTools(tool),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wrapperCalled {
+		t.Error("wrapper was not called")
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want %q", result.Text, "ok")
+	}
+}
+
+func TestWrapOnAfterToolExecute(t *testing.T) {
+	// User hook modifies output. Wrapper observes.
+	var wrapperCalled bool
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "fetch", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+	tool := Tool{Name: "fetch", Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "secret-data", nil }}
+
+	_, err := GenerateText(context.Background(), model,
+		WithOnAfterToolExecute(func(info AfterToolExecuteInfo) AfterToolExecuteResult {
+			return AfterToolExecuteResult{Output: "redacted"}
+		}),
+		WrapOnAfterToolExecute(func(existing func(AfterToolExecuteInfo) AfterToolExecuteResult) func(AfterToolExecuteInfo) AfterToolExecuteResult {
+			return func(info AfterToolExecuteInfo) AfterToolExecuteResult {
+				wrapperCalled = true
+				if existing != nil {
+					return existing(info)
+				}
+				return AfterToolExecuteResult{}
+			}
+		}),
+		WithPrompt("go"), WithMaxSteps(3), WithTools(tool),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wrapperCalled {
+		t.Error("wrapper was not called")
+	}
+}
+
+func TestWrapOnBeforeStep(t *testing.T) {
+	// User hook stops loop. Wrapper observes.
+	var wrapperCalled bool
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", callCount), Name: "t", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+			}, nil
+		},
+	}
+	tool := Tool{Name: "t", Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "ok", nil }}
+
+	result, err := GenerateText(context.Background(), model,
+		WithOnBeforeStep(func(_ BeforeStepInfo) BeforeStepResult {
+			return BeforeStepResult{Stop: true}
+		}),
+		WrapOnBeforeStep(func(existing func(BeforeStepInfo) BeforeStepResult) func(BeforeStepInfo) BeforeStepResult {
+			return func(info BeforeStepInfo) BeforeStepResult {
+				wrapperCalled = true
+				if existing != nil {
+					return existing(info)
+				}
+				return BeforeStepResult{}
+			}
+		}),
+		WithPrompt("go"), WithMaxSteps(5), WithTools(tool),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wrapperCalled {
+		t.Error("wrapper was not called")
+	}
+	if result.StepsExhausted {
+		t.Error("StepsExhausted should be false (hook stopped, not max_steps)")
+	}
+}
+
+func TestStreamObject_OnFinishAndOnStepFinish(t *testing.T) {
+	var finishCalled, stepCalled bool
+	var finishInfo FinishInfo
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: `{"name":"test"}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 10, OutputTokens: 5}},
+			), nil
+		},
+	}
+	type Simple struct{ Name string }
+	stream, err := StreamObject[Simple](t.Context(), model,
+		WithPrompt("go"),
+		WithOnStepFinish(func(sr StepResult) {
+			stepCalled = true
+			if sr.Number != 1 {
+				t.Errorf("StepResult.Number = %d, want 1", sr.Number)
+			}
+		}),
+		WithOnFinish(func(info FinishInfo) {
+			finishCalled = true
+			finishInfo = info
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := stream.Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Object.Name != "test" {
+		t.Errorf("Object.Name = %q, want %q", result.Object.Name, "test")
+	}
+	if !stepCalled {
+		t.Error("OnStepFinish was not called for StreamObject")
+	}
+	if !finishCalled {
+		t.Error("OnFinish was not called for StreamObject")
+	}
+	if finishInfo.TotalSteps != 1 {
+		t.Errorf("TotalSteps = %d, want 1", finishInfo.TotalSteps)
+	}
+	if finishInfo.FinishReason != provider.FinishStop {
+		t.Errorf("FinishReason = %q, want stop", finishInfo.FinishReason)
+	}
+}

--- a/object.go
+++ b/object.go
@@ -62,8 +62,10 @@ type ObjectStream[T any] struct {
 	partialCh <-chan *T
 
 	// Hook support.
-	onResponse []func(ResponseInfo)
-	startTime  time.Time
+	onResponse   []func(ResponseInfo)
+	onStepFinish []func(StepResult)
+	onFinish     []func(FinishInfo)
+	startTime    time.Time
 
 	// Accumulated state.
 	text             strings.Builder
@@ -159,6 +161,43 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 	}
 	if partialOut != nil {
 		defer close(partialOut)
+	}
+
+	// Call OnFinish hook when consume finishes (single-step streaming).
+	// Deferred BEFORE OnStepFinish so it runs AFTER it (LIFO order).
+	if len(os.onFinish) > 0 {
+		defer func() {
+			fireOnFinish(os.onFinish, FinishInfo{
+				TotalSteps:   1,
+				TotalUsage:   os.usage,
+				FinishReason: os.finishReason,
+			})
+		}()
+	}
+
+	// Call OnStepFinish hook when consume finishes (single-step streaming).
+	// Deferred BEFORE OnResponse so it runs AFTER it (LIFO order).
+	if len(os.onStepFinish) > 0 {
+		defer func() {
+			stepResult := StepResult{
+				Number:       1,
+				Text:         os.text.String(),
+				FinishReason: os.finishReason,
+				Usage:        os.usage,
+				Response:     os.response,
+				ProviderMetadata: os.providerMetadata,
+			}
+			for _, fn := range os.onStepFinish {
+				func(f func(StepResult)) {
+					defer func() {
+						if r := recover(); r != nil {
+							_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
+						}
+					}()
+					f(stepResult)
+				}(fn)
+			}
+		}()
 	}
 
 	// Call OnResponse hook when consume finishes (after all chunks processed).
@@ -344,19 +383,35 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		})
 
 		for _, fn := range o.OnResponse {
-			info := ResponseInfo{Latency: time.Since(start), Error: err}
-			if err == nil {
-				info.Usage = result.Usage
-				info.FinishReason = result.FinishReason
-			}
-			var apiErr *APIError
-			if errors.As(err, &apiErr) {
-				info.StatusCode = apiErr.StatusCode
-			}
-			fn(info)
+			func(f func(ResponseInfo)) {
+				defer func() {
+					if r := recover(); r != nil {
+						_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
+					}
+				}()
+				info := ResponseInfo{Latency: time.Since(start), Error: err}
+				if err == nil {
+					info.Usage = result.Usage
+					info.FinishReason = result.FinishReason
+				}
+				var apiErr *APIError
+				if errors.As(err, &apiErr) {
+					info.StatusCode = apiErr.StatusCode
+				}
+				f(info)
+			}(fn)
 		}
 
 		if err != nil {
+			lastFinish := provider.FinishReason("")
+			if len(steps) > 0 {
+				lastFinish = steps[len(steps)-1].FinishReason
+			}
+			fireOnFinish(o.OnFinish, FinishInfo{
+				TotalSteps:   len(steps),
+				TotalUsage:   totalUsage,
+				FinishReason: lastFinish,
+			})
 			return nil, err
 		}
 
@@ -399,6 +454,11 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 				// Raw model output is truncated to 200 chars to limit information disclosure.
 				return nil, fmt.Errorf("parsing structured output: %w (raw: %s)", err, truncate(text, 200))
 			}
+			fireOnFinish(o.OnFinish, FinishInfo{
+				TotalSteps:   len(steps),
+				TotalUsage:   totalUsage,
+				FinishReason: result.FinishReason,
+			})
 			return &ObjectResult[T]{
 				Object:           obj,
 				Usage:            totalUsage,
@@ -425,6 +485,16 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 	}
 
 	// MaxSteps exhausted with tool calls still pending — no structured output produced.
+	lastFinish := provider.FinishReason("")
+	if len(steps) > 0 {
+		lastFinish = steps[len(steps)-1].FinishReason
+	}
+	fireOnFinish(o.OnFinish, FinishInfo{
+		StepsExhausted: true,
+		TotalSteps:     len(steps),
+		TotalUsage:     totalUsage,
+		FinishReason:   lastFinish,
+	})
 	return nil, fmt.Errorf("goai: max steps (%d) reached without producing structured output", o.MaxSteps)
 }
 
@@ -485,12 +555,19 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 			timeoutCancel()
 		}
 		for _, fn := range o.OnResponse {
-			info := ResponseInfo{Latency: time.Since(start), Error: err}
-			var apiErr *APIError
-			if errors.As(err, &apiErr) {
-				info.StatusCode = apiErr.StatusCode
-			}
-			fn(info)
+			func(f func(ResponseInfo)) {
+				defer func() {
+					if r := recover(); r != nil {
+						_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
+					}
+				}()
+				info := ResponseInfo{Latency: time.Since(start), Error: err}
+				var apiErr *APIError
+				if errors.As(err, &apiErr) {
+					info.StatusCode = apiErr.StatusCode
+				}
+				f(info)
+			}(fn)
 		}
 		return nil, err
 	}
@@ -498,6 +575,8 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 	os := newObjectStream[T](ctx, result.Stream)
 	os.timeoutCancel = timeoutCancel
 	os.onResponse = o.OnResponse
+	os.onStepFinish = o.OnStepFinish
+	os.onFinish = o.OnFinish
 	os.startTime = start
 	return os, nil
 }

--- a/observability/langfuse/langfuse.go
+++ b/observability/langfuse/langfuse.go
@@ -24,10 +24,10 @@
 // Observation hierarchy:
 //
 //	Trace
-//	└── Span("agent")            — wraps the entire run
-//	    ├── Generation("step-1") — LLM call, child of agent span
-//	    ├── Span("tool-name")    — tool execution, sibling of generation
-//	    └── Generation("step-2") — final LLM call
+//	└── Span("agent")            -- wraps the entire run
+//	    ├── Generation("step-1") -- LLM call, child of agent span
+//	    ├── Span("tool-name")    -- tool execution, sibling of generation
+//	    └── Generation("step-2") -- final LLM call
 package langfuse
 
 import (
@@ -78,6 +78,13 @@ func PromptVersion(v int) TracingOption { return func(c *Config) { c.PromptVersi
 // OnFlushError sets a callback for flush errors (default: silently discard).
 func OnFlushError(fn func(error)) TracingOption { return func(c *Config) { c.OnFlushError = fn } }
 
+// EagerToolSpans enables creating tool spans in OnToolCallStart (before execution)
+// with an immediate flush, providing real-time "in-progress" visibility on the
+// Langfuse dashboard. The span is finalized with output/error in OnToolCall.
+// This adds an extra HTTP round-trip per tool call -- only enable for long-running
+// tools where in-progress visibility is valuable.
+func EagerToolSpans(b bool) TracingOption { return func(c *Config) { c.EagerToolSpans = b } }
+
 // PublicKey overrides the LANGFUSE_PUBLIC_KEY env var.
 func PublicKey(key string) TracingOption { return func(c *Config) { c.PublicKey = key } }
 
@@ -90,6 +97,11 @@ func Host(host string) TracingOption { return func(c *Config) { c.Host = host } 
 // WithTracing returns a goai.Option that enables Langfuse tracing for a single call.
 // Credentials are read from env vars unless overridden via PublicKey/SecretKey/Host options.
 // Each invocation creates a fresh trace -- safe for concurrent use.
+//
+// Ordering: WithTracing wraps the singleton hooks (OnBeforeToolExecute, OnAfterToolExecute,
+// OnBeforeStep) to add observability without replacing user hooks. For this to work,
+// WithTracing must be applied AFTER any user-registered singleton hooks. Place it last
+// in the option list, or use WithOptions to group user hooks before WithTracing.
 //
 // Each call allocates a small amount of state for trace isolation. The underlying
 // HTTP connections are pooled by Go's default transport, so creating a new
@@ -143,6 +155,10 @@ type Config struct {
 	// OnFlushError is called when the HTTP flush to Langfuse fails.
 	// If nil, flush errors are silently discarded (tracing must not crash the app).
 	OnFlushError func(error)
+
+	// EagerToolSpans creates tool spans in OnToolCallStart with an immediate flush
+	// for real-time in-progress visibility. Adds an extra HTTP round-trip per tool call.
+	EagerToolSpans bool
 }
 
 // Hooks holds the shared HTTP client and config.
@@ -210,7 +226,7 @@ func (h *Hooks) With(opts ...goai.Option) func() []goai.Option {
 }
 
 // Run returns a fresh set of goai options scoped to a single agent run.
-// Safe to call concurrently — each call gets completely isolated state.
+// Safe to call concurrently -- each call gets completely isolated state.
 // OnToolCall may fire from parallel goroutines, so a mutex guards shared state.
 //
 // Deprecated: Use [WithTracing] instead.
@@ -232,16 +248,38 @@ func (h *Hooks) Run() []goai.Option {
 		lastObsEnd  time.Time
 		obs         []ingestionEvent
 		mu          sync.Mutex
+
+		// E1: eager tool span IDs (keyed by toolCallID).
+		toolEagerSpanIDs = make(map[string]string) // E1: span ID for reuse in OnToolCall
+
+		// Per-tool state for B1-B3 (keyed by toolCallID).
+		// Written by OnBeforeToolExecute, read by OnToolCall.
+		toolSkipReasons    = make(map[string]string) // B1: skip reason
+		toolInputOverrides = make(map[string]bool)   // B2: input was overridden
+		toolCtxOverrides   = make(map[string]bool)   // B3: context was overridden
+
+		// Per-tool state for C1-C2 (keyed by toolCallID).
+		// Written by OnAfterToolExecute, read by OnToolCall.
+		toolOutputModified = make(map[string]bool) // C1: output was modified
+		toolErrorModified  = make(map[string]string) // C2: "injected" or "replaced"
+
+		// D1-D2: termination tracking.
+		hookStopped       bool   // D1: OnBeforeStep.Stop=true fired
+		hookStoppedAtStep int    // D1: which step was stopped
+		terminationReason string // D2: "natural", "max_steps", or "hook_stopped"
+
+		// D3: injected message count for next generation.
+		pendingInjectedMessages int
+
+		// D4: conversation size from OnBeforeStep for next generation.
+		pendingConversationSize int
+
+		// Final output from the last non-tool-call OnStepFinish, for OnFinish to flush.
+		pendingOutput any
 	)
 
 	// end is declared before opts so WithOnStepFinish can reference it.
 	var end func(result any)
-
-	// OnToolCallStart is intentionally not registered here because
-	// OnToolCall.StartTime already provides accurate timing for tool spans.
-
-	// TODO: Register OnBeforeToolExecute, OnAfterToolExecute, and OnBeforeStep hooks
-	// to annotate spans with tool skip status, output modifications, and loop termination.
 
 	opts := []goai.Option{
 		goai.WithOnRequest(func(info goai.RequestInfo) {
@@ -250,7 +288,7 @@ func (h *Hooks) Run() []goai.Option {
 			if traceID == "" {
 				traceID = newID()
 				agentSpanID = newID()
-				agentStart = time.Now()
+				agentStart = info.Timestamp // A4: use info.Timestamp instead of time.Now()
 				traceInput = input
 			}
 
@@ -272,7 +310,7 @@ func (h *Hooks) Run() []goai.Option {
 			// in Langfuse's timeline. Langfuse sorts observations by startTime, so if
 			// a generation starts at the same wall-clock instant as the last tool span
 			// ends (common when tool execution is very fast), they render in wrong order.
-			now := time.Now()
+			now := info.Timestamp // A4: use info.Timestamp
 			if !lastObsEnd.IsZero() {
 				if floor := lastObsEnd.Add(10 * time.Millisecond); !now.After(floor) {
 					now = floor
@@ -282,6 +320,20 @@ func (h *Hooks) Run() []goai.Option {
 			genMeta := map[string]any{}
 			if cfg.Environment != "" {
 				genMeta["environment"] = cfg.Environment
+			}
+			// A3: record message count and tool count.
+			genMeta["message_count"] = info.MessageCount
+			genMeta["tool_count"] = info.ToolCount
+
+			// D3: record injected messages from OnBeforeStep.
+			if pendingInjectedMessages > 0 {
+				genMeta["injected_messages"] = pendingInjectedMessages
+				pendingInjectedMessages = 0
+			}
+			// D4: record conversation size from OnBeforeStep.
+			if pendingConversationSize > 0 {
+				genMeta["conversation_size"] = pendingConversationSize
+				pendingConversationSize = 0
 			}
 
 			gen = &pendingGen{
@@ -299,9 +351,11 @@ func (h *Hooks) Run() []goai.Option {
 				return
 			}
 			gen.latency = info.Latency
+			// A5: record HTTP status code when non-zero (must precede early return on error).
+			if info.StatusCode > 0 {
+				gen.metadata["http_status_code"] = info.StatusCode
+			}
 			if info.Error != nil {
-				// Run failed (e.g. context cancelled, max retries exhausted).
-				// Flush whatever partial trace we have so it's not silently lost.
 				gen.level = levelError
 				gen.statusMsg = info.Error.Error()
 				end(nil)
@@ -330,15 +384,63 @@ func (h *Hooks) Run() []goai.Option {
 			}
 		}),
 
-		goai.WithOnStepFinish(func(step goai.StepResult) {
-			if step.FinishReason == provider.FinishToolCalls {
-				return // intermediate step — more tool calls follow
+		goai.WithOnStepFinish(func(sr goai.StepResult) {
+			// A6: record Sources, Response.Model, Response.ID, ProviderMetadata.
+			if gen != nil {
+				if len(sr.Sources) > 0 {
+					gen.metadata["sources"] = sr.Sources
+				}
+				if sr.Response.Model != "" {
+					gen.metadata["response_model"] = sr.Response.Model
+				}
+				if sr.Response.ID != "" {
+					gen.metadata["response_id"] = sr.Response.ID
+				}
+				if len(sr.ProviderMetadata) > 0 {
+					for ns, data := range sr.ProviderMetadata {
+						for k, v := range data {
+							gen.metadata["provider_metadata."+ns+"."+k] = v
+						}
+					}
+				}
 			}
-			var output any
-			if step.Text != "" {
-				_ = json.Unmarshal([]byte(step.Text), &output)
+
+			// D2: determine termination reason.
+			// "natural" and "hook_stopped" are detected here in OnStepFinish.
+			// "max_steps" is detected in OnFinish via StepsExhausted.
+			if sr.FinishReason == provider.FinishToolCalls {
+				// Capture tool calls on gen so they appear if this is the last step
+				// (max_steps or hook_stopped -- no subsequent OnRequest to finalize gen).
+				if gen != nil && len(sr.ToolCalls) > 0 {
+					var calls []map[string]any
+					for _, tc := range sr.ToolCalls {
+						c := map[string]any{"id": tc.ID, "name": tc.Name}
+						if len(tc.Input) > 0 {
+							var parsed any
+							if json.Unmarshal(tc.Input, &parsed) == nil {
+								c["input"] = parsed
+							}
+						}
+						calls = append(calls, c)
+					}
+					gen.output = calls
+				}
+				return // intermediate step -- more tool calls follow
 			}
-			end(output)
+			if !hookStopped {
+				terminationReason = "natural"
+			}
+
+			// Store the final output for OnFinish to flush.
+			// Do NOT call end() here -- OnFinish is the single closer,
+			// ensuring terminationReason is set correctly for all paths
+			// (including max_steps where StepsExhausted overrides).
+			if sr.Text != "" {
+				if err := json.Unmarshal([]byte(sr.Text), &pendingOutput); err != nil {
+					// Plain text (not JSON) -- use the raw string as output.
+					pendingOutput = sr.Text
+				}
+			}
 		}),
 
 		goai.WithOnToolCall(func(info goai.ToolCallInfo) {
@@ -368,16 +470,71 @@ func (h *Hooks) Run() []goai.Option {
 				statusMsg = info.Error.Error()
 			}
 
+			meta := map[string]any{
+				"tool_call_id": info.ToolCallID,
+				"step":         info.Step,
+			}
+
+			// A1: annotate skipped tools.
+			if info.Skipped {
+				meta["skipped"] = true
+				if level == "" {
+					level = levelWarning
+				}
+			}
+
+			// A2: merge ToolCallInfo.Metadata.
+			for k, v := range info.Metadata {
+				meta[k] = v
+			}
+
+			// B1: skip reason from OnBeforeToolExecute.
+			// Only apply when no error already set -- info.Error is the authoritative
+			// error source; the skip reason is supplementary.
 			mu.Lock()
+			if reason, ok := toolSkipReasons[info.ToolCallID]; ok {
+				if statusMsg == "" {
+					statusMsg = reason
+				}
+				delete(toolSkipReasons, info.ToolCallID)
+			}
+			// B2: input override detection.
+			if toolInputOverrides[info.ToolCallID] {
+				meta["input_overridden"] = true
+				delete(toolInputOverrides, info.ToolCallID)
+			}
+			// B3: context override detection.
+			if toolCtxOverrides[info.ToolCallID] {
+				meta["context_overridden"] = true
+				delete(toolCtxOverrides, info.ToolCallID)
+			}
+			// C1: output modification detection.
+			if toolOutputModified[info.ToolCallID] {
+				meta["output_modified"] = true
+				delete(toolOutputModified, info.ToolCallID)
+			}
+			// C2: error injection/replacement detection.
+			if errMod, ok := toolErrorModified[info.ToolCallID]; ok {
+				meta["error_"+errMod] = true
+				delete(toolErrorModified, info.ToolCallID)
+			}
+
+			// E1: reuse eager span ID if OnToolCallStart already created the span.
+			// Use span-update to update the existing span rather than creating a duplicate.
+			spanID := newID()
+			spanEventType := eventSpan
+			if eagerID, ok := toolEagerSpanIDs[info.ToolCallID]; ok {
+				spanID = eagerID
+				spanEventType = eventSpanUpdate
+				delete(toolEagerSpanIDs, info.ToolCallID)
+			}
+
 			obs = append(obs, ingestionEvent{
-				// ingestionEvent.ID is the deduplication key for the ingestion envelope;
-				// spanBody.ID is the observation ID used for parent-child relationships.
-				// Langfuse requires them to be distinct.
 				ID:        newID(),
-				Type:      eventSpan,
+				Type:      spanEventType,
 				Timestamp: formatTime(start),
 				Body: spanBody{
-					ID:                  newID(),
+					ID:                  spanID,
 					TraceID:             traceID,
 					ParentObservationID: agentSpanID,
 					Name:                info.ToolName,
@@ -386,12 +543,9 @@ func (h *Hooks) Run() []goai.Option {
 					Input:               inputVal,
 					Output:              outputVal,
 					Version:             cfg.Version,
-					Metadata: map[string]any{
-						"tool_call_id": info.ToolCallID,
-						"step":         info.Step,
-					},
-					Level:         level,
-					StatusMessage: statusMsg,
+					Metadata:            meta,
+					Level:               level,
+					StatusMessage:       statusMsg,
 				},
 			})
 			if endTime.After(lastObsEnd) {
@@ -401,13 +555,183 @@ func (h *Hooks) Run() []goai.Option {
 		}),
 	}
 
+	// E1: OnToolCallStart for real-time tool visibility (opt-in).
+	if cfg.EagerToolSpans {
+		opts = append(opts, goai.WithOnToolCallStart(func(info goai.ToolCallStartInfo) {
+			if traceID == "" {
+				return
+			}
+
+			var inputVal any = info.Input
+			if len(info.Input) > 0 {
+				var parsed any
+				if json.Unmarshal(info.Input, &parsed) == nil {
+					inputVal = parsed
+				}
+			}
+
+			spanID := newID()
+			now := time.Now()
+
+			mu.Lock()
+			// Store span ID for OnToolCall to reuse.
+			toolEagerSpanIDs[info.ToolCallID] = spanID
+			mu.Unlock()
+
+			// Create partial span and flush immediately for real-time visibility.
+			partial := ingestionEvent{
+				ID:        newID(),
+				Type:      eventSpan,
+				Timestamp: formatTime(now),
+				Body: spanBody{
+					ID:                  spanID,
+					TraceID:             traceID,
+					ParentObservationID: agentSpanID,
+					Name:                info.ToolName,
+					StartTime:           formatTime(now),
+					Input:               inputVal,
+					Version:             cfg.Version,
+					Metadata: map[string]any{
+						"tool_call_id": info.ToolCallID,
+						"step":         info.Step,
+						"status":       "in_progress",
+					},
+				},
+			}
+
+			lc.appendEvents([]ingestionEvent{partial})
+			if err := lc.flush(context.Background()); err != nil && cfg.OnFlushError != nil {
+				cfg.OnFlushError(err)
+			}
+		}))
+	}
+
+	// OnFinish: fires once after all steps complete. Handles termination reason
+	// detection (including max_steps via StepsExhausted) and ensures end() is called
+	// for all exit paths.
+	opts = append(opts, goai.WithOnFinish(func(info goai.FinishInfo) {
+		if info.StepsExhausted {
+			terminationReason = "max_steps"
+		}
+		// For hook_stopped, terminationReason was already set in OnBeforeStep wrapper.
+		// For natural, it was set in OnStepFinish (which stored output in pendingOutput).
+		// OnFinish is the single success-path closer. end() is also called from
+		// OnResponse on error (line ~361) for partial-trace flushing.
+		end(pendingOutput)
+	}))
+
+	// Section 7.1: Wrapper pattern for singleton hooks (B/C/D categories).
+	// These wrap any existing user hooks, adding observability side-effects
+	// before delegating to the user's original hook.
+
+	// B1-B3: OnBeforeToolExecute wrapper.
+	opts = append(opts, goai.WrapOnBeforeToolExecute(func(userHook func(goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult) func(goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+		return func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			// Delegate to user hook first (if any).
+			var result goai.BeforeToolExecuteResult
+			if userHook != nil {
+				result = userHook(info)
+			}
+
+			mu.Lock()
+			// B1: capture skip reason for OnToolCall to read.
+			// Note: if the user hook panics, goai forces a skip with a synthetic error
+			// but this wrapper never runs to completion -- the panic-path skip reason
+			// is not captured here. OnToolCall will still see info.Skipped=true and
+			// info.Error with the panic message, so the skip is observable via A1.
+			if result.Skip {
+				reason := "skipped by hook"
+				if result.Error != nil {
+					reason = result.Error.Error()
+				}
+				toolSkipReasons[info.ToolCallID] = reason
+			}
+			// B2: detect input override.
+			if result.Input != nil {
+				toolInputOverrides[info.ToolCallID] = true
+			}
+			// B3: detect context override.
+			if result.Ctx != nil {
+				toolCtxOverrides[info.ToolCallID] = true
+			}
+			mu.Unlock()
+
+			return result
+		}
+	}))
+
+	// C1-C2: OnAfterToolExecute wrapper.
+	opts = append(opts, goai.WrapOnAfterToolExecute(func(userHook func(goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult) func(goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+		return func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			// Delegate to user hook first (if any).
+			var result goai.AfterToolExecuteResult
+			if userHook != nil {
+				result = userHook(info)
+			}
+
+			mu.Lock()
+			// C1: detect output modification.
+			if result.Output != "" && result.Output != info.Output {
+				toolOutputModified[info.ToolCallID] = true
+			}
+			// C2: detect error injection/replacement.
+			if result.Error != nil {
+				if info.Error == nil {
+					toolErrorModified[info.ToolCallID] = "injected"
+				} else if result.Error.Error() != info.Error.Error() {
+					toolErrorModified[info.ToolCallID] = "replaced"
+				}
+			}
+			mu.Unlock()
+
+			return result
+		}
+	}))
+
+	// D1, D3-D4: OnBeforeStep wrapper.
+	opts = append(opts, goai.WrapOnBeforeStep(func(userHook func(goai.BeforeStepInfo) goai.BeforeStepResult) func(goai.BeforeStepInfo) goai.BeforeStepResult {
+		return func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+			// Delegate to user hook first (if any).
+			var result goai.BeforeStepResult
+			if userHook != nil {
+				result = userHook(info)
+			}
+
+			// D1: detect loop termination signal.
+			if result.Stop {
+				hookStopped = true
+				hookStoppedAtStep = info.Step
+				terminationReason = "hook_stopped"
+				// end() is called by OnFinish (which fires after the loop exits).
+			}
+
+			// D3: track injected messages for next generation.
+			if len(result.ExtraMessages) > 0 {
+				pendingInjectedMessages = len(result.ExtraMessages)
+			}
+
+			// D4: conversation size monitoring -- record len(Messages) per step.
+			// Note: A3 (message_count in OnRequest) covers the same signal at every step
+			// including step 1. D4 adds the pre-step message count from OnBeforeStep.
+			// We store it for the next generation metadata.
+			pendingConversationSize = len(info.Messages)
+
+			return result
+		}
+	}))
+
 	end = func(result any) {
 		if traceID == "" {
 			return
 		}
 
 		if gen != nil {
-			gen.output = result
+			// Only overwrite gen.output when result is non-nil. For max_steps and
+			// hook_stopped exits, gen.output was already set to the tool calls by
+			// OnStepFinish (line ~412). Overwriting with nil would lose that data.
+			if result != nil {
+				gen.output = result
+			}
 			obs = append(obs, gen.toEvent(traceID, agentSpanID, cfg))
 			gen = nil
 		}
@@ -419,10 +743,21 @@ func (h *Hooks) Run() []goai.Option {
 			traceMeta = mergeMeta(traceMeta, map[string]any{"environment": cfg.Environment})
 		}
 
-		// Build the complete batch in order:
-		// 1. trace-create
-		// 2. agent span-create (parent of all observations)
-		// 3. all buffered observations (generations + tool spans)
+		// D1: annotate trace with hook_stopped if applicable.
+		if hookStopped {
+			traceMeta = mergeMeta(traceMeta, map[string]any{
+				"stopped_by_hook": true,
+				"stopped_at_step": hookStoppedAtStep,
+			})
+		}
+
+		// D2: annotate trace with termination reason.
+		if terminationReason != "" {
+			traceMeta = mergeMeta(traceMeta, map[string]any{
+				"termination_reason": terminationReason,
+			})
+		}
+
 		batch := make([]ingestionEvent, 0, 2+len(obs))
 		batch = append(batch,
 			ingestionEvent{
@@ -460,7 +795,6 @@ func (h *Hooks) Run() []goai.Option {
 		)
 		batch = append(batch, obs...)
 
-		// Clear run state — the run is complete.
 		traceID = ""
 		agentSpanID = ""
 		obs = nil
@@ -533,6 +867,7 @@ type usageBody struct {
 const (
 	eventTrace      = "trace-create"
 	eventSpan       = "span-create"
+	eventSpanUpdate = "span-update"
 	eventGeneration = "generation-create"
 	levelWarning    = "WARNING"
 	levelError      = "ERROR"

--- a/observability/langfuse/langfuse_test.go
+++ b/observability/langfuse/langfuse_test.go
@@ -1644,3 +1644,875 @@ func TestWithTracing_OnFlushError(t *testing.T) {
 		t.Error("OnFlushError should have been called with a non-nil error via WithTracing")
 	}
 }
+
+// --- Enhancement tests (A/B/C/D/E/G categories) ----------------------------
+
+// toolSpanBodies returns all span bodies for non-agent spans (tool spans).
+func toolSpanBodies(t *testing.T, events []map[string]any) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, e := range events {
+		if e["type"] != eventSpan {
+			continue
+		}
+		b, ok := e["body"].(map[string]any)
+		if !ok {
+			continue
+		}
+		// Skip the agent span (has no parentObservationId or matches trace name)
+		if _, hasParent := b["parentObservationId"]; !hasParent {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// genBodies returns all generation bodies.
+func genBodies(t *testing.T, events []map[string]any) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, e := range events {
+		if e["type"] == eventGeneration {
+			if b, ok := e["body"].(map[string]any); ok {
+				out = append(out, b)
+			}
+		}
+	}
+	return out
+}
+
+// traceBodies returns all trace bodies.
+func traceBodies(t *testing.T, events []map[string]any) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, e := range events {
+		if e["type"] == eventTrace {
+			if b, ok := e["body"].(map[string]any); ok {
+				out = append(out, b)
+			}
+		}
+	}
+	return out
+}
+
+// toolModel returns a mock model that issues one tool call then finishes.
+func toolModel() (*mockModel, *int) {
+	callCount := new(int)
+	m := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			*callCount++
+			if *callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "my_tool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+					Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 20, OutputTokens: 8},
+			}, nil
+		},
+	}
+	return m, callCount
+}
+
+func defaultTool() goai.Tool {
+	return goai.Tool{
+		Name:    "my_tool",
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "tool result", nil },
+	}
+}
+
+func TestWithTracing_A1_SkippedTools(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{Skip: true, Result: "skipped"}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	span := spans[0]
+	meta, ok := span["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing or wrong type: %T", span["metadata"])
+	}
+	if meta["skipped"] != true {
+		t.Errorf("metadata.skipped = %v, want true", meta["skipped"])
+	}
+	if span["level"] != levelWarning {
+		t.Errorf("level = %v, want %q", span["level"], levelWarning)
+	}
+}
+
+func TestWithTracing_A2_Metadata(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnAfterToolExecute(func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			return goai.AfterToolExecuteResult{
+				Metadata: map[string]any{"custom_key": "custom_value"},
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	meta, ok := spans[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing: %T", spans[0]["metadata"])
+	}
+	if meta["custom_key"] != "custom_value" {
+		t.Errorf("metadata.custom_key = %v, want %q", meta["custom_key"], "custom_value")
+	}
+}
+
+func TestWithTracing_A3_MessageCount_ToolCount(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	gens := genBodies(t, events)
+	if len(gens) == 0 {
+		t.Fatal("expected at least one generation event")
+	}
+
+	for i, gen := range gens {
+		meta, ok := gen["metadata"].(map[string]any)
+		if !ok {
+			t.Fatalf("generation[%d] metadata missing: %T", i, gen["metadata"])
+		}
+		if _, ok := meta["message_count"]; !ok {
+			t.Errorf("generation[%d] metadata missing message_count", i)
+		}
+		if _, ok := meta["tool_count"]; !ok {
+			t.Errorf("generation[%d] metadata missing tool_count", i)
+		}
+	}
+
+	// First generation should have tool_count=1 (one tool registered).
+	meta0 := gens[0]["metadata"].(map[string]any)
+	if meta0["tool_count"] != float64(1) {
+		t.Errorf("generation[0] tool_count = %v, want 1", meta0["tool_count"])
+	}
+}
+
+func TestWithTracing_A5_StatusCode(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return nil, &goai.APIError{
+				Message:    "rate limited",
+				StatusCode: 429,
+			}
+		},
+	}
+
+	_, err := goai.GenerateText(t.Context(), model,
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxRetries(0),
+	)
+	if err == nil {
+		t.Fatal("expected error from model")
+	}
+
+	events := getEvents()
+	gens := genBodies(t, events)
+	if len(gens) == 0 {
+		t.Fatal("expected at least one generation event")
+	}
+
+	meta, ok := gens[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("generation metadata missing: %T", gens[0]["metadata"])
+	}
+	if meta["http_status_code"] != float64(429) {
+		t.Errorf("metadata.http_status_code = %v, want 429", meta["http_status_code"])
+	}
+}
+
+func TestWithTracing_A6_StepResultFields(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "hello",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+				Sources: []provider.Source{
+					{ID: "src1", URL: "https://example.com", Type: "url"},
+				},
+				Response: provider.ResponseMetadata{
+					ID:    "resp-123",
+					Model: "gpt-4o-2024-05-13",
+				},
+				ProviderMetadata: map[string]map[string]any{
+					"openai": {"system_fingerprint": "fp_abc"},
+				},
+			}, nil
+		},
+	}
+
+	_, err := goai.GenerateText(t.Context(), model,
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	gens := genBodies(t, events)
+	if len(gens) == 0 {
+		t.Fatal("expected at least one generation event")
+	}
+
+	meta, ok := gens[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("generation metadata missing: %T", gens[0]["metadata"])
+	}
+	if meta["response_model"] != "gpt-4o-2024-05-13" {
+		t.Errorf("metadata.response_model = %v, want %q", meta["response_model"], "gpt-4o-2024-05-13")
+	}
+	if meta["response_id"] != "resp-123" {
+		t.Errorf("metadata.response_id = %v, want %q", meta["response_id"], "resp-123")
+	}
+	if meta["sources"] == nil {
+		t.Error("metadata.sources missing")
+	}
+	if meta["provider_metadata.openai.system_fingerprint"] != "fp_abc" {
+		t.Errorf("metadata provider_metadata.openai.system_fingerprint = %v, want %q",
+			meta["provider_metadata.openai.system_fingerprint"], "fp_abc")
+	}
+}
+
+func TestWithTracing_B1_SkipReason(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{
+				Skip:  true,
+				Error: fmt.Errorf("permission denied for %s", info.ToolName),
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	statusMsg, _ := spans[0]["statusMessage"].(string)
+	if !strings.Contains(statusMsg, "permission denied") {
+		t.Errorf("statusMessage = %q, want to contain %q", statusMsg, "permission denied")
+	}
+}
+
+func TestWithTracing_B2_InputOverride(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{
+				Input: json.RawMessage(`{"overridden": true}`),
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	meta, ok := spans[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing: %T", spans[0]["metadata"])
+	}
+	if meta["input_overridden"] != true {
+		t.Errorf("metadata.input_overridden = %v, want true", meta["input_overridden"])
+	}
+}
+
+func TestWithTracing_B3_ContextOverride(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{
+				Ctx: context.WithValue(info.Ctx, struct{}{}, "custom"),
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	meta, ok := spans[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing: %T", spans[0]["metadata"])
+	}
+	if meta["context_overridden"] != true {
+		t.Errorf("metadata.context_overridden = %v, want true", meta["context_overridden"])
+	}
+}
+
+func TestWithTracing_C1_OutputModified(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnAfterToolExecute(func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			return goai.AfterToolExecuteResult{
+				Output: "modified output",
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	meta, ok := spans[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing: %T", spans[0]["metadata"])
+	}
+	if meta["output_modified"] != true {
+		t.Errorf("metadata.output_modified = %v, want true", meta["output_modified"])
+	}
+}
+
+func TestWithTracing_C2_ErrorInjected(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnAfterToolExecute(func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			return goai.AfterToolExecuteResult{
+				Error: fmt.Errorf("injected error"),
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	meta, ok := spans[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing: %T", spans[0]["metadata"])
+	}
+	if meta["error_injected"] != true {
+		t.Errorf("metadata.error_injected = %v, want true", meta["error_injected"])
+	}
+}
+
+func TestWithTracing_D1_HookStopped(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+			return goai.BeforeStepResult{Stop: true}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(5),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	traces := traceBodies(t, events)
+	if len(traces) == 0 {
+		t.Fatal("expected at least one trace event")
+	}
+
+	meta, ok := traces[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace metadata missing: %T", traces[0]["metadata"])
+	}
+	if meta["stopped_by_hook"] != true {
+		t.Errorf("metadata.stopped_by_hook = %v, want true", meta["stopped_by_hook"])
+	}
+}
+
+func TestWithTracing_D2_TerminationReason_Natural(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+			}, nil
+		},
+	}
+
+	_, err := goai.GenerateText(t.Context(), model,
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	traces := traceBodies(t, events)
+	if len(traces) == 0 {
+		t.Fatal("expected at least one trace event")
+	}
+
+	meta, ok := traces[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace metadata missing: %T", traces[0]["metadata"])
+	}
+	if meta["termination_reason"] != "natural" {
+		t.Errorf("metadata.termination_reason = %v, want %q", meta["termination_reason"], "natural")
+	}
+}
+
+func TestWithTracing_D2_TerminationReason_HookStopped(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+			return goai.BeforeStepResult{Stop: true}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(5),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	traces := traceBodies(t, events)
+	if len(traces) == 0 {
+		t.Fatal("expected at least one trace event")
+	}
+
+	meta, ok := traces[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace metadata missing: %T", traces[0]["metadata"])
+	}
+	if meta["termination_reason"] != "hook_stopped" {
+		t.Errorf("metadata.termination_reason = %v, want %q", meta["termination_reason"], "hook_stopped")
+	}
+}
+
+func TestWithTracing_D3_ExtraMessages(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+			return goai.BeforeStepResult{
+				ExtraMessages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "extra context"}}},
+				},
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	gens := genBodies(t, events)
+	// The second generation (step 2) should have injected_messages in metadata.
+	if len(gens) < 2 {
+		t.Fatalf("expected at least 2 generations, got %d", len(gens))
+	}
+
+	meta, ok := gens[1]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("generation[1] metadata missing: %T", gens[1]["metadata"])
+	}
+	if meta["injected_messages"] != float64(1) {
+		t.Errorf("metadata.injected_messages = %v, want 1", meta["injected_messages"])
+	}
+}
+
+func TestWithTracing_E1_EagerToolSpans(t *testing.T) {
+	// Track the number of flushes (HTTP requests) to the capture server.
+	var mu sync.Mutex
+	var flushCount int
+	var allEvents []map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var payload struct {
+			Batch []map[string]any `json:"batch"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		flushCount++
+		allEvents = append(allEvents, payload.Batch...)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	_, err := goai.GenerateText(t.Context(), model,
+		WithTracing(
+			PublicKey("pub"),
+			SecretKey("sec"),
+			Host(srv.URL),
+			EagerToolSpans(true),
+		),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// With EagerToolSpans, there should be at least 2 flushes:
+	// one eager flush during tool execution, one final flush.
+	if flushCount < 2 {
+		t.Errorf("flush count = %d, want >= 2 (eager + final)", flushCount)
+	}
+
+	// Verify the eager span has "in_progress" status in metadata.
+	var foundEager bool
+	for _, e := range allEvents {
+		if e["type"] != eventSpan {
+			continue
+		}
+		b, ok := e["body"].(map[string]any)
+		if !ok {
+			continue
+		}
+		meta, ok := b["metadata"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if meta["status"] == "in_progress" {
+			foundEager = true
+			break
+		}
+	}
+	if !foundEager {
+		t.Error("expected an eager tool span with metadata.status='in_progress'")
+	}
+}
+
+// NOTE: G1 (panic recovery in GenerateObject OnResponse) and G3 (StepsExhausted
+// not set by OnBeforeStep.Stop) are bugs in the main goai package, not the
+// langfuse observability layer. Their tests belong in the goai package's test files
+// (generate_test.go / object_test.go). They are noted here for traceability.
+
+func TestWithTracing_WrapperPattern_UserHookHonored(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	var userHookCalled bool
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeToolExecute(func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			userHookCalled = true
+			return goai.BeforeToolExecuteResult{Skip: true, Result: "user-skipped"}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !userHookCalled {
+		t.Error("user OnBeforeToolExecute hook was not called")
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	// User's Skip=true should be honored: tool span should have metadata.skipped=true.
+	meta, ok := spans[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing: %T", spans[0]["metadata"])
+	}
+	if meta["skipped"] != true {
+		t.Errorf("metadata.skipped = %v, want true (user's Skip should be honored)", meta["skipped"])
+	}
+}
+
+func TestWithTracing_WrapperPattern_UserAfterHookHonored(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	var userHookCalled bool
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnAfterToolExecute(func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			userHookCalled = true
+			return goai.AfterToolExecuteResult{
+				Output:   "user-modified",
+				Metadata: map[string]any{"from_user": true},
+			}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !userHookCalled {
+		t.Error("user OnAfterToolExecute hook was not called")
+	}
+
+	events := getEvents()
+	spans := toolSpanBodies(t, events)
+	if len(spans) == 0 {
+		t.Fatal("expected at least one tool span")
+	}
+
+	meta, ok := spans[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool span metadata missing: %T", spans[0]["metadata"])
+	}
+	// User's metadata should be present.
+	if meta["from_user"] != true {
+		t.Errorf("metadata.from_user = %v, want true", meta["from_user"])
+	}
+	// Tracing layer should detect the output modification.
+	if meta["output_modified"] != true {
+		t.Errorf("metadata.output_modified = %v, want true", meta["output_modified"])
+	}
+}
+
+func TestWithTracing_WrapperPattern_UserBeforeStepHonored(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	model, _ := toolModel()
+
+	var userHookCalled bool
+	_, err := goai.GenerateText(t.Context(), model,
+		goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+			userHookCalled = true
+			return goai.BeforeStepResult{Stop: true}
+		}),
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(5),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !userHookCalled {
+		t.Error("user OnBeforeStep hook was not called")
+	}
+
+	events := getEvents()
+	traces := traceBodies(t, events)
+	if len(traces) == 0 {
+		t.Fatal("expected at least one trace event")
+	}
+
+	meta, ok := traces[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace metadata missing: %T", traces[0]["metadata"])
+	}
+	if meta["stopped_by_hook"] != true {
+		t.Errorf("metadata.stopped_by_hook = %v, want true", meta["stopped_by_hook"])
+	}
+	if meta["termination_reason"] != "hook_stopped" {
+		t.Errorf("metadata.termination_reason = %v, want %q", meta["termination_reason"], "hook_stopped")
+	}
+}
+
+func TestWithTracing_D2_TerminationReason_MaxSteps(t *testing.T) {
+	srv, getEvents := newCaptureServer(t)
+	defer srv.Close()
+
+	// Model always returns tool calls, so MaxSteps will be exhausted.
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "my_tool", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+			}, nil
+		},
+	}
+
+	_, err := goai.GenerateText(t.Context(), model,
+		WithTracing(PublicKey("pub"), SecretKey("sec"), Host(srv.URL)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(2),
+		goai.WithTools(defaultTool()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	events := getEvents()
+	traces := traceBodies(t, events)
+	if len(traces) == 0 {
+		t.Fatal("expected at least one trace event")
+	}
+
+	meta, ok := traces[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("trace metadata missing: %T", traces[0]["metadata"])
+	}
+	if meta["termination_reason"] != "max_steps" {
+		t.Errorf("metadata.termination_reason = %v, want %q", meta["termination_reason"], "max_steps")
+	}
+}

--- a/observability/otel/otel.go
+++ b/observability/otel/otel.go
@@ -56,6 +56,7 @@ type config struct {
 	attrs          []attribute.KeyValue
 	recordInput    bool
 	recordOutput   bool
+	recordToolIO   bool // A7: record tool output as span events
 }
 
 // TracingOption configures WithTracing.
@@ -93,11 +94,20 @@ func RecordOutputMessages(b bool) TracingOption {
 	return func(c *config) { c.recordOutput = b }
 }
 
+// RecordToolIO controls whether tool input/output are recorded as span events
+// on tool spans (default: false, for privacy). Similar to RecordInputMessages/
+// RecordOutputMessages but for tool execution payloads.
+func RecordToolIO(b bool) TracingOption {
+	return func(c *config) { c.recordToolIO = b }
+}
+
 // instruments holds pre-created metric instruments to avoid repeated creation.
 type instruments struct {
 	tokenUsage        metric.Int64Histogram
 	operationDuration metric.Float64Histogram
 	toolDuration      metric.Float64Histogram
+	earlyStopCounter  metric.Int64Counter      // D1: loop early stop counter
+	messageCount      metric.Int64Gauge         // D4: conversation message count
 }
 
 func newInstruments(mp metric.MeterProvider) instruments {
@@ -114,15 +124,28 @@ func newInstruments(mp metric.MeterProvider) instruments {
 		metric.WithDescription("Duration of tool executions"),
 		metric.WithUnit("s"),
 	)
+	earlyStopCounter, _ := m.Int64Counter("goai.loop.early_stop",
+		metric.WithDescription("Number of tool loops stopped early by OnBeforeStep hook"),
+	)
+	messageCount, _ := m.Int64Gauge("goai.conversation.message_count",
+		metric.WithDescription("Number of messages in conversation per step"),
+	)
 	return instruments{
 		tokenUsage:        tokenUsage,
 		operationDuration: operationDuration,
 		toolDuration:      toolDuration,
+		earlyStopCounter:  earlyStopCounter,
+		messageCount:      messageCount,
 	}
 }
 
 // WithTracing returns a goai.Option that enables OTel tracing for a single call.
 // Each invocation creates a fresh trace with isolated state -- safe for concurrent use.
+//
+// Ordering: WithTracing wraps the singleton hooks (OnBeforeToolExecute, OnAfterToolExecute,
+// OnBeforeStep) to add observability without replacing user hooks. For this to work,
+// WithTracing must be applied AFTER any user-registered singleton hooks. Place it last
+// in the option list, or use WithOptions to group user hooks before WithTracing.
 func WithTracing(opts ...TracingOption) goai.Option {
 	cfg := config{
 		spanName: "chat",
@@ -161,13 +184,32 @@ func run(cfg config) []goai.Option {
 		step      int
 		toolMu    sync.Mutex
 		toolSpans = make(map[string]trace.Span) // keyed by toolCallID
+
+		// B1-B3: per-tool state from OnBeforeToolExecute (keyed by toolCallID).
+		toolSkipReasons    = make(map[string]string)
+		toolInputOverrides = make(map[string]bool)
+		toolCtxOverridden  = make(map[string]bool)   // B3: context was overridden
+		toolCtxDeadlines   = make(map[string]string) // B3: deadline string (empty if no deadline)
+
+		// C1-C2: per-tool state from OnAfterToolExecute (keyed by toolCallID).
+		toolOutputModified = make(map[string]bool)
+		toolErrorModified  = make(map[string]string)
+
+		// D1-D2: termination tracking.
+		hookStopped       bool
+		hookStoppedAtStep int
+		terminationReason string
+
+		// D3: injected message count for next generation.
+		pendingInjectedMessages int
+
+		// Pending text/finishReason from OnStepFinish, for OnFinish to flush.
+		pendingText         string
+		pendingFinishReason provider.FinishReason
 	)
 
 	// end is declared before opts so WithOnStepFinish can reference it.
 	var end func(text string, finishReason provider.FinishReason)
-
-	// TODO: Register OnBeforeToolExecute, OnAfterToolExecute, and OnBeforeStep hooks
-	// to annotate spans with tool skip status, output modifications, and loop termination.
 
 	opts := []goai.Option{
 		goai.WithOnRequest(func(info goai.RequestInfo) {
@@ -186,8 +228,11 @@ func run(cfg config) []goai.Option {
 				if parentCtx == nil {
 					parentCtx = context.Background()
 				}
+				// A4: use info.Timestamp for span start time (more accurate than
+				// in-hook wall clock -- set by goai before OnRequest fires).
 				rootCtx, rootSpan = tracer.Start(parentCtx, cfg.spanName,
 					trace.WithAttributes(attrs...),
+					trace.WithTimestamp(info.Timestamp),
 				)
 
 				if cfg.recordInput {
@@ -197,14 +242,27 @@ func run(cfg config) []goai.Option {
 				}
 			}
 
+			// A3: message count and tool count on LLM span.
+			llmAttrs := []attribute.KeyValue{
+				attribute.String("gen_ai.system", "goai"),
+				attribute.String("gen_ai.operation.name", "chat"),
+				attribute.String("gen_ai.request.model", info.Model),
+				attribute.Int("goai.step", step),
+				attribute.Int("goai.request.message_count", info.MessageCount),
+				attribute.Int("goai.request.tool_count", info.ToolCount),
+			}
+
+			// D3: annotate injected messages from OnBeforeStep.
+			if pendingInjectedMessages > 0 {
+				llmAttrs = append(llmAttrs, attribute.Int("goai.step.injected_messages", pendingInjectedMessages))
+				pendingInjectedMessages = 0
+			}
+
 			// Start LLM call span as child of root.
+			// A4: use info.Timestamp for span start time.
 			_, llmSpan = tracer.Start(rootCtx, fmt.Sprintf("chat %s", info.Model),
-				trace.WithAttributes(
-					attribute.String("gen_ai.system", "goai"),
-					attribute.String("gen_ai.operation.name", "chat"),
-					attribute.String("gen_ai.request.model", info.Model),
-					attribute.Int("goai.step", step),
-				),
+				trace.WithAttributes(llmAttrs...),
+				trace.WithTimestamp(info.Timestamp),
 			)
 		}),
 
@@ -265,7 +323,6 @@ func run(cfg config) []goai.Option {
 				llmSpan.SetStatus(codes.Error, info.Error.Error())
 				llmSpan.End()
 				llmSpan = nil
-				// On error, mark root span with error status and end immediately.
 				if rootSpan != nil {
 					rootSpan.SetStatus(codes.Error, info.Error.Error())
 				}
@@ -290,6 +347,13 @@ func run(cfg config) []goai.Option {
 				),
 			)
 
+			// A7: record tool input as span event (respecting privacy opt-in).
+			if cfg.recordToolIO && len(info.Input) > 0 {
+				toolSpan.AddEvent("goai.tool.input", trace.WithAttributes(
+					attribute.String("goai.tool.input", string(info.Input)),
+				))
+			}
+
 			toolMu.Lock()
 			toolSpans[info.ToolCallID] = toolSpan
 			toolMu.Unlock()
@@ -301,10 +365,83 @@ func run(cfg config) []goai.Option {
 			if ok {
 				delete(toolSpans, info.ToolCallID)
 			}
+
+			// Read per-tool state from B/C hooks.
+			skipReason := toolSkipReasons[info.ToolCallID]
+			delete(toolSkipReasons, info.ToolCallID)
+			inputOverridden := toolInputOverrides[info.ToolCallID]
+			delete(toolInputOverrides, info.ToolCallID)
+			ctxOverridden := toolCtxOverridden[info.ToolCallID]
+			delete(toolCtxOverridden, info.ToolCallID)
+			ctxDeadline := toolCtxDeadlines[info.ToolCallID]
+			delete(toolCtxDeadlines, info.ToolCallID)
+			outputModified := toolOutputModified[info.ToolCallID]
+			delete(toolOutputModified, info.ToolCallID)
+			errModified := toolErrorModified[info.ToolCallID]
+			delete(toolErrorModified, info.ToolCallID)
 			toolMu.Unlock()
 
 			if !ok {
 				return
+			}
+
+			// A1: annotate skipped tools.
+			if info.Skipped {
+				toolSpan.SetAttributes(attribute.Bool("goai.tool.skipped", true))
+				// B1: skip reason attribution.
+				if skipReason != "" {
+					toolSpan.AddEvent("goai.tool.skipped", trace.WithAttributes(
+						attribute.String("goai.tool.skip_reason", skipReason),
+					))
+				}
+			}
+
+			// A2: record metadata from OnAfterToolExecute.
+			for k, v := range info.Metadata {
+				switch val := v.(type) {
+				case string:
+					toolSpan.SetAttributes(attribute.String("goai.tool.metadata."+k, val))
+				case int:
+					toolSpan.SetAttributes(attribute.Int("goai.tool.metadata."+k, val))
+				case int64:
+					toolSpan.SetAttributes(attribute.Int64("goai.tool.metadata."+k, val))
+				case float64:
+					toolSpan.SetAttributes(attribute.Float64("goai.tool.metadata."+k, val))
+				case bool:
+					toolSpan.SetAttributes(attribute.Bool("goai.tool.metadata."+k, val))
+				}
+			}
+
+			// B2: input override detection.
+			if inputOverridden {
+				toolSpan.SetAttributes(attribute.Bool("goai.tool.input_overridden", true))
+			}
+
+			// B3: context override detection -- set unconditionally when ctx overridden.
+			if ctxOverridden {
+				toolSpan.SetAttributes(attribute.Bool("goai.tool.context_overridden", true))
+				if ctxDeadline != "" {
+					toolSpan.SetAttributes(attribute.String("goai.tool.deadline", ctxDeadline))
+				}
+			}
+
+			// C1: output modification detection.
+			if outputModified {
+				toolSpan.SetAttributes(attribute.Bool("goai.tool.output_modified", true))
+			}
+
+			// C2: error injection/replacement detection.
+			if errModified != "" {
+				toolSpan.AddEvent("goai.tool.error_modified", trace.WithAttributes(
+					attribute.String("goai.tool.error_modification", errModified),
+				))
+			}
+
+			// A7: record tool output as span event (respecting privacy opt-in).
+			if cfg.recordToolIO && info.Output != "" {
+				toolSpan.AddEvent("goai.tool.output", trace.WithAttributes(
+					attribute.String("goai.tool.output", info.Output),
+				))
 			}
 
 			if info.Error != nil {
@@ -313,18 +450,205 @@ func run(cfg config) []goai.Option {
 
 			toolSpan.End()
 
-			inst.toolDuration.Record(context.Background(), info.Duration.Seconds(),
-				metric.WithAttributes(attribute.String("gen_ai.tool.name", info.ToolName)),
-			)
+			// A1: skip recording tool duration metric when Skipped=true (0s pollutes histogram).
+			if !info.Skipped {
+				inst.toolDuration.Record(context.Background(), info.Duration.Seconds(),
+					metric.WithAttributes(attribute.String("gen_ai.tool.name", info.ToolName)),
+				)
+			}
 		}),
 
 		goai.WithOnStepFinish(func(sr goai.StepResult) {
+			// A6: record Sources, Response.Model, Response.ID, ProviderMetadata.
+			// The per-step LLM span has already ended in OnResponse, so these are set
+			// on rootSpan. In multi-step runs, later steps overwrite earlier values --
+			// only the last step's metadata survives. This is acceptable because the
+			// root span represents the overall operation, and the last step's response
+			// is the final answer. Per-step metadata is available on LLM spans via
+			// OnResponse attributes (usage, finish reason, etc.).
+			if rootSpan != nil {
+				if sr.Response.Model != "" {
+					rootSpan.SetAttributes(attribute.String("gen_ai.response.model", sr.Response.Model))
+				}
+				if sr.Response.ID != "" {
+					rootSpan.SetAttributes(attribute.String("gen_ai.response.id", sr.Response.ID))
+				}
+				if len(sr.Sources) > 0 {
+					sourceNames := make([]string, 0, len(sr.Sources))
+					for _, s := range sr.Sources {
+						if s.URL != "" {
+							sourceNames = append(sourceNames, s.URL)
+						} else if s.Title != "" {
+							sourceNames = append(sourceNames, s.Title)
+						}
+					}
+					if len(sourceNames) > 0 {
+						rootSpan.AddEvent("gen_ai.content.sources", trace.WithAttributes(
+							attribute.StringSlice("gen_ai.sources", sourceNames),
+						))
+					}
+				}
+				if len(sr.ProviderMetadata) > 0 {
+					for ns, data := range sr.ProviderMetadata {
+						for k, v := range data {
+							switch val := v.(type) {
+							case string:
+								rootSpan.SetAttributes(attribute.String("goai.provider_metadata."+ns+"."+k, val))
+							case float64:
+								rootSpan.SetAttributes(attribute.Float64("goai.provider_metadata."+ns+"."+k, val))
+							case bool:
+								rootSpan.SetAttributes(attribute.Bool("goai.provider_metadata."+ns+"."+k, val))
+							}
+						}
+					}
+				}
+			}
+
+			// D2: track termination reason.
+			// "natural" and "hook_stopped" are detected here in OnStepFinish.
+			// "max_steps" is detected in OnFinish via StepsExhausted.
 			if sr.FinishReason == provider.FinishToolCalls {
 				return // intermediate step -- more tool calls follow
 			}
-			end(sr.Text, sr.FinishReason)
+			if !hookStopped {
+				terminationReason = "natural"
+			}
+
+			// Store pending text/finishReason for OnFinish to flush.
+			// Do NOT call end() here -- OnFinish is the single closer.
+			pendingText = sr.Text
+			pendingFinishReason = sr.FinishReason
 		}),
 	}
+
+	// OnFinish: fires once after all steps complete. Handles termination reason
+	// detection (including max_steps via StepsExhausted) and ensures end() is called
+	// for all exit paths.
+	opts = append(opts, goai.WithOnFinish(func(info goai.FinishInfo) {
+		if info.StepsExhausted {
+			terminationReason = "max_steps"
+		}
+		// For hook_stopped, terminationReason was already set in OnBeforeStep wrapper.
+		// For natural, it was set in OnStepFinish (which stored text in pendingText).
+		// OnFinish is the single closer -- end() is only called here (and OnResponse error).
+		text := pendingText
+		fr := pendingFinishReason
+		if fr == "" {
+			fr = info.FinishReason
+		}
+		end(text, fr)
+	}))
+
+	// Section 7.1: Wrapper pattern for singleton hooks (B/C/D categories).
+
+	// B1-B4: OnBeforeToolExecute wrapper.
+	opts = append(opts, goai.WrapOnBeforeToolExecute(func(userHook func(goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult) func(goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+		return func(info goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			var result goai.BeforeToolExecuteResult
+			if userHook != nil {
+				result = userHook(info)
+			}
+
+			toolMu.Lock()
+			// B4: add pre-execution span event.
+			if toolSpan, ok := toolSpans[info.ToolCallID]; ok {
+				toolSpan.AddEvent("goai.tool.execute_start")
+			}
+
+			// B1: capture skip reason.
+			if result.Skip {
+				reason := "skipped by hook"
+				if result.Error != nil {
+					reason = result.Error.Error()
+				}
+				toolSkipReasons[info.ToolCallID] = reason
+			}
+			// B2: detect input override.
+			if result.Input != nil {
+				toolInputOverrides[info.ToolCallID] = true
+			}
+			// B3: detect context override with deadline extraction.
+			if result.Ctx != nil {
+				toolCtxOverridden[info.ToolCallID] = true
+				if dl, ok := result.Ctx.Deadline(); ok {
+					toolCtxDeadlines[info.ToolCallID] = dl.Format("2006-01-02T15:04:05.000Z07:00")
+				}
+			}
+			toolMu.Unlock()
+
+			return result
+		}
+	}))
+
+	// C1-C3: OnAfterToolExecute wrapper.
+	opts = append(opts, goai.WrapOnAfterToolExecute(func(userHook func(goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult) func(goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+		return func(info goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			var result goai.AfterToolExecuteResult
+			if userHook != nil {
+				result = userHook(info)
+			}
+
+			toolMu.Lock()
+			// C3: add timing boundary event.
+			if toolSpan, ok := toolSpans[info.ToolCallID]; ok {
+				toolSpan.AddEvent("goai.tool.after_execute")
+			}
+
+			// C1: detect output modification.
+			if result.Output != "" && result.Output != info.Output {
+				toolOutputModified[info.ToolCallID] = true
+			}
+			// C2: detect error injection/replacement.
+			if result.Error != nil {
+				if info.Error == nil {
+					toolErrorModified[info.ToolCallID] = "injected"
+				} else if result.Error.Error() != info.Error.Error() {
+					toolErrorModified[info.ToolCallID] = "replaced"
+				}
+			}
+			toolMu.Unlock()
+
+			return result
+		}
+	}))
+
+	// D1, D3-D4: OnBeforeStep wrapper.
+	opts = append(opts, goai.WrapOnBeforeStep(func(userHook func(goai.BeforeStepInfo) goai.BeforeStepResult) func(goai.BeforeStepInfo) goai.BeforeStepResult {
+		return func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+			var result goai.BeforeStepResult
+			if userHook != nil {
+				result = userHook(info)
+			}
+
+			// D1: detect loop termination signal.
+			if result.Stop {
+				hookStopped = true
+				hookStoppedAtStep = info.Step
+				terminationReason = "hook_stopped"
+				if rootSpan != nil {
+					rootSpan.AddEvent("goai.loop.stopped", trace.WithAttributes(
+						attribute.Int("goai.step", info.Step),
+					))
+					inst.earlyStopCounter.Add(context.Background(), 1)
+				}
+				// end() is called by OnFinish (which fires after the loop exits).
+			}
+
+			// D3: track injected messages.
+			if len(result.ExtraMessages) > 0 {
+				pendingInjectedMessages = len(result.ExtraMessages)
+			}
+
+			// D4: conversation size monitoring.
+			if rootSpan != nil {
+				inst.messageCount.Record(context.Background(), int64(len(info.Messages)),
+					metric.WithAttributes(attribute.Int("goai.step", info.Step)),
+				)
+			}
+
+			return result
+		}
+	}))
 
 	end = func(text string, finishReason provider.FinishReason) {
 		if rootSpan == nil {
@@ -341,6 +665,27 @@ func run(cfg config) []goai.Option {
 			rootSpan.SetAttributes(
 				attribute.StringSlice("gen_ai.response.finish_reasons", []string{string(finishReason)}),
 			)
+		}
+
+		// D1: annotate root span with hook_stopped.
+		if hookStopped {
+			rootSpan.SetAttributes(
+				attribute.Bool("goai.stopped_by_hook", true),
+				attribute.Int("goai.stopped_at_step", hookStoppedAtStep),
+			)
+		}
+
+		// D2: set termination reason on root span.
+		if terminationReason != "" {
+			rootSpan.SetAttributes(attribute.String("goai.termination_reason", terminationReason))
+		}
+
+		// End any orphaned LLM span (e.g., drainStep error or empty step where
+		// OnResponse never fired to end it). Safe to call even if llmSpan is nil.
+		if llmSpan != nil {
+			llmSpan.SetStatus(codes.Error, "stream terminated before response")
+			llmSpan.End()
+			llmSpan = nil
 		}
 
 		rootSpan.End()

--- a/observability/otel/otel_test.go
+++ b/observability/otel/otel_test.go
@@ -1216,3 +1216,931 @@ func TestWithTracing_ParentContext(t *testing.T) {
 		t.Errorf("root span parent ID = %v, want %v (parent span)", root.Parent.SpanID(), parentSC.SpanID())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Helpers for enhancement tests
+// ---------------------------------------------------------------------------
+
+// hasEvent returns true if the span has an event with the given name.
+func hasEvent(span tracetest.SpanStub, name string) bool {
+	for _, e := range span.Events {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// eventAttrValue returns the attribute value for the given event name and key.
+func eventAttrValue(span tracetest.SpanStub, eventName, key string) attribute.Value {
+	for _, e := range span.Events {
+		if e.Name == eventName {
+			return attrValue(e.Attributes, key)
+		}
+	}
+	return attribute.Value{}
+}
+
+// toolLoopModel returns a mock model that issues a single tool call on the first
+// request and returns finalText on the second. The tool call uses the given name
+// and ID. Response.Model and Response.ID are set on both results.
+func toolLoopModel(toolName, toolCallID, finalText string) *mockModel {
+	call := 0
+	return &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			call++
+			if call == 1 {
+				return &provider.GenerateResult{
+					FinishReason: provider.FinishToolCalls,
+					ToolCalls: []provider.ToolCall{
+						{ID: toolCallID, Name: toolName, Input: []byte(`{"q":"test"}`)},
+					},
+					Usage:    provider.Usage{InputTokens: 10, OutputTokens: 5},
+					Response: provider.ResponseMetadata{Model: "test-model-actual", ID: "resp-001"},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         finalText,
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 20, OutputTokens: 10},
+				Response:     provider.ResponseMetadata{Model: "test-model-actual", ID: "resp-002"},
+			}, nil
+		},
+	}
+}
+
+// simpleTool returns a goai.Tool with the given name that returns output.
+func simpleTool(name, output string) goai.Tool {
+	return goai.Tool{
+		Name: name,
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return output, nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A1: Skipped tools
+// ---------------------------------------------------------------------------
+
+func TestA1_SkippedTools(t *testing.T) {
+	tp, sr, mp, mr := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnBeforeToolExecute(func(_ goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{Skip: true, Result: "skipped"}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	// Assert goai.tool.skipped=true attribute.
+	if v := attrValue(toolSpan.Attributes, "goai.tool.skipped"); v.AsBool() != true {
+		t.Errorf("goai.tool.skipped = %v, want true", v.AsBool())
+	}
+
+	// Assert tool duration metric is NOT recorded for skipped tools.
+	rm := collectMetrics(t, mr)
+	toolMetric := findMetric(rm, "goai.tool.duration")
+	if toolMetric != nil {
+		t.Error("goai.tool.duration should not be recorded for skipped tools")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A2: Metadata
+// ---------------------------------------------------------------------------
+
+func TestA2_Metadata(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnAfterToolExecute(func(_ goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			return goai.AfterToolExecuteResult{
+				Metadata: map[string]any{
+					"region":  "us-east-1",
+					"latency": 42,
+					"cached":  true,
+					"score":   0.95,
+				},
+			}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	if v := attrValue(toolSpan.Attributes, "goai.tool.metadata.region"); v.AsString() != "us-east-1" {
+		t.Errorf("metadata.region = %q, want %q", v.AsString(), "us-east-1")
+	}
+	if v := attrValue(toolSpan.Attributes, "goai.tool.metadata.latency"); v.AsInt64() != 42 {
+		t.Errorf("metadata.latency = %d, want 42", v.AsInt64())
+	}
+	if v := attrValue(toolSpan.Attributes, "goai.tool.metadata.cached"); v.AsBool() != true {
+		t.Errorf("metadata.cached = %v, want true", v.AsBool())
+	}
+	if v := attrValue(toolSpan.Attributes, "goai.tool.metadata.score"); v.AsFloat64() != 0.95 {
+		t.Errorf("metadata.score = %f, want 0.95", v.AsFloat64())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A3: MessageCount / ToolCount
+// ---------------------------------------------------------------------------
+
+func TestA3_MessageCountAndToolCount(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	llmSpans := spansByName(sr, "chat test-model")
+	if len(llmSpans) == 0 {
+		t.Fatal("no LLM spans found")
+	}
+
+	// First LLM call should have message_count and tool_count attributes.
+	first := llmSpans[0]
+	if v := attrValue(first.Attributes, "goai.request.message_count"); v.AsInt64() == 0 {
+		t.Error("goai.request.message_count should be > 0 on first LLM span")
+	}
+	if v := attrValue(first.Attributes, "goai.request.tool_count"); v.AsInt64() != 1 {
+		t.Errorf("goai.request.tool_count = %d, want 1", v.AsInt64())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A6: StepResult fields (Response.Model, Response.ID)
+// ---------------------------------------------------------------------------
+
+func TestA6_StepResultFields(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "ok",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+				Response:     provider.ResponseMetadata{Model: "gpt-4o-2024-05-13", ID: "chatcmpl-abc123"},
+			}, nil
+		},
+	}
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	root := spanByName(sr, "chat")
+	if root.Name == "" {
+		t.Fatal("root span not found")
+	}
+
+	if v := attrValue(root.Attributes, "gen_ai.response.model"); v.AsString() != "gpt-4o-2024-05-13" {
+		t.Errorf("gen_ai.response.model = %q, want %q", v.AsString(), "gpt-4o-2024-05-13")
+	}
+	if v := attrValue(root.Attributes, "gen_ai.response.id"); v.AsString() != "chatcmpl-abc123" {
+		t.Errorf("gen_ai.response.id = %q, want %q", v.AsString(), "chatcmpl-abc123")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A7: Tool output recording
+// ---------------------------------------------------------------------------
+
+func TestA7_ToolOutputRecording(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", `{"temp":72}`)
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp), RecordToolIO(true)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	// Assert goai.tool.output event exists.
+	if !hasEvent(toolSpan, "goai.tool.output") {
+		t.Error("expected goai.tool.output event on tool span")
+	}
+	if v := eventAttrValue(toolSpan, "goai.tool.output", "goai.tool.output"); v.AsString() != `{"temp":72}` {
+		t.Errorf("goai.tool.output = %q, want %q", v.AsString(), `{"temp":72}`)
+	}
+
+	// Also verify tool input event.
+	if !hasEvent(toolSpan, "goai.tool.input") {
+		t.Error("expected goai.tool.input event on tool span")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B1: Skip reason
+// ---------------------------------------------------------------------------
+
+func TestB1_SkipReason(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	skipErr := errors.New("permission denied: admin only")
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnBeforeToolExecute(func(_ goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{Skip: true, Error: skipErr}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	// Assert goai.tool.skipped attribute.
+	if v := attrValue(toolSpan.Attributes, "goai.tool.skipped"); v.AsBool() != true {
+		t.Error("expected goai.tool.skipped=true")
+	}
+
+	// Assert goai.tool.skipped event with skip_reason.
+	if !hasEvent(toolSpan, "goai.tool.skipped") {
+		t.Fatal("expected goai.tool.skipped event")
+	}
+	if v := eventAttrValue(toolSpan, "goai.tool.skipped", "goai.tool.skip_reason"); v.AsString() != "permission denied: admin only" {
+		t.Errorf("skip_reason = %q, want %q", v.AsString(), "permission denied: admin only")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B2: Input override
+// ---------------------------------------------------------------------------
+
+func TestB2_InputOverride(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnBeforeToolExecute(func(_ goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{Input: json.RawMessage(`{"overridden":true}`)}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	if v := attrValue(toolSpan.Attributes, "goai.tool.input_overridden"); v.AsBool() != true {
+		t.Errorf("goai.tool.input_overridden = %v, want true", v.AsBool())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B3: Context override
+// ---------------------------------------------------------------------------
+
+func TestB3_ContextOverride(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	deadline := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	ctxWithDeadline, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnBeforeToolExecute(func(_ goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			return goai.BeforeToolExecuteResult{Ctx: ctxWithDeadline}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	if v := attrValue(toolSpan.Attributes, "goai.tool.context_overridden"); v.AsBool() != true {
+		t.Errorf("goai.tool.context_overridden = %v, want true", v.AsBool())
+	}
+	if v := attrValue(toolSpan.Attributes, "goai.tool.deadline"); v.AsString() == "" {
+		t.Error("goai.tool.deadline should be set when context has deadline")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B4: Pre-execution span event
+// ---------------------------------------------------------------------------
+
+func TestB4_PreExecutionSpanEvent(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	if !hasEvent(toolSpan, "goai.tool.execute_start") {
+		t.Error("expected goai.tool.execute_start event on tool span")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C1: Output modified
+// ---------------------------------------------------------------------------
+
+func TestC1_OutputModified(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "original_output")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnAfterToolExecute(func(_ goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			return goai.AfterToolExecuteResult{Output: "modified_output"}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	if v := attrValue(toolSpan.Attributes, "goai.tool.output_modified"); v.AsBool() != true {
+		t.Errorf("goai.tool.output_modified = %v, want true", v.AsBool())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C2: Error injected
+// ---------------------------------------------------------------------------
+
+func TestC2_ErrorInjected(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnAfterToolExecute(func(_ goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			return goai.AfterToolExecuteResult{Error: errors.New("injected error")}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	if !hasEvent(toolSpan, "goai.tool.error_modified") {
+		t.Fatal("expected goai.tool.error_modified event")
+	}
+	if v := eventAttrValue(toolSpan, "goai.tool.error_modified", "goai.tool.error_modification"); v.AsString() != "injected" {
+		t.Errorf("error_modification = %q, want %q", v.AsString(), "injected")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C3: Timing boundary
+// ---------------------------------------------------------------------------
+
+func TestC3_TimingBoundary(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnAfterToolExecute(func(_ goai.AfterToolExecuteInfo) goai.AfterToolExecuteResult {
+			return goai.AfterToolExecuteResult{}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	if !hasEvent(toolSpan, "goai.tool.after_execute") {
+		t.Error("expected goai.tool.after_execute event on tool span")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D1: Hook stopped
+// ---------------------------------------------------------------------------
+
+func TestD1_HookStopped(t *testing.T) {
+	tp, sr, mp, mr := newTestProviders(t)
+
+	// Use a model that does two tool-call rounds so OnBeforeStep fires.
+	call := 0
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			call++
+			if call <= 2 {
+				return &provider.GenerateResult{
+					FinishReason: provider.FinishToolCalls,
+					ToolCalls: []provider.ToolCall{
+						{ID: "tc" + strings.Repeat("x", call), Name: "my_tool", Input: []byte(`{}`)},
+					},
+					Usage:    provider.Usage{InputTokens: 10, OutputTokens: 5},
+					Response: provider.ResponseMetadata{Model: "test-model-actual", ID: "resp-001"},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 20, OutputTokens: 10},
+				Response:     provider.ResponseMetadata{Model: "test-model-actual", ID: "resp-002"},
+			}, nil
+		},
+	}
+	tool := simpleTool("my_tool", "result")
+
+	stopped := false
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnBeforeStep(func(info goai.BeforeStepInfo) goai.BeforeStepResult {
+			// Stop on step 2 (first OnBeforeStep invocation).
+			if info.Step == 2 {
+				stopped = true
+				return goai.BeforeStepResult{Stop: true}
+			}
+			return goai.BeforeStepResult{}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(5),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+	if !stopped {
+		t.Fatal("OnBeforeStep hook was not called")
+	}
+
+	// The WrapOnBeforeStep wrapper calls end() when Stop=true, so the root span
+	// is ended with hook_stopped attributes.
+	root := spanByName(sr, "chat")
+	if root.Name == "" {
+		t.Fatal("root span not found")
+	}
+	if v := attrValue(root.Attributes, "goai.stopped_by_hook"); v.AsBool() != true {
+		t.Errorf("goai.stopped_by_hook = %v, want true", v.AsBool())
+	}
+	if v := attrValue(root.Attributes, "goai.stopped_at_step"); v.AsInt64() != 2 {
+		t.Errorf("goai.stopped_at_step = %d, want 2", v.AsInt64())
+	}
+	if v := attrValue(root.Attributes, "goai.termination_reason"); v.AsString() != "hook_stopped" {
+		t.Errorf("goai.termination_reason = %q, want %q", v.AsString(), "hook_stopped")
+	}
+	// Also verify the span event and metric.
+	if !hasEvent(root, "goai.loop.stopped") {
+		t.Error("root span missing goai.loop.stopped event")
+	}
+	rm := collectMetrics(t, mr)
+	earlyStopMetric := findMetric(rm, "goai.loop.early_stop")
+	if earlyStopMetric == nil {
+		t.Fatal("goai.loop.early_stop metric not found")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D2: Termination reason
+// ---------------------------------------------------------------------------
+
+func TestD2_TerminationReason_Natural(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	root := spanByName(sr, "chat")
+	if root.Name == "" {
+		t.Fatal("root span not found")
+	}
+	if v := attrValue(root.Attributes, "goai.termination_reason"); v.AsString() != "natural" {
+		t.Errorf("goai.termination_reason = %q, want %q", v.AsString(), "natural")
+	}
+}
+
+func TestD2_TerminationReason_HookStopped(t *testing.T) {
+	tp, sr, mp, mr := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	stopped := false
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnBeforeStep(func(_ goai.BeforeStepInfo) goai.BeforeStepResult {
+			stopped = true
+			return goai.BeforeStepResult{Stop: true}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+	if !stopped {
+		t.Fatal("OnBeforeStep hook was not called")
+	}
+
+	// The WrapOnBeforeStep wrapper calls end() when Stop=true, ending the root span
+	// with termination_reason="hook_stopped".
+	root := spanByName(sr, "chat")
+	if root.Name == "" {
+		t.Fatal("root span not found")
+	}
+	if v := attrValue(root.Attributes, "goai.termination_reason"); v.AsString() != "hook_stopped" {
+		t.Errorf("goai.termination_reason = %q, want %q", v.AsString(), "hook_stopped")
+	}
+	// Also verify the metric.
+	rm := collectMetrics(t, mr)
+	earlyStopMetric := findMetric(rm, "goai.loop.early_stop")
+	if earlyStopMetric == nil {
+		t.Fatal("goai.loop.early_stop metric not found -- hook_stopped should increment counter")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D3: ExtraMessages
+// ---------------------------------------------------------------------------
+
+func TestD3_ExtraMessages(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		goai.WithOnBeforeStep(func(_ goai.BeforeStepInfo) goai.BeforeStepResult {
+			return goai.BeforeStepResult{
+				ExtraMessages: []provider.Message{
+					{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "extra context"}}},
+				},
+			}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	// The second LLM span should have goai.step.injected_messages attribute.
+	llmSpans := spansByName(sr, "chat test-model")
+	if len(llmSpans) < 2 {
+		t.Fatalf("expected at least 2 LLM spans, got %d", len(llmSpans))
+	}
+
+	second := llmSpans[1]
+	if v := attrValue(second.Attributes, "goai.step.injected_messages"); v.AsInt64() != 1 {
+		t.Errorf("goai.step.injected_messages = %d, want 1", v.AsInt64())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D4: Message count gauge
+// ---------------------------------------------------------------------------
+
+func TestD4_MessageCountGauge(t *testing.T) {
+	tp, _, mp, mr := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	rm := collectMetrics(t, mr)
+	msgMetric := findMetric(rm, "goai.conversation.message_count")
+	if msgMetric == nil {
+		t.Fatal("goai.conversation.message_count metric not found")
+	}
+	// Verify the gauge has data points with non-zero values.
+	// OnBeforeStep fires at step 2 with the accumulated messages from step 1.
+	gauge, ok := msgMetric.Data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("expected Gauge[int64], got %T", msgMetric.Data)
+	}
+	if len(gauge.DataPoints) == 0 {
+		t.Fatal("goai.conversation.message_count has no data points")
+	}
+	// The message count should be > 0 (at least the original prompt + tool round-trip).
+	for _, dp := range gauge.DataPoints {
+		if dp.Value <= 0 {
+			t.Errorf("goai.conversation.message_count data point value = %d, want > 0", dp.Value)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Wrapper pattern: User OnBeforeToolExecute + WithTracing
+// ---------------------------------------------------------------------------
+
+func TestWrapperPattern_UserSkipHonored(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := toolLoopModel("my_tool", "tc1", "done")
+	tool := simpleTool("my_tool", "result")
+
+	userHookCalled := false
+	_, err := goai.GenerateText(context.Background(), model,
+		// User hook registered BEFORE WithTracing.
+		goai.WithOnBeforeToolExecute(func(_ goai.BeforeToolExecuteInfo) goai.BeforeToolExecuteResult {
+			userHookCalled = true
+			return goai.BeforeToolExecuteResult{Skip: true, Result: "user-skip", Error: errors.New("blocked")}
+		}),
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(3),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	if !userHookCalled {
+		t.Error("user's OnBeforeToolExecute hook was not called")
+	}
+
+	toolSpan := spanByName(sr, "execute_tool my_tool")
+	if toolSpan.Name == "" {
+		t.Fatal("tool span not found")
+	}
+
+	// User's Skip=true should be honored.
+	if v := attrValue(toolSpan.Attributes, "goai.tool.skipped"); v.AsBool() != true {
+		t.Errorf("goai.tool.skipped = %v, want true (user skip should be honored)", v.AsBool())
+	}
+
+	// Observability annotations should still be present.
+	if !hasEvent(toolSpan, "goai.tool.execute_start") {
+		t.Error("expected goai.tool.execute_start event (observability wrapper)")
+	}
+
+	// B1: skip reason from user's error should be captured.
+	if !hasEvent(toolSpan, "goai.tool.skipped") {
+		t.Fatal("expected goai.tool.skipped event")
+	}
+	if v := eventAttrValue(toolSpan, "goai.tool.skipped", "goai.tool.skip_reason"); v.AsString() != "blocked" {
+		t.Errorf("skip_reason = %q, want %q", v.AsString(), "blocked")
+	}
+}
+
+func TestD2_TerminationReason_MaxSteps(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	// Model always returns tool calls, so MaxSteps will be exhausted.
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "my_tool", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 10, OutputTokens: 5},
+			}, nil
+		},
+	}
+	tool := simpleTool("my_tool", "result")
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("go"),
+		goai.WithMaxSteps(2),
+		goai.WithTools(tool),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	root := spanByName(sr, "chat")
+	if root.Name == "" {
+		t.Fatal("root span not found")
+	}
+	if v := attrValue(root.Attributes, "goai.termination_reason"); v.AsString() != "max_steps" {
+		t.Errorf("goai.termination_reason = %q, want %q", v.AsString(), "max_steps")
+	}
+}
+
+func TestA6_SourcesAndProviderMetadata(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "hello",
+				FinishReason: provider.FinishStop,
+				Usage: provider.Usage{
+					InputTokens:  10,
+					OutputTokens: 5,
+				},
+				Sources: []provider.Source{
+					{Title: "Wikipedia", URL: "https://en.wikipedia.org"},
+				},
+				ProviderMetadata: map[string]map[string]any{
+					"openai": {"system_fingerprint": "fp_abc123"},
+				},
+			}, nil
+		},
+	}
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	root := spanByName(sr, "chat")
+	if root.Name == "" {
+		t.Fatal("root span not found")
+	}
+
+	// A6: Sources should produce a gen_ai.content.sources event with URLs.
+	if !hasEvent(root, "gen_ai.content.sources") {
+		t.Fatal("expected gen_ai.content.sources event on root span")
+	}
+	sourcesVal := eventAttrValue(root, "gen_ai.content.sources", "gen_ai.sources")
+	sources := sourcesVal.AsStringSlice()
+	if len(sources) != 1 || sources[0] != "https://en.wikipedia.org" {
+		t.Errorf("gen_ai.sources = %v, want [https://en.wikipedia.org]", sources)
+	}
+
+	// A6: ProviderMetadata should produce goai.provider_metadata.* attributes.
+	if v := attrValue(root.Attributes, "goai.provider_metadata.openai.system_fingerprint"); v.AsString() != "fp_abc123" {
+		t.Errorf("provider_metadata attr = %q, want %q", v.AsString(), "fp_abc123")
+	}
+}
+
+func TestWithTracing_CacheTokens(t *testing.T) {
+	tp, sr, mp, _ := newTestProviders(t)
+
+	model := &mockModel{
+		id: "test-model",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "hello",
+				FinishReason: provider.FinishStop,
+				Usage: provider.Usage{
+					InputTokens:     10,
+					OutputTokens:    5,
+					CacheReadTokens:  100,
+					CacheWriteTokens: 50,
+				},
+			}, nil
+		},
+	}
+
+	_, err := goai.GenerateText(context.Background(), model,
+		WithTracing(WithTracerProvider(tp), WithMeterProvider(mp)),
+		goai.WithPrompt("hi"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateText: %v", err)
+	}
+
+	llm := spanByName(sr, "chat test-model")
+	if llm.Name == "" {
+		t.Fatal("llm span not found")
+	}
+
+	if v := attrValue(llm.Attributes, "gen_ai.usage.cache_read.input_tokens"); v.AsInt64() != 100 {
+		t.Errorf("cache_read.input_tokens = %d, want 100", v.AsInt64())
+	}
+	if v := attrValue(llm.Attributes, "gen_ai.usage.cache_creation.input_tokens"); v.AsInt64() != 50 {
+		t.Errorf("cache_creation.input_tokens = %d, want 50", v.AsInt64())
+	}
+}

--- a/options.go
+++ b/options.go
@@ -90,6 +90,9 @@ type options struct {
 	// OnStepFinish is called after each generation step completes (including tool execution).
 	OnStepFinish []func(StepResult)
 
+	// OnFinish is called once after all generation steps complete.
+	OnFinish []func(FinishInfo)
+
 	// OnRequest is called before each model API call.
 	OnRequest []func(RequestInfo)
 


### PR DESCRIPTION
## Summary

Implements all enhancements from the [observability hooks design document](des/observability-hooks-enhancement-design.md). Both Langfuse and OTel packages now leverage all 9 lifecycle hooks for comprehensive tracing.

### New goai core API
- **`OnFinish` hook** - fires once after all steps, carries `StepsExhausted` for max_steps detection
- **`WrapOnBeforeToolExecute/WrapOnAfterToolExecute/WrapOnBeforeStep`** - wrapper pattern enabling observability to coexist with user hooks (Section 7.1)
- **`fireOnFinish`** called in all exit paths (natural, max_steps, hook_stopped, error, drainStep)

### Observability enhancements (both Langfuse + OTel)
- **Category A**: Use existing fields (Skipped, Metadata, MessageCount, Timestamp, StatusCode, Sources, Response.Model/ID, ProviderMetadata, tool output)
- **Category B**: OnBeforeToolExecute (skip reason, input/context override, pre-execution event)
- **Category C**: OnAfterToolExecute (output modification, error injection, timing boundary)
- **Category D**: OnBeforeStep (loop termination, termination taxonomy, ExtraMessages, conversation size)
- **Category E**: Opt-in EagerToolSpans for Langfuse (span-update for completion)

### Bug fixes
- G1: Panic recovery for GenerateObject/StreamObject OnResponse
- G3: GenerateText StepsExhausted conditional (match StreamText)
- OTel orphaned llmSpan cleanup, Langfuse gen.output preservation, plain-text fallback

### Docs
- All 9 hooks documented across hooks.md, observability.md, options.md, types.md, README, core-functions.md
- 5 missing examples added to docs/examples.md and README examples list
- Langfuse/OTel examples switched to Gemini, langfuse go.mod added

## Test plan
- [x] `go test ./...` - 29 packages pass
- [x] `observability/langfuse` - 96.7% coverage, 62 tests
- [x] `observability/otel` - 94.2% coverage, 46 tests
- [x] 8 new OnFinish core tests (natural, max_steps, hook_stopped, StreamText, panic, GenerateObject)
- [x] 3 D2 termination tests per package (natural, max_steps, hook_stopped)
- [x] Wrapper pattern tests (user hook + observability coexistence)
- [x] Examples verified with real Gemini model (hooks, langfuse, otel)
