### PR TITLE
feat(retry): support unlimited retries with WithMaxRetries(-1)

### DIFF
--- a/generate_test.go
+++ b/generate_test.go
@@ -2247,13 +2247,38 @@ func TestWithMaxRetries_ClampNegative(t *testing.T) {
 		},
 	}
 
-	_, err := GenerateText(t.Context(), model, WithPrompt("hi"), WithMaxRetries(-1))
-	// WithMaxRetries(-1) clamps to 0 - no retries, just one attempt, error returned.
+	// Values below -1 are clamped to 0 (no retries).
+	_, err := GenerateText(t.Context(), model, WithPrompt("hi"), WithMaxRetries(-2))
 	if err == nil {
 		t.Fatal("expected error")
 	}
 	if callCount != 1 {
 		t.Errorf("model called %d times, want 1 (MaxRetries clamped to 0)", callCount)
+	}
+}
+
+func TestWithMaxRetries_UnlimitedMinusOne(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount <= 3 {
+				return nil, &APIError{Message: "service error", StatusCode: 503, IsRetryable: true}
+			}
+			return &provider.GenerateResult{Text: "ok"}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model, WithPrompt("hi"), WithMaxRetries(-1))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("got text %q, want %q", result.Text, "ok")
+	}
+	if callCount != 4 {
+		t.Errorf("model called %d times, want 4 (3 retries + 1 success)", callCount)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -228,13 +228,18 @@ func WithMaxSteps(n int) Option {
 }
 
 // WithMaxRetries sets the retry count for transient errors.
-// Values below 0 are clamped to 0 (no retries).
+// Pass -1 for unlimited retries (useful when the application manages its own
+// timeout/cancellation via context). Values below -1 are clamped to 0.
 func WithMaxRetries(n int) Option {
 	return func(o *options) {
-		if n < 0 {
-			n = 0
+		switch {
+		case n == -1:
+			o.MaxRetries = 1<<31 - 1 // unlimited
+		case n < 0:
+			o.MaxRetries = 0
+		default:
+			o.MaxRetries = n
 		}
-		o.MaxRetries = n
 	}
 }
 


### PR DESCRIPTION
## Summary

- `WithMaxRetries(-1)` now means unlimited retries, for apps that manage timeouts via context cancellation
- Values below -1 are clamped to 0 (no retries)
- Existing clamp test updated, new test verifies unlimited retry behavior

## Test plan

- [x] `TestWithMaxRetries_ClampNegative` passes (uses -2)
- [x] `TestWithMaxRetries_UnlimitedMinusOne` passes (3 failures + 1 success)
- [x] Pre-commit coverage checks pass (≥90%)