### PR TITLE
fix(gemini): inline $ref/$defs and strip if/then/else in SanitizeSchema

### DIFF
--- a/internal/gemini/schema.go
+++ b/internal/gemini/schema.go
@@ -40,9 +40,6 @@ func SanitizeSchema(schema map[string]any) map[string]any {
 // The function does not mutate its input: new maps/slices are allocated
 // for every container so callers can safely reuse the original schema.
 func inlineRefsAndStripDrafts(obj any, defs map[string]any, depth int) any {
-	if obj == nil {
-		return nil
-	}
 	switch v := obj.(type) {
 	case map[string]any:
 		// $ref resolution: replace with the deep-cloned target.

--- a/internal/gemini/schema.go
+++ b/internal/gemini/schema.go
@@ -1,14 +1,95 @@
 // Package gemini provides shared utilities for Google Gemini API providers.
 package gemini
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+// maxRefInlineDepth caps recursive $ref resolution to prevent infinite loops
+// on cyclic schemas. Real-world schemas rarely exceed 3-4 levels of nesting.
+const maxRefInlineDepth = 10
 
 // SanitizeSchema sanitizes a JSON Schema for Gemini compatibility.
 // It converts enum integer/number types to string, filters invalid required fields,
-// and ensures array items have a type.
+// ensures array items have a type, inlines $ref/$defs (which Gemini rejects),
+// and strips JSON Schema conditionals (if/then/else) which Gemini's OpenAPI
+// validator does not understand.
 func SanitizeSchema(schema map[string]any) map[string]any {
-	// sanitizeImpl always returns map[string]any for map input; cast is safe.
+	// Step 1: resolve $ref → $defs and strip unsupported keywords.
+	// Gemini's function_declarations validator cannot resolve
+	// "#/$defs/X" references and rejects JSON Schema conditional keywords
+	// (if/then/else) even inside allOf clauses. This preprocess pass
+	// handles both issues before the existing compatibility sanitizer runs.
+	defs, _ := schema["$defs"].(map[string]any)
+	processed := inlineRefsAndStripDrafts(schema, defs, 0)
+	if m, ok := processed.(map[string]any); ok {
+		schema = m
+	}
+	// Step 2: existing compatibility pass (nullables, enums, array items, etc.).
 	return sanitizeImpl(schema).(map[string]any)
+}
+
+// inlineRefsAndStripDrafts walks an arbitrary schema value and:
+//   - Replaces every {"$ref": "#/$defs/X"} with a deep copy of $defs.X
+//     (recursively, so nested refs are also resolved).
+//   - Strips "$defs", "if", "then", "else" keys anywhere they appear.
+//   - Bails out at maxRefInlineDepth to prevent cyclic-ref infinite loops;
+//     at the depth cap, unresolved refs become {type: "object"}.
+//
+// The function does not mutate its input: new maps/slices are allocated
+// for every container so callers can safely reuse the original schema.
+func inlineRefsAndStripDrafts(obj any, defs map[string]any, depth int) any {
+	if obj == nil {
+		return nil
+	}
+	switch v := obj.(type) {
+	case map[string]any:
+		// $ref resolution: replace with the deep-cloned target.
+		if ref, ok := v["$ref"].(string); ok {
+			if depth >= maxRefInlineDepth {
+				// Cap reached: fall back to a generic type rather than
+				// infinite-recurse or panic.
+				return map[string]any{"type": "object"}
+			}
+			if target := resolveDefRef(ref, defs); target != nil {
+				return inlineRefsAndStripDrafts(target, defs, depth+1)
+			}
+			// Dangling ref (not in $defs): fall through to generic type.
+			return map[string]any{"type": "object"}
+		}
+		// Recurse into every key except the blocklisted ones.
+		result := make(map[string]any, len(v))
+		for k, val := range v {
+			if k == "$defs" || k == "if" || k == "then" || k == "else" {
+				continue
+			}
+			result[k] = inlineRefsAndStripDrafts(val, defs, depth)
+		}
+		return result
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = inlineRefsAndStripDrafts(item, defs, depth)
+		}
+		return out
+	default:
+		return obj
+	}
+}
+
+// resolveDefRef returns the target map for a "#/$defs/X" reference, or nil
+// if the ref does not point into the provided $defs table. Only the local
+// "#/$defs/" JSON Pointer form is supported: external URIs and deep
+// pointers are returned as nil (and inlineRefsAndStripDrafts will fall
+// back to a generic type).
+func resolveDefRef(ref string, defs map[string]any) any {
+	const prefix = "#/$defs/"
+	if defs == nil || !strings.HasPrefix(ref, prefix) {
+		return nil
+	}
+	key := ref[len(prefix):]
+	return defs[key]
 }
 
 func sanitizeImpl(obj any) any {

--- a/internal/gemini/schema_test.go
+++ b/internal/gemini/schema_test.go
@@ -486,6 +486,182 @@ func TestSanitizeSchema_NoInputMutation(t *testing.T) {
 	}
 }
 
+// TestSanitizeSchema_InlinesDefsRef verifies that $ref pointing into $defs
+// is replaced with the target schema and $defs is stripped from the output.
+// Regression: Gemini rejects schemas containing #/$defs/X references with
+// "the referenced name does not match display_name".
+func TestSanitizeSchema_InlinesDefsRef(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"agent": map[string]any{
+				"$ref": "#/$defs/AgentConfig",
+			},
+		},
+		"required": []any{"agent"},
+		"$defs": map[string]any{
+			"AgentConfig": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+				"required": []any{"name"},
+			},
+		},
+	}
+	result := SanitizeSchema(schema)
+
+	if _, ok := result["$defs"]; ok {
+		t.Error("$defs should be stripped from output")
+	}
+	props, ok := result["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties missing or wrong type: %v", result["properties"])
+	}
+	agent, ok := props["agent"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties.agent missing or wrong type: %v", props["agent"])
+	}
+	if _, hasRef := agent["$ref"]; hasRef {
+		t.Error("$ref should be resolved/removed")
+	}
+	if agent["type"] != "object" {
+		t.Errorf("inlined agent.type = %v, want 'object'", agent["type"])
+	}
+	agentProps, ok := agent["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("inlined agent.properties missing: %v", agent["properties"])
+	}
+	if _, ok := agentProps["name"]; !ok {
+		t.Error("inlined agent.properties.name missing")
+	}
+}
+
+// TestSanitizeSchema_StripsAllOfIfThenElse verifies that if/then/else
+// conditionals inside allOf are stripped. Regression: Gemini errors with
+// 'Unknown name "if" at function_declarations[N].parameters.all_of[0]'.
+func TestSanitizeSchema_StripsAllOfIfThenElse(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"mode": map[string]any{"type": "string"},
+		},
+		"allOf": []any{
+			map[string]any{
+				"if":   map[string]any{"properties": map[string]any{"mode": map[string]any{"const": "advanced"}}},
+				"then": map[string]any{"required": []any{"extra_field"}},
+				"else": map[string]any{},
+			},
+		},
+	}
+	result := SanitizeSchema(schema)
+
+	allOf, ok := result["allOf"].([]any)
+	if !ok {
+		t.Fatalf("allOf missing or wrong type: %v", result["allOf"])
+	}
+	if len(allOf) != 1 {
+		t.Fatalf("allOf length = %d, want 1", len(allOf))
+	}
+	item, ok := allOf[0].(map[string]any)
+	if !ok {
+		t.Fatalf("allOf[0] not a map: %v", allOf[0])
+	}
+	for _, k := range []string{"if", "then", "else"} {
+		if _, found := item[k]; found {
+			t.Errorf("allOf[0] still contains %q after sanitization", k)
+		}
+	}
+}
+
+// TestSanitizeSchema_NestedDefsRef verifies that a $ref nested deep inside
+// items/properties still gets resolved.
+func TestSanitizeSchema_NestedDefsRef(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"items": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"$ref": "#/$defs/Item"},
+			},
+		},
+		"$defs": map[string]any{
+			"Item": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"id": map[string]any{"type": "integer"},
+				},
+			},
+		},
+	}
+	result := SanitizeSchema(schema)
+
+	props := result["properties"].(map[string]any)
+	itemsField := props["items"].(map[string]any)
+	itemSchema, ok := itemsField["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested items missing: %v", itemsField["items"])
+	}
+	if itemSchema["type"] != "object" {
+		t.Errorf("nested ref not inlined: %v", itemSchema)
+	}
+	if _, hasRef := itemSchema["$ref"]; hasRef {
+		t.Error("nested $ref not resolved")
+	}
+}
+
+// TestSanitizeSchema_DanglingRef verifies that an unresolvable $ref falls
+// back to a generic object type rather than leaking the $ref.
+func TestSanitizeSchema_DanglingRef(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"thing": map[string]any{"$ref": "#/$defs/DoesNotExist"},
+		},
+		"$defs": map[string]any{
+			"OnlyOther": map[string]any{"type": "string"},
+		},
+	}
+	result := SanitizeSchema(schema)
+
+	props := result["properties"].(map[string]any)
+	thing := props["thing"].(map[string]any)
+	if _, hasRef := thing["$ref"]; hasRef {
+		t.Error("dangling $ref should not be preserved")
+	}
+	if thing["type"] != "object" {
+		t.Errorf("dangling $ref fallback = %v, want type:object", thing)
+	}
+}
+
+// TestSanitizeSchema_CyclicRefsDepthCap verifies that self-referencing
+// schemas don't infinite-loop the inliner.
+func TestSanitizeSchema_CyclicRefsDepthCap(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"node": map[string]any{"$ref": "#/$defs/Node"},
+		},
+		"$defs": map[string]any{
+			"Node": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"child": map[string]any{"$ref": "#/$defs/Node"},
+				},
+			},
+		},
+	}
+	// Should complete quickly without stack overflow.
+	result := SanitizeSchema(schema)
+	if result == nil {
+		t.Fatal("got nil, want a schema")
+	}
+	// The top-level $defs should be stripped.
+	if _, ok := result["$defs"]; ok {
+		t.Error("$defs should be stripped")
+	}
+}
+
 func TestSanitizeSchema_NoInputMutation_AnySlice(t *testing.T) {
 	// Test the []any path (from JSON unmarshal) also does not mutate input.
 	input := map[string]any{

--- a/internal/gemini/schema_test.go
+++ b/internal/gemini/schema_test.go
@@ -634,6 +634,51 @@ func TestSanitizeSchema_DanglingRef(t *testing.T) {
 	}
 }
 
+// TestSanitizeSchema_RefWithoutDefs verifies that a $ref in a schema with
+// no $defs table at all falls back to the generic object type. Also covers
+// non-local refs (external URIs) which are not resolvable.
+func TestSanitizeSchema_RefWithoutDefs(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema map[string]any
+	}{
+		{
+			name: "no $defs at all",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"x": map[string]any{"$ref": "#/$defs/Missing"},
+				},
+			},
+		},
+		{
+			name: "external URI ref",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"x": map[string]any{"$ref": "https://example.com/schema.json#/X"},
+				},
+				"$defs": map[string]any{
+					"Y": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SanitizeSchema(tc.schema)
+			props := result["properties"].(map[string]any)
+			x := props["x"].(map[string]any)
+			if _, hasRef := x["$ref"]; hasRef {
+				t.Error("$ref should not be preserved")
+			}
+			if x["type"] != "object" {
+				t.Errorf("fallback = %v, want type:object", x)
+			}
+		})
+	}
+}
+
 // TestSanitizeSchema_CyclicRefsDepthCap verifies that self-referencing
 // schemas don't infinite-loop the inliner.
 func TestSanitizeSchema_CyclicRefsDepthCap(t *testing.T) {


### PR DESCRIPTION
## Summary
- Gemini's `function_declarations` validator rejects JSON Schema `$ref`/`$defs` (`"referenced name does not match display_name"`) and conditional keywords `if`/`then`/`else` (`'Unknown name "if" at ...all_of[0]'`), even nested inside `allOf`. MCP tool schemas and hand-written JSON schemas commonly contain both.
- New `inlineRefsAndStripDrafts` preprocessing pass resolves local `#/$defs/X` refs via deep copy and strips `$defs`/`if`/`then`/`else` anywhere they appear, non-mutating. Runs before the existing compatibility sanitizer.
- `maxRefInlineDepth=10` caps cyclic refs; dangling or capped refs fall back to `{type: "object"}` rather than leaking `$ref` or infinite-looping.

## Test plan
- [x] `go test ./internal/gemini/` passes
- [x] Pre-commit coverage gate (90% diff coverage) passes
- [x] 5 new regression tests: simple ref, nested ref (inside `items`), dangling ref fallback, cyclic ref depth cap, `allOf` `if/then/else` stripping