### PR TITLE
feat(retry): add network error retrying for transient failures

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -29,23 +28,22 @@ func retryable(err error) bool {
 	return isNetworkError(err)
 }
 
-// isNetworkError returns true for transient network errors that should be retried:
-// connection reset, connection refused, DNS failures, TLS handshake timeouts, etc.
+// isNetworkError reports whether err is a transient network error (connection
+// reset, refused, DNS, TLS handshake timeout). Context errors are excluded
+// because they represent caller-initiated cancellation.
 func isNetworkError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// net.Error covers timeouts and temporary network errors.
+	// Context errors are intentional cancellations, not network errors.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return false
+	}
+	// net.Error covers timeouts, DNS failures, connection resets, refused
+	// connections, and broken pipes (net.OpError and syscall.Errno both
+	// implement net.Error).
 	var netErr net.Error
 	if errors.As(err, &netErr) {
-		return true
-	}
-	// syscall errors: connection reset, connection refused, broken pipe.
-	var sysErr *net.OpError
-	if errors.As(err, &sysErr) {
-		return true
-	}
-	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EPIPE) {
 		return true
 	}
 	// Fallback: string match for common network error messages that may be

--- a/retry.go
+++ b/retry.go
@@ -6,12 +6,18 @@ import (
 	"fmt"
 	"math"
 	"math/rand/v2"
+	"net"
 	"regexp"
 	"strconv"
+	"strings"
+	"syscall"
 	"time"
 )
 
 // retryable checks if an error should be retried.
+// API errors use the IsRetryable flag. Network-level errors (connection reset,
+// timeout, DNS failure) are always retryable since they indicate transient
+// infrastructure issues, not permanent request problems.
 func retryable(err error) bool {
 	if err == nil {
 		return false
@@ -20,7 +26,36 @@ func retryable(err error) bool {
 	if errors.As(err, &apiErr) {
 		return apiErr.IsRetryable
 	}
-	return false
+	return isNetworkError(err)
+}
+
+// isNetworkError returns true for transient network errors that should be retried:
+// connection reset, connection refused, DNS failures, TLS handshake timeouts, etc.
+func isNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// net.Error covers timeouts and temporary network errors.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	// syscall errors: connection reset, connection refused, broken pipe.
+	var sysErr *net.OpError
+	if errors.As(err, &sysErr) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	// Fallback: string match for common network error messages that may be
+	// wrapped in ways that don't implement net.Error.
+	msg := err.Error()
+	return strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "TLS handshake timeout") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "i/o timeout")
 }
 
 // backoffDuration returns the delay for attempt n (0-indexed) with jitter.

--- a/retry.go
+++ b/retry.go
@@ -32,9 +32,6 @@ func retryable(err error) bool {
 // reset, refused, DNS, TLS handshake timeout). Context errors are excluded
 // because they represent caller-initiated cancellation.
 func isNetworkError(err error) bool {
-	if err == nil {
-		return false
-	}
 	// Context errors are intentional cancellations, not network errors.
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return false

--- a/retry_test.go
+++ b/retry_test.go
@@ -34,6 +34,9 @@ func TestRetryable(t *testing.T) {
 		{"TLS timeout string", fmt.Errorf("net/http: TLS handshake timeout"), true},
 		{"i/o timeout string", fmt.Errorf("i/o timeout"), true},
 		{"no such host string", fmt.Errorf("dial tcp: lookup api.example.com: no such host"), true},
+		{"context deadline", context.DeadlineExceeded, false},
+		{"context canceled", context.Canceled, false},
+		{"wrapped context deadline", fmt.Errorf("request: %w", context.DeadlineExceeded), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -22,10 +24,16 @@ func TestRetryable(t *testing.T) {
 		{"non-API random", fmt.Errorf("random"), false},
 		{"retryable API", &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true}, true},
 		{"not retryable API", &APIError{StatusCode: http.StatusBadRequest, IsRetryable: false}, false},
-		{"connection reset", fmt.Errorf("read tcp: connection reset by peer"), true},
-		{"connection refused", fmt.Errorf("dial tcp: connection refused"), true},
-		{"TLS timeout", fmt.Errorf("net/http: TLS handshake timeout"), true},
-		{"i/o timeout", fmt.Errorf("i/o timeout"), true},
+		{"net.OpError", &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connect refused")}, true},
+		{"net timeout", &net.DNSError{Err: "timeout", Name: "api.example.com", IsTimeout: true}, true},
+		{"syscall ECONNRESET", fmt.Errorf("read: %w", syscall.ECONNRESET), true},
+		{"syscall ECONNREFUSED", fmt.Errorf("dial: %w", syscall.ECONNREFUSED), true},
+		{"syscall EPIPE", fmt.Errorf("write: %w", syscall.EPIPE), true},
+		{"connection reset string", fmt.Errorf("read tcp: connection reset by peer"), true},
+		{"connection refused string", fmt.Errorf("dial tcp: connection refused"), true},
+		{"TLS timeout string", fmt.Errorf("net/http: TLS handshake timeout"), true},
+		{"i/o timeout string", fmt.Errorf("i/o timeout"), true},
+		{"no such host string", fmt.Errorf("dial tcp: lookup api.example.com: no such host"), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -19,9 +19,13 @@ func TestRetryable(t *testing.T) {
 		want bool
 	}{
 		{"nil", nil, false},
-		{"non-API", fmt.Errorf("random"), false},
-		{"retryable", &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true}, true},
-		{"not retryable", &APIError{StatusCode: http.StatusBadRequest, IsRetryable: false}, false},
+		{"non-API random", fmt.Errorf("random"), false},
+		{"retryable API", &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true}, true},
+		{"not retryable API", &APIError{StatusCode: http.StatusBadRequest, IsRetryable: false}, false},
+		{"connection reset", fmt.Errorf("read tcp: connection reset by peer"), true},
+		{"connection refused", fmt.Errorf("dial tcp: connection refused"), true},
+		{"TLS timeout", fmt.Errorf("net/http: TLS handshake timeout"), true},
+		{"i/o timeout", fmt.Errorf("i/o timeout"), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Retry on transient network errors (connection reset, refused, DNS failures, TLS handshake timeouts) in addition to API errors with `IsRetryable` flag
- New `isNetworkError` helper detects failures via `net.Error`, `net.OpError`, syscall errors (`ECONNRESET`, `ECONNREFUSED`, `EPIPE`), and string fallbacks for wrapped errors
- Tests cover connection reset, connection refused, TLS timeout, and i/o timeout scenarios

## Test plan

- [x] All existing retry tests pass
- [x] New test cases for network error strings pass
- [x] Coverage threshold met (pre-commit hook verified ≥90%)