### PR TITLE
feat(retry): refactor retry delay logic and add Azure body parsing

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand/v2"
+	"regexp"
 	"strconv"
 	"time"
 )
@@ -47,33 +48,71 @@ func sleep(ctx context.Context, d time.Duration) error {
 	}
 }
 
-// retryAfterDuration extracts a Retry-After delay from an APIError's response headers.
-// Supports retry-after-ms (OpenAI) and retry-after (seconds). Returns 0 if not present
-// or exceeds 60s (to avoid absurdly long waits).
+// retryAfterDuration extracts a Retry-After delay from an APIError.
+// Checks (in order): retry-after-ms header (OpenAI), retry-after header (standard),
+// then falls back to parsing "wait N seconds" from the error message body (Azure).
+//
+// Following the Vercel AI SDK pattern: the server-requested delay is only used
+// when it is "reasonable" - under 60s or less than the caller's exponential
+// backoff. Long delays (≥60s) are ignored so the caller can fail fast and let
+// the exponential schedule take over. The caller is responsible for applying
+// this threshold via retryDelay().
 func retryAfterDuration(err error) time.Duration {
 	var apiErr *APIError
-	if !errors.As(err, &apiErr) || apiErr.ResponseHeaders == nil {
+	if !errors.As(err, &apiErr) {
 		return 0
 	}
 	// OpenAI uses retry-after-ms (milliseconds).
-	if ms, ok := apiErr.ResponseHeaders["retry-after-ms"]; ok {
-		if v, parseErr := strconv.ParseInt(ms, 10, 64); parseErr == nil && v > 0 {
-			if v > 60000 {
-				v = 60000
+	if apiErr.ResponseHeaders != nil {
+		if ms, ok := apiErr.ResponseHeaders["retry-after-ms"]; ok {
+			if v, parseErr := strconv.ParseInt(ms, 10, 64); parseErr == nil && v > 0 {
+				return time.Duration(v) * time.Millisecond
 			}
-			return time.Duration(v) * time.Millisecond
+		}
+		// Standard Retry-After (seconds).
+		if secs, ok := apiErr.ResponseHeaders["retry-after"]; ok {
+			if v, parseErr := strconv.ParseInt(secs, 10, 64); parseErr == nil && v > 0 {
+				return time.Duration(v) * time.Second
+			}
 		}
 	}
-	// Standard Retry-After (seconds).
-	if secs, ok := apiErr.ResponseHeaders["retry-after"]; ok {
-		if v, parseErr := strconv.ParseInt(secs, 10, 64); parseErr == nil && v > 0 {
-			if v > 60 {
-				v = 60
-			}
-			return time.Duration(v) * time.Second
-		}
+	// Fallback: parse "wait N seconds" or "retry after N seconds" from error body.
+	// Azure AI Services embeds the retry hint in the error message rather than headers.
+	if d := parseRetryFromBody(apiErr.Message); d > 0 {
+		return d
 	}
 	return 0
+}
+
+// retryDelay returns the delay to use before the next retry attempt.
+// Follows the Vercel AI SDK pattern: the server-requested delay (from headers
+// or error body) is used only when it is under 60s or less than the calculated
+// exponential backoff. Otherwise the exponential backoff is used. This ensures
+// fast failure for long rate-limit windows instead of blocking for minutes.
+func retryDelay(err error, attempt int) time.Duration {
+	serverDelay := retryAfterDuration(err)
+	expDelay := backoffDuration(attempt)
+	if serverDelay > 0 && (serverDelay < 60*time.Second || serverDelay < expDelay) {
+		return serverDelay
+	}
+	return expDelay
+}
+
+// waitSecondsRe matches patterns like "wait 60 seconds", "retry after 30 seconds",
+// "Please wait 60 seconds before retrying".
+var waitSecondsRe = regexp.MustCompile(`(?i)(?:wait|retry after)\s+(\d+)\s+seconds?`)
+
+// parseRetryFromBody extracts a retry delay from an error message body.
+func parseRetryFromBody(msg string) time.Duration {
+	m := waitSecondsRe.FindStringSubmatch(msg)
+	if m == nil {
+		return 0
+	}
+	v, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil || v <= 0 {
+		return 0
+	}
+	return time.Duration(v) * time.Second
 }
 
 // withRetry executes fn up to maxRetries+1 times, retrying on retryable errors.
@@ -83,10 +122,7 @@ func withRetry[T any](ctx context.Context, maxRetries int, fn func() (T, error))
 	result, err := fn()
 	attempt := 0
 	for ; err != nil && retryable(err) && attempt < maxRetries; attempt++ {
-		delay := retryAfterDuration(err)
-		if delay == 0 {
-			delay = backoffDuration(attempt)
-		}
+		delay := retryDelay(err, attempt)
 		if sleepErr := sleep(ctx, delay); sleepErr != nil {
 			var zero T
 			return zero, sleepErr

--- a/retry_test.go
+++ b/retry_test.go
@@ -185,13 +185,13 @@ func TestRetryAfterDuration(t *testing.T) {
 			want: 500 * time.Millisecond,
 		},
 		{
-			name: "retry-after-ms too large (>60s)",
+			name: "retry-after-ms large value returned as-is",
 			err: &APIError{
 				StatusCode:      http.StatusTooManyRequests,
 				IsRetryable:     true,
-				ResponseHeaders: map[string]string{"retry-after-ms": "120000"},
+				ResponseHeaders: map[string]string{"retry-after-ms": "200000"},
 			},
-			want: 60000 * time.Millisecond,
+			want: 200000 * time.Millisecond,
 		},
 		{
 			name: "retry-after-ms zero",
@@ -230,13 +230,13 @@ func TestRetryAfterDuration(t *testing.T) {
 			want: 5 * time.Second,
 		},
 		{
-			name: "retry-after seconds too large (>60)",
+			name: "retry-after seconds large value returned as-is",
 			err: &APIError{
 				StatusCode:      http.StatusTooManyRequests,
 				IsRetryable:     true,
-				ResponseHeaders: map[string]string{"retry-after": "120"},
+				ResponseHeaders: map[string]string{"retry-after": "200"},
 			},
-			want: 60 * time.Second,
+			want: 200 * time.Second,
 		},
 		{
 			name: "retry-after seconds zero",
@@ -274,12 +274,124 @@ func TestRetryAfterDuration(t *testing.T) {
 			},
 			want: 3 * time.Second,
 		},
+		{
+			name: "body fallback: Please wait 60 seconds",
+			err: &APIError{
+				StatusCode:  http.StatusTooManyRequests,
+				IsRetryable: true,
+				Message:     "Rate limit of 250000 per 60s exceeded. Please wait 60 seconds before retrying.",
+			},
+			want: 60 * time.Second,
+		},
+		{
+			name: "body fallback: retry after 30 seconds",
+			err: &APIError{
+				StatusCode:  http.StatusTooManyRequests,
+				IsRetryable: true,
+				Message:     "Too many requests, retry after 30 seconds.",
+			},
+			want: 30 * time.Second,
+		},
+		{
+			name: "body fallback: Wait 300 seconds returned as-is",
+			err: &APIError{
+				StatusCode:  http.StatusTooManyRequests,
+				IsRetryable: true,
+				Message:     "Please wait 300 seconds before retrying.",
+			},
+			want: 300 * time.Second,
+		},
+		{
+			name: "body fallback: no match",
+			err: &APIError{
+				StatusCode:  http.StatusTooManyRequests,
+				IsRetryable: true,
+				Message:     "Rate limit exceeded.",
+			},
+			want: 0,
+		},
+		{
+			name: "headers take priority over body",
+			err: &APIError{
+				StatusCode:      http.StatusTooManyRequests,
+				IsRetryable:     true,
+				ResponseHeaders: map[string]string{"retry-after": "5"},
+				Message:         "Please wait 60 seconds before retrying.",
+			},
+			want: 5 * time.Second,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := retryAfterDuration(tt.err)
 			if got != tt.want {
 				t.Errorf("retryAfterDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		attempt int
+		useExp  bool // true = expect exponential backoff, false = expect server delay
+	}{
+		{
+			name:    "no server hint - use exponential",
+			err:     &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true},
+			attempt: 0,
+			useExp:  true,
+		},
+		{
+			name: "server says 5s (< 60s) - use server",
+			err: &APIError{
+				StatusCode:      http.StatusTooManyRequests,
+				IsRetryable:     true,
+				ResponseHeaders: map[string]string{"retry-after": "5"},
+			},
+			attempt: 0,
+			useExp:  false,
+		},
+		{
+			name: "server says 60s (>= 60s) - ignore, use exponential",
+			err: &APIError{
+				StatusCode:  http.StatusTooManyRequests,
+				IsRetryable: true,
+				Message:     "Please wait 60 seconds before retrying.",
+			},
+			attempt: 0,
+			useExp:  true,
+		},
+		{
+			name: "server says 120s (>= 60s) - ignore, use exponential",
+			err: &APIError{
+				StatusCode:      http.StatusTooManyRequests,
+				IsRetryable:     true,
+				ResponseHeaders: map[string]string{"retry-after": "120"},
+			},
+			attempt: 0,
+			useExp:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := retryDelay(tt.err, tt.attempt)
+			serverDelay := retryAfterDuration(tt.err)
+			if tt.useExp {
+				// Should be in exponential range (attempt 0: 1s-3s with jitter).
+				if got < 1*time.Second || got > 3*time.Second {
+					t.Errorf("retryDelay() = %v, want exponential range 1s-3s", got)
+				}
+				// Should NOT be the server delay.
+				if serverDelay >= 60*time.Second && got == serverDelay {
+					t.Errorf("retryDelay() = %v, should not use server delay %v", got, serverDelay)
+				}
+			} else {
+				if got != serverDelay {
+					t.Errorf("retryDelay() = %v, want server delay %v", got, serverDelay)
+				}
 			}
 		})
 	}

--- a/retry_test.go
+++ b/retry_test.go
@@ -331,6 +331,27 @@ func TestRetryAfterDuration(t *testing.T) {
 	}
 }
 
+func TestParseRetryFromBody(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want time.Duration
+	}{
+		{"wait N seconds", "Please wait 30 seconds before retrying.", 30 * time.Second},
+		{"retry after N seconds", "retry after 10 seconds", 10 * time.Second},
+		{"zero seconds", "Please wait 0 seconds before retrying.", 0},
+		{"no match", "Rate limit exceeded.", 0},
+		{"empty string", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseRetryFromBody(tt.msg); got != tt.want {
+				t.Errorf("parseRetryFromBody(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRetryDelay(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Separate `retryAfterDuration` (pure extraction) from `retryDelay` (60s threshold logic) for cleaner separation of concerns
- Add `parseRetryFromBody` fallback for Azure AI Services which embed retry hints in error message body rather than headers
- Simplify `withRetry` to use the new `retryDelay` function

## Test plan
- [x] All existing retry tests pass
- [x] New `TestRetryDelay` suite covers exponential vs server delay selection
- [x] Body fallback tests cover Azure-style "wait N seconds" and "retry after N seconds" patterns
- [x] Headers-over-body priority test
- [x] Coverage >= 90%