### PR TITLE
refactor(openaicompat): extract shared factories for chat + embedding

### DIFF
--- a/internal/openaicompat/factory.go
+++ b/internal/openaicompat/factory.go
@@ -1,0 +1,334 @@
+// Factory constructors for OpenAI-compatible chat and embedding models.
+//
+// Provider packages use NewChatModel / NewEmbeddingModel to obtain ready-made
+// provider.LanguageModel / provider.EmbeddingModel implementations that handle
+// the common HTTP dispatch, auth, error parsing, and response decoding. The
+// provider package only needs to build the ChatModelConfig / EmbeddingModelConfig
+// (including its public With* options) and delegate to the factory.
+
+package openaicompat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/internal/httpc"
+	"github.com/zendev-sh/goai/provider"
+)
+
+// ChatModelConfig configures a chat language model backed by the OpenAI
+// Chat Completions wire format.
+type ChatModelConfig struct {
+	// ProviderID identifies the provider in error messages and stderr warnings
+	// (for example "deepinfra", "cloudflare").
+	ProviderID string
+
+	// ModelID is the model identifier passed to the upstream API.
+	ModelID string
+
+	// BaseURL is the root URL, without the /chat/completions suffix
+	// (for example "https://api.deepinfra.com/v1/openai").
+	BaseURL string
+
+	// TokenSource resolves the bearer token on each request. When nil and
+	// TokenRequired is false, the Authorization header is omitted.
+	TokenSource provider.TokenSource
+
+	// TokenRequired controls whether a missing TokenSource causes an error at
+	// request time. Providers like compat and ollama set this to false.
+	TokenRequired bool
+
+	// BaseURLRequired causes DoGenerate / DoStream to error out when BaseURL is
+	// empty. Used by providers that refuse to build a default (compat,
+	// cloudflare, fptcloud before region resolution).
+	BaseURLRequired bool
+
+	// Headers are sent on every request. Callers are expected to have merged
+	// any user-provided and provider-fixed headers before setting this field.
+	Headers map[string]string
+
+	// HTTPClient overrides the default HTTP client. Nil uses http.DefaultClient.
+	HTTPClient *http.Client
+
+	// Capabilities is returned from the model's Capabilities() method.
+	Capabilities provider.ModelCapabilities
+
+	// ExtraBody merges provider-specific fields into the request body
+	// (for example OpenRouter's "usage": {"include": true}).
+	ExtraBody map[string]any
+
+	// IncludeStreamOptions adds stream_options.include_usage on streaming requests.
+	// Most providers want this true.
+	IncludeStreamOptions bool
+
+	// WarnPromptCaching emits a one-line stderr warning when the caller sets
+	// GenerateParams.PromptCaching and the provider does not support it.
+	WarnPromptCaching bool
+}
+
+// NewChatModel returns a provider.LanguageModel backed by the shared
+// OpenAI-compatible codec. The returned model also implements provider.CapableModel.
+func NewChatModel(cfg ChatModelConfig) provider.LanguageModel {
+	return &chatModel{cfg: cfg}
+}
+
+// EmbeddingModelConfig configures an embedding model backed by the OpenAI
+// /embeddings wire format.
+type EmbeddingModelConfig struct {
+	// ProviderID identifies the provider in error messages.
+	ProviderID string
+
+	// ModelID is the model identifier passed to the upstream API.
+	ModelID string
+
+	// BaseURL is the root URL, without the /embeddings suffix.
+	BaseURL string
+
+	// TokenSource resolves the bearer token on each request.
+	TokenSource provider.TokenSource
+
+	// TokenRequired controls whether a missing TokenSource causes an error
+	// at request time.
+	TokenRequired bool
+
+	// BaseURLRequired causes DoEmbed to error out when BaseURL is empty.
+	BaseURLRequired bool
+
+	// Headers are sent on every request.
+	Headers map[string]string
+
+	// HTTPClient overrides the default HTTP client.
+	HTTPClient *http.Client
+
+	// MaxValuesPerCall is returned from the model's MaxValuesPerCall() method.
+	// Defaults to 2048 when zero.
+	MaxValuesPerCall int
+
+	// ProviderOptionsKeys is the list of provider option keys forwarded to the
+	// request body verbatim (for example "dimensions", "user").
+	// When nil, the default set {"dimensions", "user"} is used.
+	ProviderOptionsKeys []string
+
+	// EncodingFormat is sent as the encoding_format field. Defaults to "float"
+	// when empty. Set to "-" to omit the field entirely (some providers reject
+	// unknown fields).
+	EncodingFormat string
+}
+
+// NewEmbeddingModel returns a provider.EmbeddingModel backed by the shared
+// OpenAI-compatible codec.
+func NewEmbeddingModel(cfg EmbeddingModelConfig) provider.EmbeddingModel {
+	return &embeddingModel{cfg: cfg}
+}
+
+// --- Internal chat model ---
+
+type chatModel struct {
+	cfg ChatModelConfig
+}
+
+// Compile-time interface assertions for the internal types.
+var (
+	_ provider.LanguageModel  = (*chatModel)(nil)
+	_ provider.CapableModel   = (*chatModel)(nil)
+	_ provider.EmbeddingModel = (*embeddingModel)(nil)
+)
+
+func (m *chatModel) ModelID() string { return m.cfg.ModelID }
+
+func (m *chatModel) Capabilities() provider.ModelCapabilities {
+	return m.cfg.Capabilities
+}
+
+func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
+	m.warnPromptCaching(params)
+	if err := m.checkBaseURL(); err != nil {
+		return nil, err
+	}
+	body := BuildRequest(params, m.cfg.ModelID, false, RequestConfig{
+		ExtraBody: m.cfg.ExtraBody,
+	})
+
+	resp, err := m.doHTTP(ctx, m.cfg.BaseURL+"/chat/completions", body)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	return ParseResponse(respBody)
+}
+
+func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+	m.warnPromptCaching(params)
+	if err := m.checkBaseURL(); err != nil {
+		return nil, err
+	}
+	body := BuildRequest(params, m.cfg.ModelID, true, RequestConfig{
+		IncludeStreamOptions: m.cfg.IncludeStreamOptions,
+		ExtraBody:            m.cfg.ExtraBody,
+	})
+
+	resp, err := m.doHTTP(ctx, m.cfg.BaseURL+"/chat/completions", body)
+	if err != nil {
+		return nil, err
+	}
+	return NewSSEStream(ctx, resp.Body), nil
+}
+
+func (m *chatModel) warnPromptCaching(params provider.GenerateParams) {
+	if params.PromptCaching && m.cfg.WarnPromptCaching {
+		fmt.Fprintf(os.Stderr, "goai: %s: WithPromptCaching is not supported and will be ignored\n", m.cfg.ProviderID)
+	}
+}
+
+func (m *chatModel) checkBaseURL() error {
+	if m.cfg.BaseURLRequired && m.cfg.BaseURL == "" {
+		return fmt.Errorf("%s: base URL is required", m.cfg.ProviderID)
+	}
+	return nil
+}
+
+func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
+	token, err := resolveToken(ctx, m.cfg.TokenSource, m.cfg.TokenRequired)
+	if err != nil {
+		return nil, err
+	}
+	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
+		URL:        url,
+		Token:      token,
+		Body:       body,
+		Headers:    m.cfg.Headers,
+		HTTPClient: m.cfg.HTTPClient,
+		ProviderID: m.cfg.ProviderID,
+	}, goai.ParseHTTPErrorWithHeaders)
+}
+
+// --- Internal embedding model ---
+
+type embeddingModel struct {
+	cfg EmbeddingModelConfig
+}
+
+func (m *embeddingModel) ModelID() string { return m.cfg.ModelID }
+
+func (m *embeddingModel) MaxValuesPerCall() int {
+	if m.cfg.MaxValuesPerCall > 0 {
+		return m.cfg.MaxValuesPerCall
+	}
+	return 2048
+}
+
+func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params provider.EmbedParams) (*provider.EmbedResult, error) {
+	if m.cfg.BaseURLRequired && m.cfg.BaseURL == "" {
+		return nil, fmt.Errorf("%s: base URL is required", m.cfg.ProviderID)
+	}
+
+	body := map[string]any{
+		"model": m.cfg.ModelID,
+		"input": values,
+	}
+	if enc := m.cfg.EncodingFormat; enc != "-" {
+		if enc == "" {
+			enc = "float"
+		}
+		body["encoding_format"] = enc
+	}
+
+	keys := m.cfg.ProviderOptionsKeys
+	if keys == nil {
+		keys = []string{"dimensions", "user"}
+	}
+	if params.ProviderOptions != nil {
+		for _, k := range keys {
+			if v, ok := params.ProviderOptions[k]; ok {
+				body[k] = v
+			}
+		}
+	}
+
+	token, err := resolveToken(ctx, m.cfg.TokenSource, m.cfg.TokenRequired)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonBody := httpc.MustMarshalJSON(body)
+	req := httpc.MustNewRequest(ctx, "POST", m.cfg.BaseURL+"/embeddings", jsonBody)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for k, v := range m.cfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	client := m.cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, goai.ParseHTTPErrorWithHeaders(m.cfg.ProviderID, resp.StatusCode, respBody, resp.Header)
+	}
+
+	var result struct {
+		Model string `json:"model"`
+		Data  []struct {
+			Embedding []float64 `json:"embedding"`
+			Index     int       `json:"index"`
+		} `json:"data"`
+		Usage struct {
+			PromptTokens int `json:"prompt_tokens"`
+			TotalTokens  int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	embeddings := make([][]float64, len(result.Data))
+	for _, d := range result.Data {
+		if d.Index >= 0 && d.Index < len(embeddings) {
+			embeddings[d.Index] = d.Embedding
+		}
+	}
+	return &provider.EmbedResult{
+		Embeddings: embeddings,
+		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens, TotalTokens: result.Usage.TotalTokens},
+		Response:   provider.ResponseMetadata{Model: result.Model},
+	}, nil
+}
+
+// --- Helpers ---
+
+func resolveToken(ctx context.Context, ts provider.TokenSource, required bool) (string, error) {
+	if ts == nil {
+		if required {
+			return "", errors.New("goai: no API key or token source configured")
+		}
+		return "", nil
+	}
+	tok, err := ts.Token(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolving auth token: %w", err)
+	}
+	return tok, nil
+}

--- a/internal/openaicompat/factory_test.go
+++ b/internal/openaicompat/factory_test.go
@@ -1,0 +1,501 @@
+package openaicompat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okJSONResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
+func testParams() provider.GenerateParams {
+	return provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	}
+}
+
+// --- Chat factory ---
+
+func TestNewChatModel_DoGenerate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer key" {
+			t.Errorf("auth = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:    "test",
+		ModelID:       "m",
+		BaseURL:       server.URL,
+		TokenSource:   provider.StaticToken("key"),
+		TokenRequired: true,
+	})
+	if m.ModelID() != "m" {
+		t.Errorf("ModelID = %q", m.ModelID())
+	}
+	result, err := m.DoGenerate(t.Context(), testParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q", result.Text)
+	}
+}
+
+func TestNewChatModel_DoStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{},\"index\":0,\"finish_reason\":\"stop\"}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:           "test",
+		ModelID:              "m",
+		BaseURL:              server.URL,
+		TokenSource:          provider.StaticToken("key"),
+		TokenRequired:        true,
+		IncludeStreamOptions: true,
+	})
+	result, err := m.DoStream(t.Context(), testParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got string
+	for ch := range result.Stream {
+		if ch.Type == provider.ChunkText {
+			got += ch.Text
+		}
+	}
+	if got != "Hi" {
+		t.Errorf("stream text = %q", got)
+	}
+}
+
+func TestNewChatModel_Capabilities(t *testing.T) {
+	caps := provider.ModelCapabilities{Temperature: true, ToolCall: true, Reasoning: true}
+	m := NewChatModel(ChatModelConfig{ModelID: "m", Capabilities: caps, TokenSource: provider.StaticToken("k")})
+	got := provider.ModelCapabilitiesOf(m)
+	if !got.Reasoning || !got.Temperature || !got.ToolCall {
+		t.Errorf("caps = %+v", got)
+	}
+}
+
+func TestNewChatModel_TokenRequiredMissing(t *testing.T) {
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:    "test",
+		ModelID:       "m",
+		BaseURL:       "http://example.invalid",
+		TokenRequired: true,
+	})
+	_, err := m.DoGenerate(t.Context(), testParams())
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if !strings.Contains(err.Error(), "no API key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = m.DoStream(t.Context(), testParams())
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+}
+
+func TestNewChatModel_TokenOptionalMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:    "test",
+		ModelID:       "m",
+		BaseURL:       server.URL,
+		TokenRequired: false,
+	})
+	_, err := m.DoGenerate(t.Context(), testParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewChatModel_BaseURLRequired(t *testing.T) {
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:      "test",
+		ModelID:         "m",
+		BaseURLRequired: true,
+		TokenSource:     provider.StaticToken("k"),
+	})
+	_, err := m.DoGenerate(t.Context(), testParams())
+	if err == nil || !strings.Contains(err.Error(), "base URL") {
+		t.Fatalf("expected base URL error, got %v", err)
+	}
+
+	_, err = m.DoStream(t.Context(), testParams())
+	if err == nil || !strings.Contains(err.Error(), "base URL") {
+		t.Fatalf("expected base URL error, got %v", err)
+	}
+}
+
+func TestNewChatModel_ExtraBody(t *testing.T) {
+	var gotBody []byte
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotBody, _ = io.ReadAll(req.Body)
+		return okJSONResponse(), nil
+	})
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://example.invalid",
+		TokenSource: provider.StaticToken("k"),
+		HTTPClient:  &http.Client{Transport: tr},
+		ExtraBody:   map[string]any{"custom_field": "present"},
+	})
+	_, err := m.DoGenerate(t.Context(), testParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(gotBody), "custom_field") {
+		t.Errorf("request body missing extra field: %s", gotBody)
+	}
+}
+
+func TestNewChatModel_Headers(t *testing.T) {
+	var got string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Get("X-Test")
+		return okJSONResponse(), nil
+	})
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://example.invalid",
+		TokenSource: provider.StaticToken("k"),
+		Headers:     map[string]string{"X-Test": "header-value"},
+		HTTPClient:  &http.Client{Transport: tr},
+	})
+	_, err := m.DoGenerate(t.Context(), testParams())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "header-value" {
+		t.Errorf("X-Test = %q", got)
+	}
+}
+
+func TestNewChatModel_PromptCachingWarning(t *testing.T) {
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return okJSONResponse(), nil
+	})
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:        "test-prov",
+		ModelID:           "m",
+		BaseURL:           "http://example.invalid",
+		TokenSource:       provider.StaticToken("k"),
+		HTTPClient:        &http.Client{Transport: tr},
+		WarnPromptCaching: true,
+	})
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages:      []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		PromptCaching: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// DoStream warning branch
+	streamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer streamServer.Close()
+	ms := NewChatModel(ChatModelConfig{
+		ProviderID:        "test-prov",
+		ModelID:           "m",
+		BaseURL:           streamServer.URL,
+		TokenSource:       provider.StaticToken("k"),
+		WarnPromptCaching: true,
+	})
+	_, err = ms.DoStream(t.Context(), provider.GenerateParams{
+		Messages:      []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		PromptCaching: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type failingTokenSource struct{}
+
+func (failingTokenSource) Token(ctx context.Context) (string, error) {
+	return "", errors.New("token fetch failed")
+}
+
+func TestNewChatModel_TokenSourceError(t *testing.T) {
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://example.invalid",
+		TokenSource: failingTokenSource{},
+	})
+	_, err := m.DoGenerate(t.Context(), testParams())
+	if err == nil || !strings.Contains(err.Error(), "resolving auth token") {
+		t.Fatalf("expected token wrap, got %v", err)
+	}
+}
+
+// --- Embedding factory ---
+
+func TestNewEmbeddingModel_DoEmbed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"model":"m","data":[{"embedding":[0.1,0.2],"index":0}],"usage":{"prompt_tokens":2,"total_tokens":2}}`)
+	}))
+	defer server.Close()
+
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:    "test",
+		ModelID:       "m",
+		BaseURL:       server.URL,
+		TokenSource:   provider.StaticToken("k"),
+		TokenRequired: true,
+	})
+	if m.ModelID() != "m" {
+		t.Errorf("ModelID = %q", m.ModelID())
+	}
+	if m.MaxValuesPerCall() != 2048 {
+		t.Errorf("MaxValuesPerCall default = %d", m.MaxValuesPerCall())
+	}
+	result, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Embeddings) != 1 || result.Embeddings[0][0] != 0.1 {
+		t.Errorf("embeddings = %v", result.Embeddings)
+	}
+	if result.Usage.InputTokens != 2 {
+		t.Errorf("InputTokens = %d", result.Usage.InputTokens)
+	}
+}
+
+func TestNewEmbeddingModel_MaxValuesOverride(t *testing.T) {
+	m := NewEmbeddingModel(EmbeddingModelConfig{ModelID: "m", MaxValuesPerCall: 100})
+	if m.MaxValuesPerCall() != 100 {
+		t.Errorf("MaxValuesPerCall = %d", m.MaxValuesPerCall())
+	}
+}
+
+func TestNewEmbeddingModel_BaseURLRequired(t *testing.T) {
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:      "test",
+		ModelID:         "m",
+		BaseURLRequired: true,
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err == nil || !strings.Contains(err.Error(), "base URL") {
+		t.Fatalf("expected base URL error, got %v", err)
+	}
+}
+
+func TestNewEmbeddingModel_EncodingFormat(t *testing.T) {
+	// "-" means omit encoding_format
+	var gotBody []byte
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotBody, _ = io.ReadAll(req.Body)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"model":"m","data":[{"embedding":[0.1],"index":0}],"usage":{"prompt_tokens":1,"total_tokens":1}}`)),
+		}, nil
+	})
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:     "test",
+		ModelID:        "m",
+		BaseURL:        "http://example.invalid",
+		TokenSource:    provider.StaticToken("k"),
+		HTTPClient:     &http.Client{Transport: tr},
+		EncodingFormat: "-",
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(gotBody), "encoding_format") {
+		t.Errorf("should omit encoding_format: %s", gotBody)
+	}
+}
+
+func TestNewEmbeddingModel_ProviderOptionsKeys(t *testing.T) {
+	var gotBody []byte
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotBody, _ = io.ReadAll(req.Body)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"model":"m","data":[{"embedding":[0.1],"index":0}],"usage":{"prompt_tokens":1,"total_tokens":1}}`)),
+		}, nil
+	})
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:          "test",
+		ModelID:             "m",
+		BaseURL:             "http://example.invalid",
+		TokenSource:         provider.StaticToken("k"),
+		HTTPClient:          &http.Client{Transport: tr},
+		ProviderOptionsKeys: []string{"dimensions"},
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{
+		ProviderOptions: map[string]any{"dimensions": 512, "other": "ignored"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(gotBody), "dimensions") {
+		t.Errorf("dimensions missing: %s", gotBody)
+	}
+	if strings.Contains(string(gotBody), "other") {
+		t.Errorf("unknown key should not be forwarded: %s", gotBody)
+	}
+}
+
+func TestNewEmbeddingModel_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":"boom"}`)
+	}))
+	defer server.Close()
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     server.URL,
+		TokenSource: provider.StaticToken("k"),
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewEmbeddingModel_TokenSourceError(t *testing.T) {
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://example.invalid",
+		TokenSource: failingTokenSource{},
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err == nil || !strings.Contains(err.Error(), "resolving auth token") {
+		t.Fatalf("expected token wrap, got %v", err)
+	}
+}
+
+func TestNewEmbeddingModel_ConnectionError(t *testing.T) {
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://127.0.0.1:1",
+		TokenSource: provider.StaticToken("k"),
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewEmbeddingModel_OptionalToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("unexpected auth: %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"model":"m","data":[{"embedding":[0.1],"index":0}],"usage":{"prompt_tokens":1,"total_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:    "test",
+		ModelID:       "m",
+		BaseURL:       server.URL,
+		TokenRequired: false,
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewEmbeddingModel_Headers(t *testing.T) {
+	var got string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Get("X-Test")
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"model":"m","data":[{"embedding":[0.1],"index":0}],"usage":{"prompt_tokens":1,"total_tokens":1}}`)),
+		}, nil
+	})
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://example.invalid",
+		TokenSource: provider.StaticToken("k"),
+		Headers:     map[string]string{"X-Test": "v"},
+		HTTPClient:  &http.Client{Transport: tr},
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v" {
+		t.Errorf("X-Test = %q", got)
+	}
+}
+
+func TestNewEmbeddingModel_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{not-json`)
+	}))
+	defer server.Close()
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     server.URL,
+		TokenSource: provider.StaticToken("k"),
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err == nil || !strings.Contains(err.Error(), "parsing response") {
+		t.Fatalf("expected parsing error, got %v", err)
+	}
+}

--- a/internal/openaicompat/factory_test.go
+++ b/internal/openaicompat/factory_test.go
@@ -482,6 +482,53 @@ func TestNewEmbeddingModel_Headers(t *testing.T) {
 	}
 }
 
+type errReader struct{}
+
+func (errReader) Read(p []byte) (int, error) { return 0, errors.New("read boom") }
+func (errReader) Close() error               { return nil }
+
+func TestNewChatModel_ReadError(t *testing.T) {
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       errReader{},
+		}, nil
+	})
+	m := NewChatModel(ChatModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://example.invalid",
+		TokenSource: provider.StaticToken("k"),
+		HTTPClient:  &http.Client{Transport: tr},
+	})
+	_, err := m.DoGenerate(t.Context(), testParams())
+	if err == nil || !strings.Contains(err.Error(), "reading response") {
+		t.Fatalf("expected read error, got %v", err)
+	}
+}
+
+func TestNewEmbeddingModel_ReadError(t *testing.T) {
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       errReader{},
+		}, nil
+	})
+	m := NewEmbeddingModel(EmbeddingModelConfig{
+		ProviderID:  "test",
+		ModelID:     "m",
+		BaseURL:     "http://example.invalid",
+		TokenSource: provider.StaticToken("k"),
+		HTTPClient:  &http.Client{Transport: tr},
+	})
+	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
+	if err == nil || !strings.Contains(err.Error(), "reading response") {
+		t.Fatalf("expected read error, got %v", err)
+	}
+}
+
 func TestNewEmbeddingModel_InvalidJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/provider/cerebras/cerebras.go
+++ b/provider/cerebras/cerebras.go
@@ -1,29 +1,17 @@
-// Package cerebras provides a Cerebras language model implementation for GoAI.
+// Package cerebras provides a cerebras language model implementation for GoAI.
 package cerebras
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.cerebras.ai/v1"
 
-// Option configures the Cerebras provider.
+// Option configures the cerebras provider.
 type Option func(*options)
 
 type options struct {
@@ -33,133 +21,64 @@ type options struct {
 	httpClient  *http.Client
 }
 
-// WithAPIKey sets the Cerebras API key.
+// WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a Cerebras language model for the given model ID.
+// Chat creates a cerebras language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("CEREBRAS_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("CEREBRAS_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: cerebras: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: cerebras: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "cerebras",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "cerebras",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/cerebras/cerebras_test.go
+++ b/provider/cerebras/cerebras_test.go
@@ -98,12 +98,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -165,35 +186,65 @@ func TestModelID(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("CEREBRAS_API_KEY", "env-key")
 	t.Setenv("CEREBRAS_BASE_URL", "")
-	m := Chat("llama-3.3-70b")
+	m := Chat("llama-3.3-70b", WithHTTPClient(&http.Client{Transport: tr}))
 	if m.ModelID() != "llama-3.3-70b" {
 		t.Errorf("ModelID() = %q", m.ModelID())
 	}
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from CEREBRAS_API_KEY")
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("CEREBRAS_API_KEY", "env-key")
-	t.Setenv("CEREBRAS_BASE_URL", "https://custom.cerebras.ai/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.cerebras.ai/v1" {
-		t.Errorf("baseURL = %q, want https://custom.cerebras.ai/v1", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("CEREBRAS_API_KEY", "k")
+	t.Setenv("CEREBRAS_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
 	t.Setenv("CEREBRAS_API_KEY", "env-key")
 	t.Setenv("CEREBRAS_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q, want https://explicit.url", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/cloudflare/cloudflare.go
+++ b/provider/cloudflare/cloudflare.go
@@ -5,25 +5,12 @@
 package cloudflare
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
-)
-
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel  = (*chatModel)(nil)
-	_ provider.CapableModel   = (*chatModel)(nil)
-	_ provider.EmbeddingModel = (*embeddingModel)(nil)
 )
 
 const defaultAPIBase = "https://api.cloudflare.com/client/v4"
@@ -34,7 +21,7 @@ type Option func(*options)
 type options struct {
 	tokenSource provider.TokenSource
 	accountID   string
-	baseURL     string // full base URL including /accounts/{id}/ai/v1, overrides accountID-derived URL
+	baseURL     string
 	headers     map[string]string
 	httpClient  *http.Client
 }
@@ -97,184 +84,43 @@ func resolveOptions(opts []Option) options {
 // Chat creates a Cloudflare Workers AI language model for the given model ID.
 // Either WithBaseURL or WithAccountID (plus an account ID from env) is required.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
-	return &chatModel{id: modelID, opts: resolveOptions(opts)}
+	o := resolveOptions(opts)
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "cloudflare",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		BaseURLRequired:      true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
+		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
+	})
 }
 
 // Embedding creates a Cloudflare Workers AI embedding model for the given model ID.
 func Embedding(modelID string, opts ...Option) provider.EmbeddingModel {
-	return &embeddingModel{id: modelID, opts: resolveOptions(opts)}
-}
-
-// --- Chat Model ---
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: cloudflare: WithPromptCaching is not supported and will be ignored\n")
-	}
-	if err := m.checkBaseURL(); err != nil {
-		return nil, err
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: cloudflare: WithPromptCaching is not supported and will be ignored\n")
-	}
-	if err := m.checkBaseURL(); err != nil {
-		return nil, err
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
-		IncludeStreamOptions: true,
+	o := resolveOptions(opts)
+	return openaicompat.NewEmbeddingModel(openaicompat.EmbeddingModelConfig{
+		ProviderID:          "cloudflare",
+		ModelID:             modelID,
+		BaseURL:             o.baseURL,
+		TokenSource:         o.tokenSource,
+		TokenRequired:       true,
+		BaseURLRequired:     true,
+		Headers:             o.headers,
+		HTTPClient:          o.httpClient,
+		MaxValuesPerCall:    100,
+		ProviderOptionsKeys: []string{"dimensions"},
+		EncodingFormat:      "-",
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) checkBaseURL() error {
-	if m.opts.baseURL == "" {
-		return errors.New("cloudflare: account ID is required (use WithAccountID or CLOUDFLARE_ACCOUNT_ID)")
-	}
-	return nil
-}
-
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := resolveToken(ctx, m.opts.tokenSource)
-	if err != nil {
-		return nil, err
-	}
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "cloudflare",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-// --- Embedding Model ---
-
-type embeddingModel struct {
-	id   string
-	opts options
-}
-
-func (m *embeddingModel) ModelID() string { return m.id }
-
-// MaxValuesPerCall returns the maximum batch size. Cloudflare accepts multiple
-// inputs per request; 100 is a safe default aligned with their documented limits.
-func (m *embeddingModel) MaxValuesPerCall() int { return 100 }
-
-func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params provider.EmbedParams) (*provider.EmbedResult, error) {
-	if m.opts.baseURL == "" {
-		return nil, errors.New("cloudflare: account ID is required (use WithAccountID or CLOUDFLARE_ACCOUNT_ID)")
-	}
-
-	body := map[string]any{
-		"model": m.id,
-		"input": values,
-	}
-	if params.ProviderOptions != nil {
-		if v, ok := params.ProviderOptions["dimensions"]; ok {
-			body["dimensions"] = v
-		}
-	}
-
-	token, err := resolveToken(ctx, m.opts.tokenSource)
-	if err != nil {
-		return nil, err
-	}
-
-	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", m.opts.baseURL+"/embeddings", jsonBody)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
-	for k, v := range m.opts.headers {
-		req.Header.Set(k, v)
-	}
-
-	client := m.opts.httpClient
-	if client == nil {
-		client = http.DefaultClient
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, goai.ParseHTTPErrorWithHeaders("cloudflare", resp.StatusCode, respBody, resp.Header)
-	}
-
-	var result struct {
-		Model string `json:"model"`
-		Data  []struct {
-			Embedding []float64 `json:"embedding"`
-			Index     int       `json:"index"`
-		} `json:"data"`
-		Usage struct {
-			PromptTokens int `json:"prompt_tokens"`
-			TotalTokens  int `json:"total_tokens"`
-		} `json:"usage"`
-	}
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
-	}
-
-	embeddings := make([][]float64, len(result.Data))
-	for _, d := range result.Data {
-		if d.Index >= 0 && d.Index < len(embeddings) {
-			embeddings[d.Index] = d.Embedding
-		}
-	}
-	return &provider.EmbedResult{
-		Embeddings: embeddings,
-		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens, TotalTokens: result.Usage.TotalTokens},
-		Response:   provider.ResponseMetadata{Model: result.Model},
-	}, nil
-}
-
-func resolveToken(ctx context.Context, ts provider.TokenSource) (string, error) {
-	if ts == nil {
-		return "", errors.New("goai: no API token or token source configured")
-	}
-	return ts.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/cloudflare/cloudflare_test.go
+++ b/provider/cloudflare/cloudflare_test.go
@@ -75,26 +75,44 @@ func TestChat_MissingAccountID(t *testing.T) {
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "account ID") {
-		t.Fatalf("expected account ID error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "base URL") {
+		t.Fatalf("expected base URL error, got: %v", err)
 	}
 
 	_, err = model.DoStream(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 	})
-	if err == nil || !strings.Contains(err.Error(), "account ID") {
-		t.Fatalf("expected account ID error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "base URL") {
+		t.Fatalf("expected base URL error, got: %v", err)
 	}
 }
 
 func TestChat_AccountIDBuildsURL(t *testing.T) {
-	m := Chat("m", WithAPIKey("k"), WithAccountID("acc123"))
-	cm := m.(*chatModel)
-	want := "https://api.cloudflare.com/client/v4/accounts/acc123/ai/v1"
-	if cm.opts.baseURL != want {
-		t.Errorf("baseURL = %q, want %q", cm.opts.baseURL, want)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+		}, nil
+	})
+	m := Chat("m", WithAPIKey("k"), WithAccountID("acc123"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://api.cloudflare.com/client/v4/accounts/acc123/ai/v1/chat/completions"
+	if gotURL != want {
+		t.Errorf("URL = %q, want %q", gotURL, want)
 	}
 }
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 func TestChat_HTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -162,11 +180,24 @@ func TestWithTokenSource(t *testing.T) {
 }
 
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	m := Chat("m", WithAPIKey("k"), WithHTTPClient(c), WithAccountID("a"))
-	cm := m.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+		}, nil
+	})
+	m := Chat("m", WithAPIKey("k"), WithAccountID("a"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -203,25 +234,54 @@ func TestPromptCachingIgnored(t *testing.T) {
 }
 
 func TestEnvVarResolution(t *testing.T) {
+	var gotAuth, gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		gotURL = req.URL.String()
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+		}, nil
+	})
 	t.Setenv("CLOUDFLARE_API_TOKEN", "env-tok")
 	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "env-acc")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(cm.opts.baseURL, "env-acc") {
-		t.Errorf("baseURL should include account ID: %q", cm.opts.baseURL)
+	if gotAuth != "Bearer env-tok" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+	if !strings.Contains(gotURL, "env-acc") {
+		t.Errorf("URL should include account ID: %q", gotURL)
 	}
 }
 
 func TestEnvVarBaseURL(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+		}, nil
+	})
 	t.Setenv("CLOUDFLARE_API_TOKEN", "k")
 	t.Setenv("CLOUDFLARE_BASE_URL", "https://gateway.example.com/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://gateway.example.com/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://gateway.example.com/v1/") {
+		t.Errorf("URL = %q, expected prefix https://gateway.example.com/v1/", gotURL)
 	}
 }
 
@@ -302,8 +362,8 @@ func TestEmbed_MissingAccountID(t *testing.T) {
 	t.Setenv("CLOUDFLARE_BASE_URL", "")
 	m := Embedding("m", WithAPIKey("k"))
 	_, err := m.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{})
-	if err == nil || !strings.Contains(err.Error(), "account ID") {
-		t.Fatalf("expected account ID error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "base URL") {
+		t.Fatalf("expected base URL error, got %v", err)
 	}
 }
 

--- a/provider/compat/compat.go
+++ b/provider/compat/compat.go
@@ -10,24 +10,10 @@
 package compat
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"io"
 	"net/http"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
-)
-
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel  = (*chatModel)(nil)
-	_ provider.CapableModel   = (*chatModel)(nil)
-	_ provider.EmbeddingModel = (*embeddingModel)(nil)
 )
 
 // Option configures the generic OpenAI-compatible provider.
@@ -44,248 +30,81 @@ type options struct {
 // WithProviderID overrides the provider name used in error messages.
 // Defaults to "compat".
 func WithProviderID(id string) Option {
-	return func(o *options) {
-		o.providerID = id
-	}
+	return func(o *options) { o.providerID = id }
 }
 
 // WithAPIKey sets a static API key for authentication.
 // When not set, the Authorization header is omitted.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL sets the API base URL. This is required for the generic provider.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
+	return func(o *options) { o.httpClient = c }
+}
+
+func resolveOptions(opts []Option) options {
+	o := options{providerID: "compat"}
+	for _, opt := range opts {
+		opt(&o)
 	}
+	return o
 }
 
 // Chat creates a generic OpenAI-compatible language model.
 // WithBaseURL is required; calls will fail without it.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
-	o := options{providerID: "compat"}
-	for _, opt := range opts {
-		opt(&o)
-	}
-	return &chatModel{id: modelID, opts: o}
+	o := resolveOptions(opts)
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           o.providerID,
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		BaseURLRequired:      true,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        false,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
+		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
+	})
 }
 
 // Embedding creates a generic OpenAI-compatible embedding model.
 // WithBaseURL is required; calls will fail without it.
 func Embedding(modelID string, opts ...Option) provider.EmbeddingModel {
-	o := options{providerID: "compat"}
-	for _, opt := range opts {
-		opt(&o)
-	}
-	return &embeddingModel{id: modelID, opts: o}
-}
-
-// --- Chat Model ---
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: %s: WithPromptCaching is not supported and will be ignored\n", m.opts.providerID)
-	}
-	if m.opts.baseURL == "" {
-		return nil, fmt.Errorf("compat: base URL is required (use WithBaseURL)")
-	}
-
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: %s: WithPromptCaching is not supported and will be ignored\n", m.opts.providerID)
-	}
-	if m.opts.baseURL == "" {
-		return nil, fmt.Errorf("compat: base URL is required (use WithBaseURL)")
-	}
-
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
-		IncludeStreamOptions: true,
+	o := resolveOptions(opts)
+	return openaicompat.NewEmbeddingModel(openaicompat.EmbeddingModelConfig{
+		ProviderID:      o.providerID,
+		ModelID:         modelID,
+		BaseURL:         o.baseURL,
+		BaseURLRequired: true,
+		TokenSource:     o.tokenSource,
+		TokenRequired:   false,
+		Headers:         o.headers,
+		HTTPClient:      o.httpClient,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	// Only resolve token when a token source is configured (auth is optional for compat).
-	var token string
-	if m.opts.tokenSource != nil {
-		var err error
-		token, err = m.opts.tokenSource.Token(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("resolving auth token: %w", err)
-		}
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: m.opts.providerID,
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-// --- Embedding Model ---
-
-type embeddingModel struct {
-	id   string
-	opts options
-}
-
-func (m *embeddingModel) ModelID() string { return m.id }
-
-// MaxValuesPerCall returns the maximum batch size. Returns 2048 as a safe default.
-func (m *embeddingModel) MaxValuesPerCall() int { return 2048 }
-
-func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params provider.EmbedParams) (*provider.EmbedResult, error) {
-	if m.opts.baseURL == "" {
-		return nil, fmt.Errorf("compat: base URL is required (use WithBaseURL)")
-	}
-
-	body := map[string]any{
-		"model":           m.id,
-		"input":           values,
-		"encoding_format": "float",
-	}
-
-	if params.ProviderOptions != nil {
-		if v, ok := params.ProviderOptions["dimensions"]; ok {
-			body["dimensions"] = v
-		}
-		if v, ok := params.ProviderOptions["user"]; ok {
-			body["user"] = v
-		}
-	}
-
-	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", m.opts.baseURL+"/embeddings", jsonBody)
-	req.Header.Set("Content-Type", "application/json")
-
-	// Only set Authorization when a token source is configured.
-	if m.opts.tokenSource != nil {
-		token, err := m.opts.tokenSource.Token(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("resolving auth token: %w", err)
-		}
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	for k, v := range m.opts.headers {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := m.httpClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, goai.ParseHTTPErrorWithHeaders(m.opts.providerID, resp.StatusCode, respBody, resp.Header)
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	var result struct {
-		Model string `json:"model"`
-		Data  []struct {
-			Embedding []float64 `json:"embedding"`
-			Index     int       `json:"index"`
-		} `json:"data"`
-		Usage struct {
-			PromptTokens int `json:"prompt_tokens"`
-			TotalTokens  int `json:"total_tokens"`
-		} `json:"usage"`
-	}
-
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
-	}
-
-	embeddings := make([][]float64, len(result.Data))
-	for _, d := range result.Data {
-		if d.Index >= 0 && d.Index < len(embeddings) {
-			embeddings[d.Index] = d.Embedding
-		}
-	}
-
-	return &provider.EmbedResult{
-		Embeddings: embeddings,
-		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens, TotalTokens: result.Usage.TotalTokens},
-		Response:   provider.ResponseMetadata{Model: result.Model},
-	}, nil
-}
-
-func (m *embeddingModel) httpClient() *http.Client {
-	if m.opts.httpClient != nil {
-		return m.opts.httpClient
-	}
-	return http.DefaultClient
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/compat/compat_test.go
+++ b/provider/compat/compat_test.go
@@ -223,11 +223,37 @@ func TestChat_ReadError(t *testing.T) {
 }
 
 func TestChat_WithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+		}, nil
+	})
+	model := Chat("model", WithBaseURL("http://example.invalid"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestWithProviderID(t *testing.T) {
+	// Smoke test: WithProviderID is a setter; behavior impact is internal (error
+	// tagging, logging). The option must not panic or break model construction.
+	m := Chat("m", WithBaseURL("http://example.invalid"), WithProviderID("custom-id"))
+	if m.ModelID() != "m" {
+		t.Errorf("ModelID = %q", m.ModelID())
 	}
 }
 

--- a/provider/deepinfra/deepinfra.go
+++ b/provider/deepinfra/deepinfra.go
@@ -2,23 +2,11 @@
 package deepinfra
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
-)
-
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
 )
 
 const defaultBaseURL = "https://api.deepinfra.com/v1/openai"
@@ -35,37 +23,27 @@ type options struct {
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
 // Chat creates a DeepInfra language model for the given model ID.
@@ -74,92 +52,33 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("DEEPINFRA_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("DEEPINFRA_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: deepinfra: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: deepinfra: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "deepinfra",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "deepinfra",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/deepinfra/deepinfra_test.go
+++ b/provider/deepinfra/deepinfra_test.go
@@ -101,13 +101,31 @@ func TestNoTokenSource(t *testing.T) {
 }
 
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+		}, nil
+	})
+	c := &http.Client{Transport: tr}
+	model := Chat("model", WithAPIKey("key"), WithBaseURL("http://example.invalid"), WithHTTPClient(c))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 func TestWithHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -269,31 +287,68 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer env-key" {
+			t.Errorf("auth = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
 	t.Setenv("DEEPINFRA_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from DEEPINFRA_API_KEY")
+	m := Chat("m", WithBaseURL(server.URL))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
 	t.Setenv("DEEPINFRA_API_KEY", "env-key")
-	t.Setenv("DEEPINFRA_BASE_URL", "https://custom.deepinfra.com/v1")
+	t.Setenv("DEEPINFRA_BASE_URL", server.URL)
 	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.deepinfra.com/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	envHit := false
+	envServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		envHit = true
+		w.WriteHeader(500)
+	}))
+	defer envServer.Close()
+
+	explicitServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer explicitServer.Close()
+
 	t.Setenv("DEEPINFRA_API_KEY", "env-key")
-	t.Setenv("DEEPINFRA_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	t.Setenv("DEEPINFRA_BASE_URL", envServer.URL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL(explicitServer.URL))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if envHit {
+		t.Error("env-url server was hit; explicit baseURL should take precedence")
 	}
 }
 

--- a/provider/deepseek/deepseek.go
+++ b/provider/deepseek/deepseek.go
@@ -1,29 +1,17 @@
-// Package deepseek provides a DeepSeek language model implementation for GoAI.
+// Package deepseek provides a deepseek language model implementation for GoAI.
 package deepseek
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.deepseek.com"
 
-// Option configures the DeepSeek provider.
+// Option configures the deepseek provider.
 type Option func(*options)
 
 type options struct {
@@ -35,132 +23,63 @@ type options struct {
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a DeepSeek language model for the given model ID.
+// Chat creates a deepseek language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("DEEPSEEK_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("DEEPSEEK_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		Reasoning:        true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: deepseek: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: deepseek: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "deepseek",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "deepseek",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	Reasoning:        true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/deepseek/deepseek_test.go
+++ b/provider/deepseek/deepseek_test.go
@@ -100,12 +100,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -272,31 +293,61 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("DEEPSEEK_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from DEEPSEEK_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("DEEPSEEK_API_KEY", "env-key")
-	t.Setenv("DEEPSEEK_BASE_URL", "https://custom.deepseek.com")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.deepseek.com" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("DEEPSEEK_API_KEY", "k")
+	t.Setenv("DEEPSEEK_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
 	t.Setenv("DEEPSEEK_API_KEY", "env-key")
 	t.Setenv("DEEPSEEK_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/fireworks/fireworks.go
+++ b/provider/fireworks/fireworks.go
@@ -1,29 +1,17 @@
-// Package fireworks provides a Fireworks AI language model implementation for GoAI.
+// Package fireworks provides a fireworks language model implementation for GoAI.
 package fireworks
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.fireworks.ai/inference/v1"
 
-// Option configures the Fireworks AI provider.
+// Option configures the fireworks provider.
 type Option func(*options)
 
 type options struct {
@@ -35,131 +23,62 @@ type options struct {
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a Fireworks AI language model for the given model ID.
+// Chat creates a fireworks language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("FIREWORKS_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("FIREWORKS_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: fireworks: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: fireworks: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "fireworks",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "fireworks",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/fireworks/fireworks_test.go
+++ b/provider/fireworks/fireworks_test.go
@@ -100,12 +100,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -269,30 +290,61 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("FIREWORKS_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from FIREWORKS_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("FIREWORKS_API_KEY", "env-key")
-	t.Setenv("FIREWORKS_BASE_URL", "https://custom.fireworks.ai/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.fireworks.ai/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("FIREWORKS_API_KEY", "k")
+	t.Setenv("FIREWORKS_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("FIREWORKS_API_KEY", "env-key")
 	t.Setenv("FIREWORKS_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/fptcloud/fptcloud.go
+++ b/provider/fptcloud/fptcloud.go
@@ -7,25 +7,11 @@
 package fptcloud
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
-)
-
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel  = (*chatModel)(nil)
-	_ provider.CapableModel   = (*chatModel)(nil)
-	_ provider.EmbeddingModel = (*embeddingModel)(nil)
 )
 
 const (
@@ -38,8 +24,8 @@ type Option func(*options)
 
 type options struct {
 	tokenSource provider.TokenSource
-	region      string // "global" | "jp"
-	baseURL     string // explicit override
+	region      string
+	baseURL     string
 	headers     map[string]string
 	httpClient  *http.Client
 }
@@ -109,170 +95,38 @@ func resolveOptions(opts []Option) options {
 
 // Chat creates an FPT Smart Cloud language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
-	return &chatModel{id: modelID, opts: resolveOptions(opts)}
+	o := resolveOptions(opts)
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "fptcloud",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
+		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
+	})
 }
 
 // Embedding creates an FPT Smart Cloud embedding model for the given model ID.
 func Embedding(modelID string, opts ...Option) provider.EmbeddingModel {
-	return &embeddingModel{id: modelID, opts: resolveOptions(opts)}
-}
-
-// --- Chat Model ---
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: fptcloud: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: fptcloud: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
-		IncludeStreamOptions: true,
+	o := resolveOptions(opts)
+	return openaicompat.NewEmbeddingModel(openaicompat.EmbeddingModelConfig{
+		ProviderID:    "fptcloud",
+		ModelID:       modelID,
+		BaseURL:       o.baseURL,
+		TokenSource:   o.tokenSource,
+		TokenRequired: true,
+		Headers:       o.headers,
+		HTTPClient:    o.httpClient,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := resolveToken(ctx, m.opts.tokenSource)
-	if err != nil {
-		return nil, err
-	}
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "fptcloud",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-// --- Embedding Model ---
-
-type embeddingModel struct {
-	id   string
-	opts options
-}
-
-func (m *embeddingModel) ModelID() string { return m.id }
-
-// MaxValuesPerCall returns the maximum batch size. 2048 is a safe default.
-func (m *embeddingModel) MaxValuesPerCall() int { return 2048 }
-
-func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params provider.EmbedParams) (*provider.EmbedResult, error) {
-	body := map[string]any{
-		"model":           m.id,
-		"input":           values,
-		"encoding_format": "float",
-	}
-	if params.ProviderOptions != nil {
-		if v, ok := params.ProviderOptions["dimensions"]; ok {
-			body["dimensions"] = v
-		}
-		if v, ok := params.ProviderOptions["user"]; ok {
-			body["user"] = v
-		}
-	}
-
-	token, err := resolveToken(ctx, m.opts.tokenSource)
-	if err != nil {
-		return nil, err
-	}
-
-	jsonBody := httpc.MustMarshalJSON(body)
-	req := httpc.MustNewRequest(ctx, "POST", m.opts.baseURL+"/embeddings", jsonBody)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
-	for k, v := range m.opts.headers {
-		req.Header.Set(k, v)
-	}
-
-	client := m.opts.httpClient
-	if client == nil {
-		client = http.DefaultClient
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, goai.ParseHTTPErrorWithHeaders("fptcloud", resp.StatusCode, respBody, resp.Header)
-	}
-
-	var result struct {
-		Model string `json:"model"`
-		Data  []struct {
-			Embedding []float64 `json:"embedding"`
-			Index     int       `json:"index"`
-		} `json:"data"`
-		Usage struct {
-			PromptTokens int `json:"prompt_tokens"`
-			TotalTokens  int `json:"total_tokens"`
-		} `json:"usage"`
-	}
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
-	}
-
-	embeddings := make([][]float64, len(result.Data))
-	for _, d := range result.Data {
-		if d.Index >= 0 && d.Index < len(embeddings) {
-			embeddings[d.Index] = d.Embedding
-		}
-	}
-	return &provider.EmbedResult{
-		Embeddings: embeddings,
-		Usage:      provider.Usage{InputTokens: result.Usage.PromptTokens, TotalTokens: result.Usage.TotalTokens},
-		Response:   provider.ResponseMetadata{Model: result.Model},
-	}, nil
-}
-
-func resolveToken(ctx context.Context, ts provider.TokenSource) (string, error) {
-	if ts == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return ts.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/fptcloud/fptcloud_test.go
+++ b/provider/fptcloud/fptcloud_test.go
@@ -64,27 +64,60 @@ func TestChat_Stream(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestRegionDefault(t *testing.T) {
-	m := Chat("m", WithAPIKey("k"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != baseURLGlobal {
-		t.Errorf("baseURL = %q, want %q", cm.opts.baseURL, baseURLGlobal)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	m := Chat("m", WithAPIKey("k"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, _ = m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if !strings.HasPrefix(gotURL, baseURLGlobal) {
+		t.Errorf("URL = %q, want prefix %q", gotURL, baseURLGlobal)
 	}
 }
 
 func TestRegionJP(t *testing.T) {
-	m := Chat("m", WithAPIKey("k"), WithRegion("jp"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != baseURLJP {
-		t.Errorf("baseURL = %q, want %q", cm.opts.baseURL, baseURLJP)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	m := Chat("m", WithAPIKey("k"), WithRegion("jp"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, _ = m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if !strings.HasPrefix(gotURL, baseURLJP) {
+		t.Errorf("URL = %q, want prefix %q", gotURL, baseURLJP)
 	}
 }
 
 func TestRegionUnknownFallback(t *testing.T) {
-	m := Chat("m", WithAPIKey("k"), WithRegion("mars"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != baseURLGlobal {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	m := Chat("m", WithAPIKey("k"), WithRegion("mars"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, _ = m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if !strings.HasPrefix(gotURL, baseURLGlobal) {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
@@ -154,10 +187,17 @@ func TestWithTokenSource(t *testing.T) {
 }
 
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	m := Chat("m", WithAPIKey("k"), WithHTTPClient(c))
-	if m.(*chatModel).opts.httpClient != c {
-		t.Error("client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("m", WithAPIKey("k"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, _ = m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -177,35 +217,66 @@ func TestModelID(t *testing.T) {
 }
 
 func TestEnvVarResolution(t *testing.T) {
+	var gotURL, gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("FPT_API_KEY", "env-key")
 	t.Setenv("FPT_REGION", "jp")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource nil")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if cm.opts.baseURL != baseURLJP {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+	if !strings.HasPrefix(gotURL, baseURLJP) {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestEnvVarBaseURL(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
 	t.Setenv("FPT_API_KEY", "k")
 	t.Setenv("FPT_BASE_URL", "https://custom.example.com/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.example.com/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestEnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
 	t.Setenv("FPT_API_KEY", "env")
 	t.Setenv("FPT_BASE_URL", "https://env.example.com")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.example.com"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.example.com" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.example.com"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.example.com/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/groq/groq.go
+++ b/provider/groq/groq.go
@@ -1,29 +1,17 @@
-// Package groq provides a Groq language model implementation for GoAI.
+// Package groq provides a groq language model implementation for GoAI.
 package groq
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.groq.com/openai/v1"
 
-// Option configures the Groq provider.
+// Option configures the groq provider.
 type Option func(*options)
 
 type options struct {
@@ -35,131 +23,62 @@ type options struct {
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a Groq language model for the given model ID.
+// Chat creates a groq language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("GROQ_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("GROQ_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: groq: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: groq: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "groq",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "groq",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/groq/groq_test.go
+++ b/provider/groq/groq_test.go
@@ -100,12 +100,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -269,30 +290,61 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("GROQ_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from GROQ_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("GROQ_API_KEY", "env-key")
-	t.Setenv("GROQ_BASE_URL", "https://custom.groq.com/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.groq.com/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("GROQ_API_KEY", "k")
+	t.Setenv("GROQ_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("GROQ_API_KEY", "env-key")
 	t.Setenv("GROQ_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/mistral/mistral.go
+++ b/provider/mistral/mistral.go
@@ -1,29 +1,17 @@
-// Package mistral provides a Mistral AI language model implementation for GoAI.
+// Package mistral provides a mistral language model implementation for GoAI.
 package mistral
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.mistral.ai/v1"
 
-// Option configures the Mistral AI provider.
+// Option configures the mistral provider.
 type Option func(*options)
 
 type options struct {
@@ -33,133 +21,64 @@ type options struct {
 	httpClient  *http.Client
 }
 
-// WithAPIKey sets the Mistral API key.
+// WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a Mistral AI language model for the given model ID.
+// Chat creates a mistral language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("MISTRAL_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("MISTRAL_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: mistral: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: mistral: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "mistral",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "mistral",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/mistral/mistral_test.go
+++ b/provider/mistral/mistral_test.go
@@ -98,12 +98,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -265,30 +286,61 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("MISTRAL_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from MISTRAL_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("MISTRAL_API_KEY", "env-key")
-	t.Setenv("MISTRAL_BASE_URL", "https://custom.mistral.ai/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.mistral.ai/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("MISTRAL_API_KEY", "k")
+	t.Setenv("MISTRAL_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("MISTRAL_API_KEY", "env-key")
 	t.Setenv("MISTRAL_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/openrouter/openrouter.go
+++ b/provider/openrouter/openrouter.go
@@ -1,31 +1,15 @@
 // Package openrouter provides an OpenRouter language model implementation for GoAI.
 //
-// OpenRouter is an OpenAI-compatible API aggregator with extra headers.
-//
-// Usage:
-//
-//	model := openrouter.Chat("anthropic/claude-sonnet-4", openrouter.WithAPIKey("sk-or-..."))
-//	result, err := goai.GenerateText(ctx, model, goai.WithPrompt("Hello"))
+// OpenRouter is a unified API for accessing multiple LLM providers through
+// a single OpenAI-compatible endpoint.
 package openrouter
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
-)
-
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
 )
 
 const defaultBaseURL = "https://openrouter.ai/api/v1"
@@ -42,37 +26,27 @@ type options struct {
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
-// WithBaseURL overrides the default OpenRouter API base URL.
+// WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
 // Chat creates an OpenRouter language model for the given model ID.
@@ -81,112 +55,47 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("OPENROUTER_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("OPENROUTER_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{
-		id:   modelID,
-		opts: o,
-	}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: openrouter: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{
-		ExtraBody: map[string]any{"usage": map[string]any{"include": true}},
-	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: openrouter: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "openrouter",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              mergeHeaders(o.headers),
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 		ExtraBody:            map[string]any{"usage": map[string]any{"include": true}},
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-// --- HTTP helpers ---
-
-// mergedHeaders returns provider headers merged with OpenRouter-specific headers.
-func (m *chatModel) mergedHeaders() map[string]string {
-	h := map[string]string{
+// mergeHeaders returns user-provided headers with OpenRouter-specific headers added.
+// Requested per https://openrouter.ai/docs/api-reference/overview#headers
+func mergeHeaders(user map[string]string) map[string]string {
+	merged := map[string]string{
 		"HTTP-Referer": "https://github.com/zendev-sh/goai",
 		"X-Title":      "goai",
 	}
-	for k, v := range m.opts.headers {
-		h[k] = v
+	for k, v := range user {
+		merged[k] = v
 	}
-	return h
+	return merged
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.mergedHeaders(),
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "openrouter",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/openrouter/openrouter_test.go
+++ b/provider/openrouter/openrouter_test.go
@@ -115,12 +115,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -238,30 +259,61 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("OPENROUTER_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from OPENROUTER_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("OPENROUTER_API_KEY", "env-key")
-	t.Setenv("OPENROUTER_BASE_URL", "https://custom.openrouter.ai/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.openrouter.ai/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("OPENROUTER_API_KEY", "k")
+	t.Setenv("OPENROUTER_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("OPENROUTER_API_KEY", "env-key")
 	t.Setenv("OPENROUTER_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/perplexity/perplexity.go
+++ b/provider/perplexity/perplexity.go
@@ -1,29 +1,17 @@
-// Package perplexity provides a Perplexity language model implementation for GoAI.
+// Package perplexity provides a perplexity language model implementation for GoAI.
 package perplexity
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.perplexity.ai"
 
-// Option configures the Perplexity provider.
+// Option configures the perplexity provider.
 type Option func(*options)
 
 type options struct {
@@ -33,133 +21,64 @@ type options struct {
 	httpClient  *http.Client
 }
 
-// WithAPIKey sets the Perplexity API key.
+// WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a Perplexity language model for the given model ID.
+// Chat creates a perplexity language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("PERPLEXITY_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("PERPLEXITY_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: perplexity: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: perplexity: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "perplexity",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "perplexity",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/perplexity/perplexity_test.go
+++ b/provider/perplexity/perplexity_test.go
@@ -98,12 +98,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -265,30 +286,61 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("PERPLEXITY_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from PERPLEXITY_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("PERPLEXITY_API_KEY", "env-key")
-	t.Setenv("PERPLEXITY_BASE_URL", "https://custom.perplexity.ai")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.perplexity.ai" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("PERPLEXITY_API_KEY", "k")
+	t.Setenv("PERPLEXITY_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("PERPLEXITY_API_KEY", "env-key")
 	t.Setenv("PERPLEXITY_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 

--- a/provider/runpod/runpod.go
+++ b/provider/runpod/runpod.go
@@ -12,23 +12,12 @@
 package runpod
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
-)
-
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
 )
 
 const baseURLTemplate = "https://api.runpod.ai/v2/%s/openai/v1"
@@ -45,37 +34,27 @@ type options struct {
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
 // Chat creates a RunPod language model for the given endpoint and model IDs.
@@ -86,92 +65,33 @@ func Chat(endpointID, modelID string, opts ...Option) provider.LanguageModel {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("RUNPOD_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("RUNPOD_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: runpod: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: runpod: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "runpod",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "runpod",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/runpod/runpod_test.go
+++ b/provider/runpod/runpod_test.go
@@ -100,12 +100,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("ep-abc123", "model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("ep", "model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -269,44 +290,80 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("RUNPOD_API_KEY", "env-key")
-	m := Chat("ep-abc123", "m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from RUNPOD_API_KEY")
+	m := Chat("ep", "m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("RUNPOD_API_KEY", "env-key")
-	t.Setenv("RUNPOD_BASE_URL", "https://custom.runpod.example/v1")
-	m := Chat("ep-abc123", "m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.runpod.example/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("RUNPOD_API_KEY", "k")
+	t.Setenv("RUNPOD_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("ep", "m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
 	t.Setenv("RUNPOD_API_KEY", "env-key")
 	t.Setenv("RUNPOD_BASE_URL", "https://env.url")
-	m := Chat("ep-abc123", "m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("ep", "m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestEndpointIDInURL(t *testing.T) {
-	endpointID := "abc123def456"
-	m := Chat(endpointID, "some-model", WithAPIKey("k"))
-	cm := m.(*chatModel)
-	if !strings.Contains(cm.opts.baseURL, endpointID) {
-		t.Errorf("baseURL %q does not contain endpoint ID %q", cm.opts.baseURL, endpointID)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	m := Chat("abc123def456", "some-model", WithAPIKey("k"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	expected := "https://api.runpod.ai/v2/abc123def456/openai/v1"
-	if cm.opts.baseURL != expected {
-		t.Errorf("baseURL = %q, want %q", cm.opts.baseURL, expected)
+	want := "https://api.runpod.ai/v2/abc123def456/openai/v1/chat/completions"
+	if gotURL != want {
+		t.Errorf("URL = %q, want %q", gotURL, want)
 	}
 }
 

--- a/provider/together/together.go
+++ b/provider/together/together.go
@@ -1,30 +1,18 @@
-// Package together provides a Together AI language model implementation for GoAI.
+// Package together provides a together language model implementation for GoAI.
 package together
 
 import (
 	"cmp"
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.together.xyz/v1"
 
-// Option configures the Together AI provider.
+// Option configures the together provider.
 type Option func(*options)
 
 type options struct {
@@ -34,133 +22,64 @@ type options struct {
 	httpClient  *http.Client
 }
 
-// WithAPIKey sets the Together AI API key.
+// WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a Together AI language model for the given model ID.
+// Chat creates a together language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := cmp.Or(os.Getenv("TOGETHER_AI_API_KEY"), os.Getenv("TOGETHER_API_KEY")); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("TOGETHER_AI_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: together: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: together: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "together",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "together",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/together/together_test.go
+++ b/provider/together/together_test.go
@@ -98,12 +98,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -265,40 +286,81 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("TOGETHER_AI_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from TOGETHER_AI_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("TOGETHER_AI_API_KEY", "env-key")
-	t.Setenv("TOGETHER_AI_BASE_URL", "https://custom.together.xyz/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.together.xyz/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("TOGETHER_AI_API_KEY", "k")
+	t.Setenv("TOGETHER_AI_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("TOGETHER_AI_API_KEY", "env-key")
 	t.Setenv("TOGETHER_AI_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarResolution_TogetherAPIKey(t *testing.T) {
-	// TOGETHER_API_KEY should work as fallback when TOGETHER_AI_API_KEY is not set.
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
+	t.Setenv("TOGETHER_AI_API_KEY", "")
 	t.Setenv("TOGETHER_API_KEY", "alt-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from TOGETHER_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer alt-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 

--- a/provider/xai/xai.go
+++ b/provider/xai/xai.go
@@ -1,29 +1,17 @@
-// Package xai provides a xAI (Grok) language model implementation for GoAI.
+// Package xai provides a xai language model implementation for GoAI.
 package xai
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"os"
 
-	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
-// Compile-time interface compliance checks.
-var (
-	_ provider.LanguageModel = (*chatModel)(nil)
-	_ provider.CapableModel  = (*chatModel)(nil)
-)
-
 const defaultBaseURL = "https://api.x.ai/v1"
 
-// Option configures the xAI provider.
+// Option configures the xai provider.
 type Option func(*options)
 
 type options struct {
@@ -35,131 +23,62 @@ type options struct {
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
-	return func(o *options) {
-		o.tokenSource = provider.StaticToken(key)
-	}
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
 }
 
 // WithTokenSource sets a dynamic token source for authentication.
 func WithTokenSource(ts provider.TokenSource) Option {
-	return func(o *options) {
-		o.tokenSource = ts
-	}
+	return func(o *options) { o.tokenSource = ts }
 }
 
 // WithBaseURL overrides the default API base URL.
 func WithBaseURL(url string) Option {
-	return func(o *options) {
-		o.baseURL = url
-	}
+	return func(o *options) { o.baseURL = url }
 }
 
 // WithHeaders sets additional HTTP headers sent with every request.
 func WithHeaders(h map[string]string) Option {
-	return func(o *options) {
-		o.headers = h
-	}
+	return func(o *options) { o.headers = h }
 }
 
 // WithHTTPClient sets a custom HTTP client for all requests.
 func WithHTTPClient(c *http.Client) Option {
-	return func(o *options) {
-		o.httpClient = c
-	}
+	return func(o *options) { o.httpClient = c }
 }
 
-// Chat creates a xAI language model for the given model ID.
+// Chat creates a xai language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	// Resolve API key from env if not set.
 	if o.tokenSource == nil {
 		if key := os.Getenv("XAI_API_KEY"); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
-	// Resolve base URL from env if not overridden.
 	if o.baseURL == defaultBaseURL {
 		if base := os.Getenv("XAI_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{id: modelID, opts: o}
-}
-
-type chatModel struct {
-	id   string
-	opts options
-}
-
-func (m *chatModel) ModelID() string { return m.id }
-
-func (m *chatModel) Capabilities() provider.ModelCapabilities {
-	return provider.ModelCapabilities{
-		Temperature:      true,
-		ToolCall:         true,
-		InputModalities:  provider.ModalitySet{Text: true, Image: true},
-		OutputModalities: provider.ModalitySet{Text: true},
-	}
-}
-
-func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: xai: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, false, openaicompat.RequestConfig{})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	return openaicompat.ParseResponse(respBody)
-}
-
-func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
-	if params.PromptCaching {
-		fmt.Fprintf(os.Stderr, "goai: xai: WithPromptCaching is not supported and will be ignored\n")
-	}
-	body := openaicompat.BuildRequest(params, m.id, true, openaicompat.RequestConfig{
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "xai",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              o.headers,
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
 	})
-
-	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/chat/completions", body)
-	if err != nil {
-		return nil, err
-	}
-
-	return openaicompat.NewSSEStream(ctx, resp.Body), nil
 }
 
-func (m *chatModel) doHTTP(ctx context.Context, url string, body map[string]any) (*http.Response, error) {
-	token, err := m.resolveToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("resolving auth token: %w", err)
-	}
-
-	return httpc.DoJSONRequest(ctx, httpc.RequestConfig{
-		URL:        url,
-		Token:      token,
-		Body:       body,
-		Headers:    m.opts.headers,
-		HTTPClient: m.opts.httpClient,
-		ProviderID: "xai",
-	}, goai.ParseHTTPErrorWithHeaders)
-}
-
-func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
-	if m.opts.tokenSource == nil {
-		return "", errors.New("goai: no API key or token source configured")
-	}
-	return m.opts.tokenSource.Token(ctx)
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true, Image: true},
+	OutputModalities: provider.ModalitySet{Text: true},
 }

--- a/provider/xai/xai_test.go
+++ b/provider/xai/xai_test.go
@@ -100,12 +100,33 @@ func TestNoTokenSource(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
-	c := &http.Client{}
-	model := Chat("model", WithAPIKey("key"), WithHTTPClient(c))
-	cm := model.(*chatModel)
-	if cm.opts.httpClient != c {
-		t.Error("custom client not set")
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
 	}
 }
 
@@ -272,30 +293,61 @@ func TestReadError(t *testing.T) {
 }
 
 func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
 	t.Setenv("XAI_API_KEY", "env-key")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.tokenSource == nil {
-		t.Error("tokenSource should be set from XAI_API_KEY")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
 	}
 }
 
 func TestChat_EnvVarBaseURL(t *testing.T) {
-	t.Setenv("XAI_API_KEY", "env-key")
-	t.Setenv("XAI_BASE_URL", "https://custom.x.ai/v1")
-	m := Chat("m")
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://custom.x.ai/v1" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("XAI_API_KEY", "k")
+	t.Setenv("XAI_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 
 func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("XAI_API_KEY", "env-key")
 	t.Setenv("XAI_BASE_URL", "https://env.url")
-	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"))
-	cm := m.(*chatModel)
-	if cm.opts.baseURL != "https://explicit.url" {
-		t.Errorf("baseURL = %q", cm.opts.baseURL)
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
 	}
 }
 


### PR DESCRIPTION
## Summary

Moves ~1,700 lines of duplicated boilerplate from 14 OpenAI-compat provider packages into shared factories in `internal/openaicompat`.

- New `openaicompat.NewChatModel(cfg)` and `openaicompat.NewEmbeddingModel(cfg)` factories own the HTTP dispatch, token resolution, env-var plumbing, PromptCaching warnings, and error parsing.
- Provider packages keep their public API unchanged (`<provider>.Chat(...)`, `<provider>.With*` options, env var fallbacks). They shrink from 165–280 LOC to 84–132 LOC.
- Providers refactored: `deepinfra`, `groq`, `mistral`, `cerebras`, `perplexity`, `xai`, `fireworks`, `deepseek`, `together`, `runpod`, `openrouter`, `compat`, `cloudflare`, `fptcloud`.
- `openai` and `vertex` keep their custom logic (Responses API routing, OAuth2 ADC). These have provider-specific complexity the factory doesn't try to capture.

### LOC impact

| Before | After | Delta |
|---|---|---|
| ~3,035 LOC (14 providers) | ~1,324 LOC (14 providers) + 334 LOC factory | **−1,377 LOC net** |

### Test changes

Several provider tests previously reached into internal `chatModel.opts` fields to verify option wiring. After refactor those structs live inside the factory, so tests were rewritten to assert observable behavior via `httptest.NewServer` or a custom `http.RoundTripper` that captures URL/Authorization/body bytes. The public API is unchanged so existing integration patterns continue to work.

## Test plan

- [x] `go test ./...` passes
- [x] 14 refactored providers at 100% statement coverage
- [x] `internal/openaicompat` at 99.3% (was 95.3%)
- [x] `go build ./...` clean
- [x] Public API surface unchanged (no provider's `Chat()`, `Embedding()`, or `With*` signatures touched)

## Not in this PR

- `openai` and `vertex` still hand-write the HTTP plumbing. Those would need factory extensions for Responses API routing and OAuth2 ADC before they could be absorbed.
- Embedding codec shape (in the factory) is kept close to the per-provider implementations it replaced; no attempt to share response parsing across providers with divergent embedding response shapes.