### PR TITLE
fix(bedrock): race condition in cross-region fallback for parallel requests

### DIFF
--- a/provider/bedrock/bedrock.go
+++ b/provider/bedrock/bedrock.go
@@ -579,9 +579,23 @@ func (m *chatModel) tryBareUSFallback(err error) bool {
 // routes the request through a US endpoint. Returns true (and mutates m) if
 // the fallback should be attempted. Only runs once per model instance.
 func (m *chatModel) tryCrossRegionFallback(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// If fallback was already applied by a parallel request, return true
+	// so the caller retries with the updated model ID. The caller's HTTP
+	// request used the pre-fallback ID, so it needs a retry.
+	m.mu.RLock()
+	alreadyDone := m.fallbackDone
+	m.mu.RUnlock()
+	if alreadyDone {
+		return true
+	}
+
 	currentID := m.ModelID()
-	if err == nil || inferRegionFromModel(currentID) != "" {
-		return false // already has geo prefix, or no error
+	if inferRegionFromModel(currentID) != "" {
+		return false // already has geo prefix at construction time
 	}
 	var apiErr *goai.APIError
 	if !errors.As(err, &apiErr) {
@@ -593,7 +607,8 @@ func (m *chatModel) tryCrossRegionFallback(err error) bool {
 	if !isInvalidModel {
 		return false
 	}
-	// Only attempt fallback once.
+	// Only attempt mutation once. sync.Once.Do blocks concurrent callers
+	// until the function completes, ensuring all see the updated state.
 	m.fallbackAttempted.Do(func() {
 		m.mu.Lock()
 		defer m.mu.Unlock()

--- a/provider/bedrock/bedrock_test.go
+++ b/provider/bedrock/bedrock_test.go
@@ -2022,6 +2022,38 @@ func TestTryCrossRegionFallback_OnDemandThroughput(t *testing.T) {
 	}
 }
 
+func TestTryCrossRegionFallback_ParallelRequests(t *testing.T) {
+	// Regression: parallel requests should all get true after fallback is applied.
+	// Before fix, request B would see the mutated m.id ("us.m"), check
+	// inferRegionFromModel("us.m") != "" → return false, skipping the retry.
+	m := &chatModel{id: "anthropic.claude-sonnet-4-6", originalID: "anthropic.claude-sonnet-4-6", opts: options{region: "us-east-1"}}
+	err := &goai.APIError{Message: "on-demand throughput isn\u2019t supported"}
+
+	// First call triggers the fallback.
+	if !m.tryCrossRegionFallback(err) {
+		t.Fatal("first call should return true")
+	}
+	if m.ModelID() != "us.anthropic.claude-sonnet-4-6" {
+		t.Fatalf("id = %q after first fallback", m.ModelID())
+	}
+
+	// Second call (parallel request with same error) should ALSO return true
+	// so the caller retries with the updated model ID.
+	if !m.tryCrossRegionFallback(err) {
+		t.Error("second call should return true (parallel request needs retry with updated ID)")
+	}
+
+	// Third call with same error - still true.
+	if !m.tryCrossRegionFallback(err) {
+		t.Error("third call should return true")
+	}
+
+	// Call with nil error - should return false.
+	if m.tryCrossRegionFallback(nil) {
+		t.Error("nil error should return false even after fallback")
+	}
+}
+
 // --- #9: applyBedrockOptions ---
 
 func TestApplyBedrockOptions_NonAnthropicReasoningNoType(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix race condition where parallel requests could miss cross-region fallback retry
- When request A triggers fallback and mutates `m.id` to `"us.model"`, request B (same error) would see the prefixed ID via `inferRegionFromModel`, return `false`, and skip the retry despite using the old model ID
- Add early `fallbackDone` check under `RLock` so concurrent callers still get `true` and retry with the updated ID

## Test plan
- [x] New `TestTryCrossRegionFallback_ParallelRequests` covers the scenario
- [x] All existing fallback tests pass
- [x] Coverage meets 90% threshold