### PR TITLE
feat: add AgentState, WithStopWhen, ToolResult, StopCause

### DIFF
--- a/agent_state.go
+++ b/agent_state.go
@@ -1,0 +1,261 @@
+package goai
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// StepKind identifies the lifecycle phase of the tool loop at a given moment.
+//
+// AgentState (observed via Observe) transitions through these kinds as the
+// goai tool loop progresses. Consumers poll from a separate goroutine to
+// decide whether it is safe to inject work / send wake signals without
+// interrupting an in-flight LLM call or tool execution.
+type StepKind int
+
+const (
+	// StepStarting is the initial state before the first LLM call begins.
+	StepStarting StepKind = iota
+
+	// StepLLMInFlight indicates an LLM request is in flight (sync or stream).
+	// For StreamText this covers the period from DoStream dispatch until the
+	// last chunk of the step has been drained.
+	StepLLMInFlight
+
+	// StepStepFinished indicates the LLM call for the current step has fully
+	// returned (DoGenerate returned / the stream's ChunkStepFinish has been
+	// emitted) and the step result has been recorded, but tool execution has
+	// not yet begun and loop-termination predicates (WithStopWhen,
+	// OnBeforeStep) have not yet decided whether to continue. This state
+	// exists so that pollers observing between phases cannot mistake the
+	// post-LLM / pre-tool window for "LLM still in flight".
+	StepStepFinished
+
+	// StepToolExecuting indicates one or more tool Execute functions are
+	// running. It is entered after the LLM's stepN response is fully drained
+	// and exited when all parallel tool calls return.
+	StepToolExecuting
+
+	// StepIdle indicates the tool loop has terminated (either naturally, by
+	// MaxSteps exhaustion, by OnBeforeStep.Stop, or by WithStopWhen returning
+	// true). Once StepIdle is observed, the state will not transition again.
+	StepIdle
+)
+
+// String returns a human-readable name for the kind.
+func (k StepKind) String() string {
+	switch k {
+	case StepStarting:
+		return "starting"
+	case StepLLMInFlight:
+		return "llm-in-flight"
+	case StepStepFinished:
+		return "step-finished"
+	case StepToolExecuting:
+		return "tool-executing"
+	case StepIdle:
+		return "idle"
+	default:
+		return "unknown"
+	}
+}
+
+// AgentState is a race-free observable handle into the tool-loop's lifecycle
+// state. Zero value is usable and reports (StepStarting, 0) until goai begins
+// mutating it.
+//
+// Concurrency: goai writes atomically from the tool-loop goroutine; consumers
+// may poll Observe concurrently from any number of goroutines.
+//
+// Layout: we pack (step:uint32, kind:uint32) into a single atomic.Uint64 so
+// that both fields advance together without tearing.
+type AgentState struct {
+	// packed holds step in the high 32 bits and kind in the low 32 bits.
+	packed atomic.Uint64
+}
+
+// Observe returns the current (kind, step) of the agent.
+//
+// Step semantics:
+//   - Before first LLM call: step == 0.
+//   - During StepLLMInFlight / StepStepFinished / StepToolExecuting:
+//     step == the 1-indexed current step number.
+//   - At StepIdle: step == the highest step announced via StepLLMInFlight
+//     (FIX 47 monotonicity invariant). NOTE: at StepIdle, `step` may EXCEED
+//     `len(TextResult.Steps)` when an in-flight step errored before being
+//     appended to the step list - the counter was advanced for
+//     StepLLMInFlight but the StepResult was never recorded because the
+//     error short-circuited the step. Consumers tracking "how many steps
+//     completed" should use `len(result.Steps)`, not `state.Observe()`'s
+//     step return.
+func (s *AgentState) Observe() (kind StepKind, step int) {
+	if s == nil {
+		return StepStarting, 0
+	}
+	v := s.packed.Load()
+	return StepKind(uint32(v)), int(uint32(v >> 32))
+}
+
+// set stores (kind, step) atomically. A negative step is a programming
+// error (goai's internal tool loop never passes one) and panics loudly
+// rather than silently clamping - silent clamps hid real bugs in earlier
+// iterations. Exported API callers cannot reach this function; only goai
+// itself calls set.
+func (s *AgentState) set(kind StepKind, step int) {
+	if s == nil {
+		return
+	}
+	if step < 0 {
+		// Panic with an error value (not a string) so recoverers can use
+		// errors.Is / errors.As and so the standard panic-recovery style
+		// (r, ok := r.(error)) works. The Sprintf form loses type information.
+		panic(fmt.Errorf("goai: negative step %d in AgentState.set (internal invariant violated)", step))
+	}
+	packed := (uint64(uint32(step)) << 32) | uint64(uint32(kind))
+	s.packed.Store(packed)
+}
+
+// WithStateRef exposes goai's tool-loop lifecycle state via an
+// externally-owned AgentState. The caller allocates the value and retains a
+// pointer; goai mutates it atomically as the loop progresses.
+//
+// Typical use (zenflow poller):
+//
+//	var state goai.AgentState
+//	go pollLoop(&state)
+//	_, err := goai.GenerateText(ctx, model, goai.WithStateRef(&state), ...)
+//
+// ref must be non-nil; nil refs are ignored.
+//
+// Supported entry points: GenerateText and StreamText (both single-shot
+// and multi-step tool-loop paths). WithStateRef is NOT supported by
+// GenerateObject or StreamObject - those functions do not run a
+// multi-step loop worth polling, so the AgentState would remain at its
+// zero value (StepStarting, 0) indefinitely. Passing WithStateRef to
+// either function emits a one-shot stderr warning per process per entry
+// point and is otherwise a no-op (FIX 35).
+//
+// Warning semantics (FIX 48). The stderr warning fires ONCE per process
+// per entry point: GenerateObject and StreamObject each own an
+// independent atomic.Bool latch. A long-lived process that calls
+// GenerateObject with WithStateRef a thousand times sees exactly ONE
+// warning for GenerateObject; if that same process later calls
+// StreamObject with WithStateRef it sees one additional warning for
+// StreamObject. Tests may reset these latches in a hermetic way (see
+// object.go FIX 33 caveat) - production code must not.
+//
+// Observation semantics (FIX 43). StateRef provides an atomic read of the
+// (kind, step) pair, but reading StepIdle does NOT establish happens-before
+// on other TextStream / TextResult fields (streamErr, ResponseMessages,
+// Steps, final Usage, etc.). A poller that observes StepIdle and
+// immediately reads stream.Err() or the TextResult return value without
+// additional synchronization races against goai's last writes.
+//
+// Pollers that observe StepIdle MUST still wait on conventional sync
+// before reading result data. The defer-chain ordering of the raw
+// Stream() channel close relative to the StepIdle publish differs
+// between the single-shot and multi-step StreamText paths, so users
+// MUST NOT rely on raw channel close as a StepIdle sync point:
+//
+//   - StreamText, single-shot path (MaxSteps==1 OR no tools bound):
+//     the consume goroutine's defer chain closes the raw Stream()
+//     channel BEFORE publishing the StepIdle atomic store. A poller
+//     that waits only on raw channel close and then reads
+//     state.Observe() may still see StepLLMInFlight / StepToolExecuting.
+//   - StreamText, multi-step path (MaxSteps>1 with tools): StepIdle is
+//     published by the tool-loop goroutine's defer, while the raw
+//     output channel is closed by the same goroutine in a separate
+//     defer. Callers should not depend on inter-defer ordering here.
+//   - StreamText, BOTH paths: call stream.Err() or stream.Result() to
+//     reliably observe StepIdle. These block on the internal doneCh
+//     which closes AFTER the StepIdle atomic store - so a caller that
+//     sees Err()/Result() return is guaranteed to observe StepIdle on
+//     a subsequent state.Observe().
+//   - GenerateText: use the TextResult returned by GenerateText - by the
+//     time GenerateText returns, StepIdle and result fields are
+//     synchronized via the function-return happens-before edge.
+//
+// Use StateRef for "should I wake up / inject work?" polling decisions;
+// use conventional sync (channel close, function return) for reading
+// result data.
+func WithStateRef(ref *AgentState) Option {
+	return func(o *options) { o.StateRef = ref }
+}
+
+// StopCondition is a composable predicate evaluated AFTER each step of the
+// tool loop fully completes - including tool execution for that step --
+// and BEFORE deciding whether to issue the next LLM call. Returning true
+// causes the loop to exit cleanly using the last completed step's natural
+// FinishReason (no synthetic reason is emitted).
+//
+// The predicate receives the full list of completed steps. Each StepResult
+// exposes both ToolCalls (requests the model made this step) and
+// ToolResults (outputs produced by executeToolsParallel for those calls);
+// ToolResults are populated in element-for-element order with ToolCalls and
+// are visible to the predicate because the predicate fires AFTER tool
+// execution. Predicates may branch on either - e.g. "stop after the first
+// step where any tool result is empty":
+//
+//	goai.WithStopWhen(func(steps []goai.StepResult) bool {
+//	    last := steps[len(steps)-1]
+//	    for _, r := range last.ToolResults {
+//	        if r.Output == "" && !r.IsError {
+//	            return true
+//	        }
+//	    }
+//	    return false
+//	})
+//
+// This mirrors Vercel AI SDK's StopCondition placement
+// (packages/ai/src/generate-text/generate-text.ts and stop-condition.ts):
+// the predicate gates the NEXT iteration, not the tool exec of the current
+// iteration. Consumers can compose multiple predicates with a standard OR:
+//
+//	goai.WithStopWhen(func(steps []goai.StepResult) bool {
+//	    return pred1(steps) || pred2(steps)
+//	})
+type StopCondition func(steps []StepResult) bool
+
+// WithStopWhen registers a stop predicate. It is evaluated after the
+// current step's LLM call AND its tool executions complete (tool-result
+// messages already folded into the running message list), and BEFORE the
+// next DoGenerate/DoStream is issued. This matches Vercel AI SDK's
+// placement (packages/ai/src/generate-text/generate-text.ts).
+//
+// Consequences of this placement:
+//
+//   - If the predicate returns true on a step whose LLM response contained
+//     tool calls, those tool calls ARE executed before the break. Both
+//     the assistant message (with tool_use parts) and the paired
+//     tool-result message for the last step are included in
+//     ResponseMessages, making the transcript safe to replay against
+//     strict providers (Anthropic, OpenAI) that reject dangling tool_use.
+//   - The loop's FinishReason is the last completed step's natural reason
+//     (typically FinishToolCalls when stopping mid-loop).
+//   - StepsExhausted is NOT set by a predicate-driven break even when the
+//     break coincides with step == MaxSteps.
+//
+// If predicate is nil, the option is a no-op. If called multiple times the
+// last value wins. Panics in the predicate are recovered and logged; they
+// are treated as "do not stop".
+//
+// Aliasing contract (FIX 30 / FIX 36). The predicate receives a SHALLOW
+// clone of goai's internal steps slice: the top-level slice header is
+// safe to reslice / append / zero (those mutations stay local). Nested
+// slices (StepResult.ToolCalls, StepResult.ToolResults,
+// StepResult.Content) are ALIASED into goai's internal state - writing
+// to an element of those nested slices WILL corrupt goai's internal
+// record and may cause incorrect ResponseMessages or undefined
+// downstream behavior. Predicates MUST treat StepResult contents as
+// read-only. goai does NOT enforce this via deep-clone (prohibitive
+// per-step cost for a feature that is not a supported use case).
+// TestStopSafe_AliasingContract_ShallowCloneIsolatesTopLevel locks in
+// both halves of the contract.
+//
+// WithStopWhen is ignored by GenerateObject and StreamObject (those
+// functions use their own fixed exit conditions tied to structured output
+// parsing). A one-shot stderr warning is emitted the first time WithStopWhen
+// is passed to those paths.
+func WithStopWhen(predicate StopCondition) Option {
+	return func(o *options) { o.StopWhen = predicate }
+}

--- a/agent_state_test.go
+++ b/agent_state_test.go
@@ -1,0 +1,2592 @@
+package goai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+// validateReplayStrict enforces Anthropic-style replay invariants on a
+// ResponseMessages transcript:
+//
+//  1. Count: every tool_use ID has exactly one tool_result with the same ID.
+//  2. Role correctness: tool_result parts appear only in RoleTool messages;
+//     tool_use parts appear only in RoleAssistant messages.
+//  3. Adjacency: the tool_result message(s) for an assistant's tool_use
+//     message appear in the *immediately next* message(s) - before any
+//     following RoleAssistant / RoleUser message.
+//  4. Ordering within turn: all tool_results for a given assistant turn
+//     appear before the next RoleAssistant message.
+//  5. No dangling tool_result: every tool_result has a preceding tool_use.
+//
+// Returns the first violation found or nil when the transcript is sound.
+func validateReplayStrict(msgs []provider.Message) error {
+	// Invariant 2a + 5 + 1-count precheck: collect tool_use ids (assistant)
+	// and tool_result ids (tool), then cross-check.
+	assistantUses := map[string]int{}     // id -> count
+	toolResultsByID := map[string]int{}    // id -> count
+	for i, m := range msgs {
+		for _, p := range m.Content {
+			if p.Type == provider.PartToolCall {
+				if m.Role != provider.RoleAssistant {
+					return fmt.Errorf("msg[%d]: tool_use in non-assistant role %q", i, m.Role)
+				}
+				assistantUses[p.ToolCallID]++
+			}
+			if p.Type == provider.PartToolResult {
+				if m.Role != provider.RoleTool {
+					return fmt.Errorf("msg[%d]: tool_result in non-tool role %q", i, m.Role)
+				}
+				toolResultsByID[p.ToolCallID]++
+			}
+		}
+	}
+	// Invariant 5: every tool_result has a preceding tool_use.
+	for id := range toolResultsByID {
+		if _, ok := assistantUses[id]; !ok {
+			return fmt.Errorf("dangling tool_result with no matching tool_use: %q", id)
+		}
+	}
+	// Invariant 1 (count): exactly-one tool_result per tool_use.
+	for id, uses := range assistantUses {
+		if uses != 1 {
+			return fmt.Errorf("tool_use id %q appears %d times (want 1)", id, uses)
+		}
+		if toolResultsByID[id] != 1 {
+			return fmt.Errorf("tool_use id %q has %d tool_results (want 1)", id, toolResultsByID[id])
+		}
+	}
+	// Invariants 3 + 4: for each assistant message with tool_use parts, the
+	// next message(s) must be RoleTool and together cover all tool_use ids,
+	// before any subsequent RoleAssistant / RoleUser message.
+	for i, m := range msgs {
+		if m.Role != provider.RoleAssistant {
+			continue
+		}
+		pendingIDs := map[string]bool{}
+		for _, p := range m.Content {
+			if p.Type == provider.PartToolCall {
+				pendingIDs[p.ToolCallID] = true
+			}
+		}
+		if len(pendingIDs) == 0 {
+			continue
+		}
+		// Walk forward. Next message must be RoleTool; keep consuming
+		// RoleTool messages until all ids covered. No RoleAssistant /
+		// RoleUser is allowed before all ids are covered.
+		j := i + 1
+		for len(pendingIDs) > 0 {
+			if j >= len(msgs) {
+				// Transcript ended while tool_use ids are still uncovered. This
+				// is distinct from "mismatching id" (handled below) - here the
+				// transcript is simply truncated / incomplete.
+				return fmt.Errorf("assistant msg[%d]: transcript ends with %d unmatched tool_use id(s) (missing: %v)", i, len(pendingIDs), keysOf(pendingIDs))
+			}
+			next := msgs[j]
+			if next.Role != provider.RoleTool {
+				return fmt.Errorf("assistant msg[%d]: expected RoleTool at msg[%d] to cover pending tool_use ids, got role %q (missing: %v)", i, j, next.Role, keysOf(pendingIDs))
+			}
+			for _, p := range next.Content {
+				if p.Type == provider.PartToolResult {
+					if !pendingIDs[p.ToolCallID] {
+						return fmt.Errorf("tool msg[%d] pos %d: tool_result id %q does not match any pending tool_use from assistant msg[%d]", j, i, p.ToolCallID, i)
+					}
+					delete(pendingIDs, p.ToolCallID)
+				}
+			}
+			j++
+		}
+	}
+	return nil
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestWithStopWhen_NeverTrue_FullLoop: predicate always false; loop runs until
+// the model returns a step without tool calls.
+func TestWithStopWhen_NeverTrue_FullLoop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			if n < 3 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+					Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	var checks atomic.Int32
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithStopWhen(func(steps []StepResult) bool {
+			checks.Add(1)
+			return false
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Steps) != 3 {
+		t.Fatalf("steps=%d want 3", len(result.Steps))
+	}
+	if result.FinishReason != provider.FinishStop {
+		t.Errorf("FinishReason=%q want stop", result.FinishReason)
+	}
+	// Predicate is evaluated only after steps that had tool calls (so step 1 & step 2),
+	// not after the terminal step. We expect at least 2 evaluations.
+	if checks.Load() < 2 {
+		t.Errorf("predicate evaluated %d times, want >= 2", checks.Load())
+	}
+}
+
+// TestWithStopWhen_TrueAfterStep1_ExitsCleanly: predicate returns true after
+// the first step; loop exits with Steps[0] populated and no goroutine leaks.
+func TestWithStopWhen_TrueAfterStep1_ExitsCleanly(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	var toolInvokes atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) {
+			toolInvokes.Add(1)
+			return "ok", nil
+		}}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 1 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("steps=%d want 1", len(result.Steps))
+	}
+	// Vercel-parity StopWhen placement: step-1's tools run BEFORE the
+	// predicate evaluation, so the one tool call is invoked exactly once.
+	if callCount.Load() != 1 {
+		t.Errorf("callCount=%d want 1 (step 2 must not issue DoGenerate)", callCount.Load())
+	}
+	if toolInvokes.Load() != 1 {
+		t.Errorf("toolInvokes=%d want 1 (step-1 tool executes before StopWhen break)", toolInvokes.Load())
+	}
+	// Natural finish reason from step 1 (tool_calls) is preserved.
+	if result.FinishReason != provider.FinishToolCalls {
+		t.Errorf("FinishReason=%q want %q", result.FinishReason, provider.FinishToolCalls)
+	}
+	if result.StepsExhausted {
+		t.Errorf("StepsExhausted=true; expected false for StopWhen-break under MaxSteps")
+	}
+	// ResponseMessages must contain the paired assistant(tool_use) +
+	// tool(tool_result) for step 1 so the transcript is replay-safe against
+	// Anthropic/OpenAI (which reject a dangling tool_use).
+	if len(result.ResponseMessages) != 2 {
+		t.Fatalf("ResponseMessages len=%d want 2 (assistant+tool pair); got=%#v", len(result.ResponseMessages), result.ResponseMessages)
+	}
+	if result.ResponseMessages[0].Role != provider.RoleAssistant {
+		t.Errorf("msg[0].Role=%q want assistant", result.ResponseMessages[0].Role)
+	}
+	if result.ResponseMessages[1].Role != provider.RoleTool {
+		t.Errorf("msg[1].Role=%q want tool", result.ResponseMessages[1].Role)
+	}
+}
+
+// TestWithStopWhen_TrueAfterStep2_ResponseMessagesIntact: verifies that both
+// step 1 and step 2 contribute their assistant/tool-result messages to
+// ResponseMessages.
+func TestWithStopWhen_TrueAfterStep2_ResponseMessagesIntact(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				Text:         fmt.Sprintf("step-%d-text", n),
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "tool-out", nil }}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 2 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("steps=%d want 2", len(result.Steps))
+	}
+	if len(result.ResponseMessages) == 0 {
+		t.Fatalf("ResponseMessages is empty")
+	}
+	// Vercel-parity StopWhen placement: the predicate fires AFTER the
+	// current step's tools have executed, so both step-1 and step-2 have
+	// fully paired assistant(tool_use) + tool(tool_result) messages in the
+	// delta. The transcript is safe to replay against strict providers
+	// (Anthropic, OpenAI) that reject dangling tool_use.
+	//   1. assistant(step-1-text + tc1)
+	//   2. tool(result for tc1)
+	//   3. assistant(step-2-text + tc2)
+	//   4. tool(result for tc2)
+	if len(result.ResponseMessages) != 4 {
+		t.Fatalf("ResponseMessages len=%d want 4; got=%#v", len(result.ResponseMessages), result.ResponseMessages)
+	}
+	// Both step-1 and step-2 assistant text must be present.
+	foundStep1, foundStep2 := false, false
+	for _, m := range result.ResponseMessages {
+		for _, p := range m.Content {
+			if p.Text == "step-1-text" {
+				foundStep1 = true
+			}
+			if p.Text == "step-2-text" {
+				foundStep2 = true
+			}
+		}
+	}
+	if !foundStep1 {
+		t.Errorf("step-1 assistant text missing from ResponseMessages")
+	}
+	if !foundStep2 {
+		t.Errorf("step-2 assistant text missing from ResponseMessages (Gap 1 regressed)")
+	}
+	// StepsExhausted must remain false even though we stopped with pending tool
+	// calls; the stop was driven by the predicate, not MaxSteps exhaustion.
+	if result.StepsExhausted {
+		t.Errorf("StepsExhausted=true; want false for StopWhen break")
+	}
+}
+
+// TestWithStopWhen_OnBeforeStepStop_ResponseMessagesIntact verifies the
+// OnBeforeStep.Stop path: because OnBeforeStep fires at the START of the
+// next step (AFTER appendToolRoundTrip ran for the previous step), the last
+// step's assistant AND tool-result are already in the delta. We must NOT
+// duplicate them.
+func TestWithStopWhen_OnBeforeStepStop_ResponseMessagesIntact(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				Text:         fmt.Sprintf("step-%d-text", n),
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	// OnBeforeStep fires at step 2+; stop immediately so LLM call #2 never issues.
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "tool-out", nil }}),
+		WithOnBeforeStep(func(BeforeStepInfo) BeforeStepResult { return BeforeStepResult{Stop: true} }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("steps=%d want 1", len(result.Steps))
+	}
+	if callCount.Load() != 1 {
+		t.Errorf("callCount=%d want 1 (step 2 must not issue DoGenerate)", callCount.Load())
+	}
+	// Expected: assistant(step1) + tool-result(step1) = 2 messages. Must NOT
+	// be duplicated; appendToolRoundTrip already ran for step 1.
+	if len(result.ResponseMessages) != 2 {
+		t.Fatalf("ResponseMessages len=%d want 2 (no duplication); got=%#v", len(result.ResponseMessages), result.ResponseMessages)
+	}
+	if result.StepsExhausted {
+		t.Errorf("StepsExhausted=true; want false for OnBeforeStep.Stop")
+	}
+}
+
+// TestWithStopWhen_AtMaxSteps_StepsExhaustedFalse: the predicate fires on
+// exactly the MaxSteps step with pending tool calls. The post-loop derivation
+// must NOT flip StepsExhausted=true, because the loop was stopped by the
+// user predicate, not by MaxSteps exhaustion.
+func TestWithStopWhen_AtMaxSteps_StepsExhaustedFalse(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				Text:         fmt.Sprintf("s%d", n),
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(2),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 2 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("steps=%d want 2", len(result.Steps))
+	}
+	if result.StepsExhausted {
+		t.Errorf("StepsExhausted=true; want false (StopWhen break at MaxSteps boundary)")
+	}
+}
+
+// TestStreamText_StopWhenMidLoop_CleanClose: streaming version - StopWhen
+// true after step 1 closes the stream cleanly with no leaks and a final
+// ChunkFinish carrying step 1's natural finish reason.
+func TestStreamText_StopWhenMidLoop_CleanClose(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test-stream",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: fmt.Sprintf("step%d", n)},
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: fmt.Sprintf("tc%d", n), ToolName: "t", ToolInput: `{}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}},
+			), nil
+		},
+	}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 1 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var finalFinish provider.FinishReason
+	var sawFinish bool
+	for chunk := range stream.Stream() {
+		if chunk.Type == provider.ChunkFinish {
+			finalFinish = chunk.FinishReason
+			sawFinish = true
+		}
+	}
+
+	if !sawFinish {
+		t.Fatal("never observed ChunkFinish")
+	}
+	if finalFinish != provider.FinishToolCalls {
+		t.Errorf("final ChunkFinish.FinishReason=%q want %q", finalFinish, provider.FinishToolCalls)
+	}
+
+	result := stream.Result()
+	if len(result.Steps) != 1 {
+		t.Errorf("Steps=%d want 1", len(result.Steps))
+	}
+	if callCount.Load() != 1 {
+		t.Errorf("callCount=%d want 1", callCount.Load())
+	}
+	if err := stream.Err(); err != nil {
+		t.Errorf("stream.Err()=%v", err)
+	}
+}
+
+// TestAgentState_Observe_TransitionsCorrectly: verifies state transitions
+// across a 2-step tool loop: Starting -> LLMInFlight(1) -> ToolExecuting(1)
+// -> LLMInFlight(2) -> Idle.
+func TestAgentState_Observe_TransitionsCorrectly(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var state AgentState
+
+	// Record observed transitions via a tool Execute hook.
+	var observations []struct {
+		kind StepKind
+		step int
+	}
+	var mu sync.Mutex
+	record := func(label string) {
+		k, s := state.Observe()
+		mu.Lock()
+		observations = append(observations, struct {
+			kind StepKind
+			step int
+		}{k, s})
+		mu.Unlock()
+		_ = label
+	}
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			// At time of LLM call, we should see LLMInFlight with step==n.
+			k, s := state.Observe()
+			if k != StepLLMInFlight {
+				t.Errorf("during DoGenerate step %d: observed kind=%v want LLMInFlight", n, k)
+			}
+			if s != int(n) {
+				t.Errorf("during DoGenerate step %d: observed step=%d want %d", n, s, n)
+			}
+			if n < 2 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "t", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+					Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	// OnStepFinish fires AFTER StateRef transitions to StepStepFinished
+	// (see Gap 4 fix). Capture the state observed from inside OnStepFinish
+	// to assert the post-LLM / pre-tool window is visible to pollers.
+	var stepFinishedObservations []StepKind
+	var sfMu sync.Mutex
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithStateRef(&state),
+		WithOnStepFinish(func(StepResult) {
+			k, _ := state.Observe()
+			sfMu.Lock()
+			stepFinishedObservations = append(stepFinishedObservations, k)
+			sfMu.Unlock()
+		}),
+		WithTools(Tool{
+			Name: "t",
+			Execute: func(context.Context, json.RawMessage) (string, error) {
+				record("during-tool-execute")
+				return "ok", nil
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// After return, state must be Idle.
+	k, _ := state.Observe()
+	if k != StepIdle {
+		t.Errorf("after return: kind=%v want Idle", k)
+	}
+
+	// While tool was executing we must have observed ToolExecuting.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(observations) == 0 {
+		t.Fatal("no tool-execute observations recorded")
+	}
+	for _, obs := range observations {
+		if obs.kind != StepToolExecuting {
+			t.Errorf("tool-execute observation kind=%v want ToolExecuting", obs.kind)
+		}
+	}
+
+	// Gap 4: StepStepFinished must be observable between DoGenerate return
+	// and tool execution. OnStepFinish fires exactly in that window.
+	sfMu.Lock()
+	defer sfMu.Unlock()
+	if len(stepFinishedObservations) == 0 {
+		t.Fatal("no OnStepFinish observations recorded")
+	}
+	for i, k := range stepFinishedObservations {
+		if k != StepStepFinished {
+			t.Errorf("OnStepFinish obs[%d] kind=%v want StepStepFinished", i, k)
+		}
+	}
+}
+
+// TestAgentState_RaceFree: concurrent readers + one writer via goai's tool
+// loop. Run with `-race` to validate atomic access.
+func TestAgentState_RaceFree(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var state AgentState
+	stopPoll := make(chan struct{})
+	var pollWG sync.WaitGroup
+	for range 8 {
+		pollWG.Go(func() {
+			for {
+				select {
+				case <-stopPoll:
+					return
+				default:
+					_, _ = state.Observe()
+				}
+			}
+		})
+	}
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			if n < 3 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+					Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+				}, nil
+			}
+			return &provider.GenerateResult{
+				Text:         "done",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithStateRef(&state),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) {
+			// Let pollers spin briefly during tool execution.
+			time.Sleep(2 * time.Millisecond)
+			return "ok", nil
+		}}),
+	)
+	close(stopPoll)
+	pollWG.Wait()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	k, _ := state.Observe()
+	if k != StepIdle {
+		t.Errorf("post-run kind=%v want Idle", k)
+	}
+}
+
+// TestWithStopWhen_NilPredicate_NoOp: explicit nil is safe and behaves as if
+// the option were never set.
+func TestWithStopWhen_NilPredicate_NoOp(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "ok",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+	_, err := GenerateText(t.Context(), model, WithPrompt("go"), WithStopWhen(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWithStopWhen_Panic_Recovered: a panicking predicate is treated as "do
+// not stop" and logged; loop continues normally.
+func TestWithStopWhen_Panic_Recovered(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			if n < 2 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "t", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+					Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}}, nil
+		},
+	}
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithStopWhen(func(steps []StepResult) bool { panic(errors.New("boom")) }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount.Load() != 2 {
+		t.Errorf("callCount=%d want 2 (loop should have proceeded past panic)", callCount.Load())
+	}
+}
+
+// TestWithStopWhen_ReplaySafety verifies the ResponseMessages produced on a
+// StopWhen break is a valid replay transcript: every tool_use has a paired
+// tool_result. We simulate replay by appending a user message and running
+// GenerateText again through a strict mock that rejects dangling tool_use.
+func TestWithStopWhen_ReplaySafety(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				Text:         fmt.Sprintf("s%d", n),
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+	first, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 1 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Strict Anthropic-style replay validator: enforces 5 invariants --
+	// count, role correctness, adjacency, ordering, no-dangling. See
+	// validateReplayStrict above.
+	if err := validateReplayStrict(first.ResponseMessages); err != nil {
+		t.Fatalf("ResponseMessages are not replay-safe: %v", err)
+	}
+
+	// Second call: simulate "continue conversation" with a strict mock that
+	// runs the validator on the incoming message list.
+	var innerErr error
+	strict := &mockModel{
+		id: "strict",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			if err := validateReplayStrict(p.Messages); err != nil {
+				innerErr = err
+				return nil, err
+			}
+			return &provider.GenerateResult{
+				Text:         "ok",
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+	msgs := append([]provider.Message{}, first.ResponseMessages...)
+	msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "continue"}}})
+
+	_, err = GenerateText(t.Context(), strict,
+		WithMessages(msgs...),
+	)
+	if err != nil {
+		t.Fatalf("replay GenerateText failed: %v (innerErr=%v)", err, innerErr)
+	}
+}
+
+// TestAgentState_ValidationError_StillIdle verifies that a pre-loop
+// validation error (empty prompt/messages) still transitions StateRef to
+// StepIdle so pollers waiting on it do not deadlock.
+func TestAgentState_ValidationError_StillIdle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var state AgentState
+	_, err := GenerateText(t.Context(), &mockModel{id: "t"}, WithStateRef(&state))
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	k, _ := state.Observe()
+	if k != StepIdle {
+		t.Errorf("GenerateText validation-error: state=%v want StepIdle", k)
+	}
+
+	var state2 AgentState
+	_, err = StreamText(t.Context(), &mockModel{id: "t"}, WithStateRef(&state2))
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	k2, _ := state2.Observe()
+	if k2 != StepIdle {
+		t.Errorf("StreamText validation-error: state=%v want StepIdle", k2)
+	}
+}
+
+// TestWithStopWhen_OnBeforeStep_MarksHookStopped verifies FIX 2: when
+// OnBeforeStep returns Stop=true the post-loop StepsExhausted derivation
+// treats it like a WithStopWhen break (hookStopped semantics), so a Stop=true
+// at exactly the MaxSteps boundary does NOT flip StepsExhausted=true.
+func TestWithStopWhen_OnBeforeStep_MarksHookStopped(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	var finalInfo FinishInfo
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(2),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithOnBeforeStep(func(info BeforeStepInfo) BeforeStepResult {
+			if info.Step == 2 {
+				return BeforeStepResult{Stop: true}
+			}
+			return BeforeStepResult{}
+		}),
+		WithOnFinish(func(fi FinishInfo) { finalInfo = fi }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.StepsExhausted {
+		t.Errorf("StepsExhausted=true; want false (OnBeforeStep.Stop at MaxSteps boundary)")
+	}
+	if finalInfo.StoppedBy != provider.StopCauseBeforeStep {
+		t.Errorf("FinishInfo.StoppedBy=%q want %q", finalInfo.StoppedBy, provider.StopCauseBeforeStep)
+	}
+}
+
+// TestWithStopWhen_StoppedByCause exercises FIX 5: the StopCause signal is
+// surfaced on FinishInfo and the final ChunkFinish for each termination
+// kind (natural, predicate, max-steps, before-step).
+func TestWithStopWhen_StoppedByCause(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	mkModel := func(cc *atomic.Int32, steps int) *mockModel {
+		return &mockModel{
+			id: "test",
+			generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+				n := cc.Add(1)
+				if int(n) < steps {
+					return &provider.GenerateResult{
+						ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "t", Input: json.RawMessage(`{}`)}},
+						FinishReason: provider.FinishToolCalls,
+						Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+					}, nil
+				}
+				return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}}, nil
+			},
+		}
+	}
+
+	type tc struct {
+		name  string
+		run   func() FinishInfo
+		stream bool
+		want  provider.StopCause
+	}
+	cases := []tc{
+		{
+			name: "natural",
+			want: provider.StopCauseNatural,
+			run: func() FinishInfo {
+				var cc atomic.Int32
+				var info FinishInfo
+				_, _ = GenerateText(t.Context(), mkModel(&cc, 2),
+					WithPrompt("go"), WithMaxSteps(5),
+					WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+					WithOnFinish(func(fi FinishInfo) { info = fi }),
+				)
+				return info
+			},
+		},
+		{
+			name: "predicate",
+			want: provider.StopCausePredicate,
+			run: func() FinishInfo {
+				var cc atomic.Int32
+				var info FinishInfo
+				_, _ = GenerateText(t.Context(), mkModel(&cc, 10),
+					WithPrompt("go"), WithMaxSteps(10),
+					WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+					WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 1 }),
+					WithOnFinish(func(fi FinishInfo) { info = fi }),
+				)
+				return info
+			},
+		},
+		{
+			name: "max-steps",
+			want: provider.StopCauseMaxSteps,
+			run: func() FinishInfo {
+				var cc atomic.Int32
+				var info FinishInfo
+				_, _ = GenerateText(t.Context(), mkModel(&cc, 100),
+					WithPrompt("go"), WithMaxSteps(2),
+					WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+					WithOnFinish(func(fi FinishInfo) { info = fi }),
+				)
+				return info
+			},
+		},
+		{
+			name: "before-step",
+			want: provider.StopCauseBeforeStep,
+			run: func() FinishInfo {
+				var cc atomic.Int32
+				var info FinishInfo
+				_, _ = GenerateText(t.Context(), mkModel(&cc, 10),
+					WithPrompt("go"), WithMaxSteps(5),
+					WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+					WithOnBeforeStep(func(info BeforeStepInfo) BeforeStepResult {
+						if info.Step == 2 {
+							return BeforeStepResult{Stop: true}
+						}
+						return BeforeStepResult{}
+					}),
+					WithOnFinish(func(fi FinishInfo) { info = fi }),
+				)
+				return info
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.run()
+			if got.StoppedBy != c.want {
+				t.Errorf("FinishInfo.StoppedBy=%q want %q", got.StoppedBy, c.want)
+			}
+		})
+	}
+
+	// Streaming parity: verify the final ChunkFinish carries StoppedBy for a
+	// predicate-driven break.
+	t.Run("stream-predicate", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		var cc atomic.Int32
+		streamModel := &mockModel{
+			id: "test-stream",
+			streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+				n := cc.Add(1)
+				return streamFromChunks(
+					provider.StreamChunk{Type: provider.ChunkText, Text: fmt.Sprintf("s%d", n)},
+					provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: fmt.Sprintf("tc%d", n), ToolName: "t", ToolInput: `{}`},
+					provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}},
+				), nil
+			},
+		}
+		stream, err := StreamText(t.Context(), streamModel,
+			WithPrompt("go"), WithMaxSteps(10),
+			WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+			WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 1 }),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var lastFinish provider.StreamChunk
+		for chunk := range stream.Stream() {
+			if chunk.Type == provider.ChunkFinish {
+				lastFinish = chunk
+			}
+		}
+		_ = stream.Result()
+		if lastFinish.StoppedBy != provider.StopCausePredicate {
+			t.Errorf("final ChunkFinish.StoppedBy=%q want %q", lastFinish.StoppedBy, provider.StopCausePredicate)
+		}
+	})
+}
+
+// TestWithStopWhen_PredicateSeesToolResults verifies FIX 7: the StopCondition
+// predicate sees ToolResults populated on the most recent step (not only
+// ToolCalls). The predicate stops iff the last step's tool result contains a
+// magic string. The model returns a tool call each step; the tool echoes an
+// input-driven token so the predicate can branch on outputs.
+func TestWithStopWhen_PredicateSeesToolResults(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				Text:         fmt.Sprintf("s%d", n),
+				ToolCalls:    []provider.ToolCall{{ID: fmt.Sprintf("tc%d", n), Name: "echo", Input: json.RawMessage(fmt.Sprintf(`{"v":%d}`, n))}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+
+	// Tool returns "STOP" on step 2 input, otherwise "continue".
+	echoTool := Tool{
+		Name: "echo",
+		Execute: func(_ context.Context, in json.RawMessage) (string, error) {
+			var v struct{ V int }
+			_ = json.Unmarshal(in, &v)
+			if v.V == 2 {
+				return "STOP-NOW", nil
+			}
+			return "continue", nil
+		},
+	}
+
+	var observed [][]provider.ToolResult
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(echoTool),
+		WithStopWhen(func(steps []StepResult) bool {
+			// Snapshot the last step's tool results so we can audit the
+			// predicate actually saw them.
+			last := steps[len(steps)-1]
+			observed = append(observed, append([]provider.ToolResult(nil), last.ToolResults...))
+			for _, r := range last.ToolResults {
+				if r.Output == "STOP-NOW" {
+					return true
+				}
+			}
+			return false
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("steps=%d want 2 (should stop after step 2)", len(result.Steps))
+	}
+	// Verify StepResult.ToolResults was populated on the final step.
+	last := result.Steps[len(result.Steps)-1]
+	if len(last.ToolResults) != 1 {
+		t.Fatalf("step[last].ToolResults len=%d want 1", len(last.ToolResults))
+	}
+	if last.ToolResults[0].Output != "STOP-NOW" {
+		t.Errorf("ToolResults[0].Output=%q want STOP-NOW", last.ToolResults[0].Output)
+	}
+	if last.ToolResults[0].ToolCallID != "tc2" {
+		t.Errorf("ToolResults[0].ToolCallID=%q want tc2", last.ToolResults[0].ToolCallID)
+	}
+	if last.ToolResults[0].IsError {
+		t.Errorf("ToolResults[0].IsError=true want false")
+	}
+	// Predicate saw both steps' outputs.
+	if len(observed) != 2 {
+		t.Errorf("predicate fired %d times, want 2", len(observed))
+	}
+}
+
+// TestWithStopWhen_PredicateSeesToolResults_Stream is the streaming-path
+// analog: verifies that StreamText also exposes ToolResults to the predicate
+// before the stop decision, matching the sync path.
+func TestWithStopWhen_PredicateSeesToolResults_Stream(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: fmt.Sprintf("s%d", n)},
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: fmt.Sprintf("tc%d", n), ToolName: "echo", ToolInput: fmt.Sprintf(`{"v":%d}`, n)},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}},
+			), nil
+		},
+	}
+	echoTool := Tool{
+		Name: "echo",
+		Execute: func(_ context.Context, in json.RawMessage) (string, error) {
+			var v struct{ V int }
+			_ = json.Unmarshal(in, &v)
+			if v.V == 2 {
+				return "STOP-NOW", nil
+			}
+			return "continue", nil
+		},
+	}
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(echoTool),
+		WithStopWhen(func(steps []StepResult) bool {
+			last := steps[len(steps)-1]
+			for _, r := range last.ToolResults {
+				if r.Output == "STOP-NOW" {
+					return true
+				}
+			}
+			return false
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.Stream() {
+	}
+	res := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Steps) != 2 {
+		t.Fatalf("stream steps=%d want 2", len(res.Steps))
+	}
+	last := res.Steps[len(res.Steps)-1]
+	if len(last.ToolResults) != 1 || last.ToolResults[0].Output != "STOP-NOW" {
+		t.Errorf("stream step[last].ToolResults=%#v want one STOP-NOW entry", last.ToolResults)
+	}
+}
+
+// TestWithStopWhen_ReplaySafety_ParallelTools verifies that when a single step
+// requests MULTIPLE tool calls in parallel and the predicate fires after that
+// step, every tool_use has a paired tool_result in ResponseMessages (strict
+// Anthropic-style replay validation). Also asserts ToolResults has one entry
+// per call in the same order.
+func TestWithStopWhen_ReplaySafety_ParallelTools(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text: "parallel",
+				ToolCalls: []provider.ToolCall{
+					{ID: "tcA", Name: "t", Input: json.RawMessage(`{"n":1}`)},
+					{ID: "tcB", Name: "t", Input: json.RawMessage(`{"n":2}`)},
+					{ID: "tcC", Name: "t", Input: json.RawMessage(`{"n":3}`)},
+				},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+	first, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{Name: "t", Execute: func(_ context.Context, in json.RawMessage) (string, error) {
+			return "ok:" + string(in), nil
+		}}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 1 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert ToolResults parity with ToolCalls, element-for-element.
+	last := first.Steps[len(first.Steps)-1]
+	if len(last.ToolResults) != 3 {
+		t.Fatalf("ToolResults len=%d want 3", len(last.ToolResults))
+	}
+	for i, want := range []string{"tcA", "tcB", "tcC"} {
+		if last.ToolResults[i].ToolCallID != want {
+			t.Errorf("ToolResults[%d].ToolCallID=%q want %q", i, last.ToolResults[i].ToolCallID, want)
+		}
+		if last.ToolResults[i].IsError {
+			t.Errorf("ToolResults[%d].IsError=true", i)
+		}
+	}
+
+	if err := validateReplayStrict(first.ResponseMessages); err != nil {
+		t.Fatalf("parallel-tool ResponseMessages not replay-safe: %v", err)
+	}
+	// Sanity: replay against a strict mock that validates incoming messages.
+	var innerErr error
+	strict := &mockModel{
+		id: "strict",
+		generateFn: func(_ context.Context, p provider.GenerateParams) (*provider.GenerateResult, error) {
+			if err := validateReplayStrict(p.Messages); err != nil {
+				innerErr = err
+				return nil, err
+			}
+			return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}}, nil
+		},
+	}
+	msgs := append([]provider.Message{}, first.ResponseMessages...)
+	msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "go on"}}})
+	if _, err := GenerateText(t.Context(), strict, WithMessages(msgs...)); err != nil {
+		t.Fatalf("parallel-tool replay failed: %v (inner=%v)", err, innerErr)
+	}
+}
+
+// TestWithStopWhen_ReplaySafety_MultiRound verifies replay safety across
+// MULTIPLE rounds of parallel tool calls before the predicate fires. Three
+// rounds, each with 2 parallel tool calls; predicate stops after round 3.
+// The full transcript must have all 6 tool_use IDs paired.
+func TestWithStopWhen_ReplaySafety_MultiRound(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			n := callCount.Add(1)
+			return &provider.GenerateResult{
+				Text: fmt.Sprintf("round %d", n),
+				ToolCalls: []provider.ToolCall{
+					{ID: fmt.Sprintf("r%d-a", n), Name: "t", Input: json.RawMessage(`{}`)},
+					{ID: fmt.Sprintf("r%d-b", n), Name: "t", Input: json.RawMessage(`{}`)},
+				},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+	first, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 3 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Steps) != 3 {
+		t.Fatalf("steps=%d want 3", len(first.Steps))
+	}
+	// Every step must carry ToolResults (len==2).
+	for i, s := range first.Steps {
+		if len(s.ToolResults) != 2 {
+			t.Errorf("step[%d].ToolResults len=%d want 2", i, len(s.ToolResults))
+		}
+	}
+
+	if err := validateReplayStrict(first.ResponseMessages); err != nil {
+		t.Fatalf("multi-round ResponseMessages not replay-safe: %v", err)
+	}
+}
+
+// TestWithStopWhen_ReplaySafety_ParallelTools_Stream is the streaming-path
+// analog of TestWithStopWhen_ReplaySafety_ParallelTools: a single step with
+// multiple parallel tool calls, predicate stops after that step. Enforces
+// the full Anthropic-style invariants via validateReplayStrict on
+// TextResult.ResponseMessages drained from stream.Result().
+func TestWithStopWhen_ReplaySafety_ParallelTools_Stream(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "parallel"},
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tcA", ToolName: "t", ToolInput: `{"n":1}`},
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tcB", ToolName: "t", ToolInput: `{"n":2}`},
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tcC", ToolName: "t", ToolInput: `{"n":3}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}},
+			), nil
+		},
+	}
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),
+		WithTools(Tool{Name: "t", Execute: func(_ context.Context, in json.RawMessage) (string, error) {
+			return "ok:" + string(in), nil
+		}}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 1 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.Stream() {
+	}
+	res := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+	// Assert element-for-element ToolResults parity on the last step.
+	last := res.Steps[len(res.Steps)-1]
+	if len(last.ToolResults) != 3 {
+		t.Fatalf("stream ToolResults len=%d want 3", len(last.ToolResults))
+	}
+	for i, want := range []string{"tcA", "tcB", "tcC"} {
+		if last.ToolResults[i].ToolCallID != want {
+			t.Errorf("stream ToolResults[%d].ToolCallID=%q want %q", i, last.ToolResults[i].ToolCallID, want)
+		}
+	}
+	if err := validateReplayStrict(res.ResponseMessages); err != nil {
+		t.Fatalf("stream parallel-tool ResponseMessages not replay-safe: %v", err)
+	}
+}
+
+// TestWithStopWhen_ReplaySafety_MultiRound_Stream is the streaming-path
+// analog of TestWithStopWhen_ReplaySafety_MultiRound: three rounds of two
+// parallel tool calls each, predicate stops after round 3. The full
+// transcript (6 tool_use IDs) must pass validateReplayStrict.
+func TestWithStopWhen_ReplaySafety_MultiRound_Stream(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var callCount atomic.Int32
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			n := callCount.Add(1)
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: fmt.Sprintf("round %d", n)},
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: fmt.Sprintf("r%d-a", n), ToolName: "t", ToolInput: `{}`},
+				provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: fmt.Sprintf("r%d-b", n), ToolName: "t", ToolInput: `{}`},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}},
+			), nil
+		},
+	}
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(10),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithStopWhen(func(steps []StepResult) bool { return len(steps) >= 3 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.Stream() {
+	}
+	res := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Steps) != 3 {
+		t.Fatalf("stream steps=%d want 3", len(res.Steps))
+	}
+	for i, s := range res.Steps {
+		if len(s.ToolResults) != 2 {
+			t.Errorf("stream step[%d].ToolResults len=%d want 2", i, len(s.ToolResults))
+		}
+	}
+	if err := validateReplayStrict(res.ResponseMessages); err != nil {
+		t.Fatalf("stream multi-round ResponseMessages not replay-safe: %v", err)
+	}
+}
+
+// TestStopCauseEmpty_StreamEmptyProviderResponse verifies FIX 9: when the
+// provider closes its stream without emitting any chunks (no text, no tool
+// calls, no finish_reason), goai exits the tool loop with StopCauseEmpty --
+// NOT StopCauseAbort (which is reserved for real error paths).
+func TestStopCauseEmpty_StreamEmptyProviderResponse(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			// Close immediately with no chunks at all.
+			ch := make(chan provider.StreamChunk)
+			close(ch)
+			return &provider.StreamResult{Stream: ch}, nil
+		},
+	}
+	var finishInfo FinishInfo
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+		WithOnFinish(func(fi FinishInfo) { finishInfo = fi }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lastFinish provider.StreamChunk
+	for chunk := range stream.Stream() {
+		if chunk.Type == provider.ChunkFinish {
+			lastFinish = chunk
+		}
+	}
+	_ = stream.Result()
+	if lastFinish.StoppedBy != provider.StopCauseEmpty {
+		t.Errorf("final ChunkFinish.StoppedBy=%q want %q", lastFinish.StoppedBy, provider.StopCauseEmpty)
+	}
+	if finishInfo.StoppedBy != provider.StopCauseEmpty {
+		t.Errorf("FinishInfo.StoppedBy=%q want %q", finishInfo.StoppedBy, provider.StopCauseEmpty)
+	}
+}
+
+// TestStopCauseNoExecutableTools verifies FIX 11: when the model returns tool
+// calls but no tool in the configured set has an Execute function, the sync
+// loop exits cleanly with StopCauseNoExecutableTools - distinguishing it from
+// StopCauseNatural ("model stopped on its own").
+//
+// Emission scope: StopCauseNoExecutableTools is sync-only (GenerateText).
+// The streaming tool-loop (streamWithToolLoop) is only entered when at least
+// one executable tool is configured, so the cause is unreachable from that
+// path; a streaming call with zero executable tools takes the single-shot
+// path and reports StopCauseNatural. This is intentional and documented on
+// the StopCauseNoExecutableTools constant godoc.
+func TestStopCauseNoExecutableTools(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         "calling",
+				ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "declared", Input: json.RawMessage(`{}`)}},
+				FinishReason: provider.FinishToolCalls,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+	var fi FinishInfo
+	// Tool is declared (for model awareness) but has no Execute - so toolMap
+	// is empty. goai must exit with NoExecutableTools, not Natural.
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{Name: "declared"}), // no Execute
+		WithOnFinish(func(info FinishInfo) { fi = info }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.StoppedBy != provider.StopCauseNoExecutableTools {
+		t.Errorf("FinishInfo.StoppedBy=%q want %q", fi.StoppedBy, provider.StopCauseNoExecutableTools)
+	}
+}
+
+// TestStopCauseNatural_MaxStepsOne_EmptyResponse_SingleShot locks in the
+// documented behavior (FIX 32 / FIX 38) for the streaming single-shot
+// branch when the provider emits zero chunks: the loop exits cleanly
+// with StopCauseNatural - NOT StopCauseEmpty (which is reserved for the
+// multi-step tool-loop path; see provider.StopCauseEmpty godoc), NOT
+// StopCauseMaxSteps, NOT StopCauseAbort - and leaks no goroutines.
+//
+// MaxSteps=1 (or zero executable tools) bypasses streamWithToolLoop
+// entirely, so the classification is whatever the single-shot defer
+// hardcodes. Today that defer emits StopCauseNatural unconditionally.
+// A latent semantic TODO (should empty single-shot streams emit
+// StopCauseEmpty for symmetry with the multi-step path?) is tracked
+// below; if the defer is ever changed, this test breaks and the change
+// must be reviewed jointly with provider/types.go StopCauseEmpty godoc
+// and the plan doc §1.5.
+//
+// Originally named TestStopCauseEmpty_MaxStepsOne_EmptyResponse --
+// renamed FIX 37 to match the actual asserted behavior; the old name
+// implied StopCauseEmpty was expected here, which contradicted the
+// assertion body.
+func TestStopCauseNatural_MaxStepsOne_EmptyResponse_SingleShot(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			ch := make(chan provider.StreamChunk)
+			close(ch)
+			return &provider.StreamResult{Stream: ch}, nil
+		},
+	}
+	var finishInfo FinishInfo
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(1),
+		// No tools: forces the MaxSteps=1 single-shot branch.
+		WithOnFinish(func(fi FinishInfo) { finishInfo = fi }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lastFinish provider.StreamChunk
+	chunkCount := 0
+	for chunk := range stream.Stream() {
+		chunkCount++
+		if chunk.Type == provider.ChunkFinish {
+			lastFinish = chunk
+		}
+	}
+	res := stream.Result()
+	if err := stream.Err(); err != nil {
+		t.Fatalf("unexpected stream Err: %v", err)
+	}
+	// The single-shot path does not classify "empty" streams - only the
+	// multi-step loop emits StopCauseEmpty. In MaxSteps=1 the loop is
+	// bypassed entirely, so StoppedBy on ChunkFinish (the provider's
+	// chunk, absent in this case) stays empty and OnFinish fires with
+	// StopCauseNatural (the default for single-shot streaming; hardcoded
+	// in generate.go ~line 280).
+	//
+	// FIX 32: positive assertion locks in current behavior.
+	// TODO(stopcause-semantics): StopCauseNatural semantically means
+	// "model stopped on its own"; an empty-chunk stream is arguably
+	// better classified as StopCauseEmpty here too. Keeping the
+	// single-shot path simple for now - revisit if consumers report
+	// ambiguity. If this assertion breaks, also review the
+	// hardcoded StopCauseNatural at generate.go `fireOnFinish`.
+	if finishInfo.StoppedBy != provider.StopCauseNatural {
+		t.Errorf("FinishInfo.StoppedBy=%q; want %q (single-shot empty stream hardcodes natural)",
+			finishInfo.StoppedBy, provider.StopCauseNatural)
+	}
+	// Defense-in-depth: the specific wrong classifications we must never emit.
+	if finishInfo.StoppedBy == provider.StopCauseMaxSteps {
+		t.Errorf("FinishInfo.StoppedBy=max-steps; must not be overwritten on empty single-shot")
+	}
+	if finishInfo.StoppedBy == provider.StopCauseAbort {
+		t.Errorf("FinishInfo.StoppedBy=abort on empty single-shot; want non-abort (clean exit)")
+	}
+	// lastFinish is the zero StreamChunk because the provider emitted none;
+	// chunkCount must be 0.
+	if chunkCount != 0 {
+		t.Errorf("chunkCount=%d; empty stream should emit 0 chunks, got lastFinish=%+v", chunkCount, lastFinish)
+	}
+	if len(res.Steps) != 0 {
+		t.Errorf("len(Steps)=%d; MaxSteps=1 empty single-shot should produce 0 steps", len(res.Steps))
+	}
+}
+
+// TestAgentState_SetNegativeStepPanics verifies FIX 26: AgentState.set
+// panics on a negative step rather than silently clamping to 0. Silent
+// clamps hid real bugs in earlier iterations; a panic makes the internal
+// invariant violation loud. Callers inside goai never pass negatives.
+func TestAgentState_SetNegativeStepPanics(t *testing.T) {
+	var s AgentState
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("AgentState.set(-1) did not panic")
+		}
+		// FIX 31: panic value is now an error (was a string). Using error
+		// allows errors.Is / errors.As at the recovery site; more idiomatic.
+		err, ok := r.(error)
+		if !ok {
+			t.Fatalf("panic value is not an error: %T %v", r, r)
+		}
+		if !strings.Contains(err.Error(), "negative step") {
+			t.Errorf("panic message = %q; want it to contain %q", err.Error(), "negative step")
+		}
+	}()
+	s.set(StepLLMInFlight, -1)
+}
+
+// TestAgentState_NilModel_StillIdle verifies FIX 27: GenerateText and
+// StreamText must transition a caller-provided AgentState to StepIdle even
+// when they early-return on nil model. Otherwise a poller waiting for
+// StepIdle would deadlock.
+func TestAgentState_NilModel_StillIdle_Generate(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	var state AgentState
+	_, err := GenerateText(t.Context(), nil,
+		WithPrompt("hi"),
+		WithStateRef(&state),
+	)
+	if err == nil {
+		t.Fatal("GenerateText(nil model) must return error")
+	}
+	if !strings.Contains(err.Error(), "model must not be nil") {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	kind, _ := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state=%v; want StepIdle after nil-model early return", kind)
+	}
+}
+
+func TestAgentState_NilModel_StillIdle_Stream(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	var state AgentState
+	_, err := StreamText(t.Context(), nil,
+		WithPrompt("hi"),
+		WithStateRef(&state),
+	)
+	if err == nil {
+		t.Fatal("StreamText(nil model) must return error")
+	}
+	if !strings.Contains(err.Error(), "model must not be nil") {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	kind, _ := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state=%v; want StepIdle after nil-model early return", kind)
+	}
+}
+
+// TestAgentState_EmptyPrompt_StillIdle covers the other pre-loop early
+// return (prompt/messages validation). FIX 27 already handled this path;
+// we lock it in with an explicit test.
+func TestAgentState_EmptyPrompt_StillIdle_Generate(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	var state AgentState
+	model := &mockModel{id: "m"}
+	_, err := GenerateText(t.Context(), model, WithStateRef(&state))
+	if err == nil {
+		t.Fatal("GenerateText(empty prompt) must return error")
+	}
+	kind, _ := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state=%v; want StepIdle after empty-prompt early return", kind)
+	}
+}
+
+func TestAgentState_EmptyPrompt_StillIdle_Stream(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	var state AgentState
+	model := &mockModel{id: "m"}
+	_, err := StreamText(t.Context(), model, WithStateRef(&state))
+	if err == nil {
+		t.Fatal("StreamText(empty prompt) must return error")
+	}
+	kind, _ := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state=%v; want StepIdle after empty-prompt early return", kind)
+	}
+}
+
+// TestStopSafe_AliasingContract documents FIX 30 as refined by FIX 36:
+// stopSafe passes a shallow clone to the predicate. We assert TWO things
+// about the resulting safety surface, so the test is actually
+// load-bearing (rather than just re-asserting stdlib slices.Clone):
+//
+//  1. Top-level mutations (zero-out / reslice / append) are isolated.
+//     This is the safety guarantee stopSafe provides on purpose.
+//  2. Nested-slice mutations (StepResult.ToolCalls / ToolResults
+//     element-writes) DO propagate to goai's internal state. This is
+//     documented as a contract violation in WithStopWhen's godoc; the
+//     test pins the actual behavior so a future deep-clone refactor
+//     updates both the test and the godoc together.
+//
+// Without assertion #2 this test was tautological - it only re-tested
+// stdlib `slices.Clone`'s documented behavior. The hazardous case (#2)
+// is now exercised explicitly so the contract is visible from the
+// test suite and accidental deep-clone regressions are caught.
+func TestStopSafe_AliasingContract_ShallowCloneIsolatesTopLevel(t *testing.T) {
+	// Populate nested slices with sentinel payloads so we can check
+	// whether a predicate mutation to nested elements leaked back.
+	originalCall := provider.ToolCall{ID: "call_1", Name: "orig", Input: json.RawMessage(`{}`)}
+	originalResult := provider.ToolResult{ToolCallID: "call_1", ToolName: "orig", Output: "original"}
+	internal := []StepResult{
+		{
+			Number:      1,
+			Text:        "a",
+			ToolCalls:   []provider.ToolCall{originalCall},
+			ToolResults: []provider.ToolResult{originalResult},
+		},
+		{Number: 2, Text: "b"},
+	}
+	called := false
+	pred := StopCondition(func(steps []StepResult) bool {
+		called = true
+		// (1) Top-level header mutations - must NOT propagate.
+		for i := range steps {
+			// Copy before zeroing so the nested-slice pointer we need
+			// in step (2) is still reachable via the clone element.
+			_ = steps[i]
+		}
+		// Reslice / append / zero; these operations may only affect
+		// the predicate's local view of the slice header, never the
+		// caller's `internal`.
+		steps[0].Text = "CLOBBER_TOP_LEVEL"
+		steps = append(steps[:0], StepResult{Number: 999, Text: "clobber"})
+		_ = steps
+		return false
+	})
+	stop := stopSafe(pred, internal)
+	if stop {
+		t.Fatalf("stopSafe returned true; predicate returned false")
+	}
+	if !called {
+		t.Fatalf("predicate not invoked")
+	}
+	// (1a) Len untouched - resize did NOT leak.
+	if len(internal) != 2 {
+		t.Fatalf("internal len=%d; want 2 (shallow-clone did not isolate resize)", len(internal))
+	}
+	// (1b) The top-level field write - into a StepResult the clone
+	// copied by value - must NOT be visible on internal.
+	if internal[0].Number != 1 || internal[0].Text != "a" {
+		t.Errorf("internal[0]=%+v; want {Number:1 Text:a} - top-level mutation leaked", internal[0])
+	}
+	if internal[1].Number != 2 || internal[1].Text != "b" {
+		t.Errorf("internal[1]=%+v; want {Number:2 Text:b} - top-level mutation leaked", internal[1])
+	}
+
+	// (2) Nested-slice aliasing - hazardous contract. Run a SECOND
+	// predicate invocation that intentionally mutates a nested slice
+	// element. Assert mutation DOES propagate. This proves the
+	// aliasing is real and motivates the WithStopWhen godoc "treat
+	// contents as read-only" warning.
+	hazardous := StopCondition(func(steps []StepResult) bool {
+		if len(steps) > 0 && len(steps[0].ToolResults) > 0 {
+			// Mutate the element of the nested slice (not the header).
+			// The clone shares this backing array - the write is
+			// visible on the caller side.
+			steps[0].ToolResults[0].Output = "CORRUPTED_BY_PREDICATE"
+		}
+		return false
+	})
+	if stopSafe(hazardous, internal) {
+		t.Fatalf("hazardous predicate returned false but stopSafe reported true")
+	}
+	if got := internal[0].ToolResults[0].Output; got != "CORRUPTED_BY_PREDICATE" {
+		t.Fatalf("nested mutation did NOT propagate (got Output=%q); stopSafe must still use SHALLOW clone per FIX 30 / FIX 36 godoc. If you intentionally moved to deep clone, update this test AND provider/WithStopWhen godoc.", got)
+	}
+	// Reset for test hygiene - do NOT leave the corrupted sentinel
+	// visible to any later assertions in this function.
+	internal[0].ToolResults[0].Output = originalResult.Output
+}
+
+// ---------------------------------------------------------------------------
+// FIX 34 - StreamText single-shot StateRef wiring tests.
+// ---------------------------------------------------------------------------
+
+// TestAgentState_StreamText_SingleShot_ReachesIdle exercises the single-shot
+// streaming path (MaxSteps=1, no executable tools) and asserts the
+// AgentState transitions through StepStarting → StepLLMInFlight → StepIdle
+// without deadlocking pollers. Before FIX 34 the single-shot path never
+// touched StateRef, leaving pollers stuck at (StepStarting, 0) indefinitely.
+func TestAgentState_StreamText_SingleShot_ReachesIdle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hi"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+	var state AgentState
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(1),
+		WithStateRef(&state),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Consume the stream to close.
+	for range stream.Stream() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatalf("unexpected stream Err: %v", err)
+	}
+	kind, step := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state kind=%v; want StepIdle after single-shot drain", kind)
+	}
+	if step != 1 {
+		t.Errorf("state step=%d; want 1 (single step completed)", step)
+	}
+}
+
+// TestAgentState_StreamText_SingleShot_EmptyStream_ReachesIdle is the
+// empty-stream companion to FIX 34. A provider that emits zero chunks still
+// must leave AgentState at StepIdle (otherwise pollers deadlock).
+func TestAgentState_StreamText_SingleShot_EmptyStream_ReachesIdle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			ch := make(chan provider.StreamChunk)
+			close(ch)
+			return &provider.StreamResult{Stream: ch}, nil
+		},
+	}
+	var state AgentState
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(1),
+		WithStateRef(&state),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = stream.Result()
+	kind, _ := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state kind=%v; want StepIdle after empty single-shot stream", kind)
+	}
+}
+
+// TestAgentState_StreamText_SingleShot_DoStreamError_ReachesIdle covers the
+// other inline return path in FIX 34: DoStream failing before the consume
+// goroutine starts. Pollers waiting for StepIdle must still be released.
+func TestAgentState_StreamText_SingleShot_DoStreamError_ReachesIdle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	wantErr := errors.New("upstream boom")
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return nil, wantErr
+		},
+	}
+	var state AgentState
+	_, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(1),
+		WithStateRef(&state),
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err=%v; want wrapping wantErr", err)
+	}
+	kind, step := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state kind=%v; want StepIdle after DoStream error", kind)
+	}
+	// FIX 47: step=1 (not 0) - StreamText advertised (StepLLMInFlight, 1)
+	// before the DoStream call; the post-error StepIdle must preserve the
+	// same step count to keep the step counter monotonically non-decreasing.
+	if step != 1 {
+		t.Errorf("state step=%d; want 1 (monotonic: LLMInFlight=1 → Idle=1)", step)
+	}
+}
+
+// TestAgentState_StreamText_SingleShot_NoTools_ReachesIdle exercises the
+// alternative trigger for the single-shot path: tools are supplied but none
+// has an Execute function, which also bypasses streamWithToolLoop.
+func TestAgentState_StreamText_SingleShot_NoTools_ReachesIdle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "ok"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+	var state AgentState
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(5),                   // >1, but toolMap will be empty
+		WithTools(Tool{Name: "declared"}), // no Execute - bypasses tool loop
+		WithStateRef(&state),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = stream.Result()
+	kind, _ := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state kind=%v; want StepIdle (single-shot path via no-executable-tools)", kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FIX 35 - GenerateObject / StreamObject emit WithStateRef warning.
+// ---------------------------------------------------------------------------
+
+// TestGenerateObject_StateRefIgnored_Warns verifies FIX 35: passing
+// WithStateRef to GenerateObject emits a one-shot stderr warning (per
+// process per entry point) and otherwise proceeds as if StateRef were
+// absent. This mirrors the FIX 12 / FIX 21 pattern used for WithStopWhen.
+func TestGenerateObject_StateRefIgnored_Warns(t *testing.T) {
+	// Reset the once flag so this test sees a fresh atomic.Bool.
+	// Pattern matches FIX 33 caveat: tests that reset these flags do
+	// NOT use t.Parallel().
+	generateObjectStateRefWarned.Store(false)
+	var captured strings.Builder
+	orig := warnStateRefIgnoredForObject
+	t.Cleanup(func() { warnStateRefIgnoredForObject = orig })
+	warnStateRefIgnoredForObject = func(fn string) {
+		fmt.Fprintf(&captured, "warn:%s\n", fn)
+	}
+	// Not invoking the real function - just verify that GenerateObject
+	// reaches the warn site. A mock model that returns an error keeps
+	// the test hermetic (no real provider call / schema handling).
+	model := &mockModel{
+		id: "t",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return nil, errors.New("mock short-circuit")
+		},
+	}
+	var state AgentState
+	type payload struct {
+		X int `json:"x"`
+	}
+	_, _ = GenerateObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStateRef(&state),
+	)
+	if !strings.Contains(captured.String(), "warn:GenerateObject") {
+		t.Errorf("expected warn:GenerateObject; got %q", captured.String())
+	}
+	// Second call with the same swapped warn: our replacement fires
+	// every call (no once-check inside the mock), which is fine - the
+	// real defaultWarnStateRefIgnoredForObject uses CompareAndSwap so
+	// it fires at most once per process. We cover that in the next
+	// sub-test below using the default warn.
+	captured.Reset()
+	_, _ = GenerateObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStateRef(&state),
+	)
+	if !strings.Contains(captured.String(), "warn:GenerateObject") {
+		t.Errorf("expected warn:GenerateObject on second call too (test double fires every call); got %q", captured.String())
+	}
+}
+
+// TestStreamObject_StateRefIgnored_Warns mirrors the GenerateObject test for
+// the streaming structured-output entry point.
+func TestStreamObject_StateRefIgnored_Warns(t *testing.T) {
+	streamObjectStateRefWarned.Store(false)
+	var captured strings.Builder
+	orig := warnStateRefIgnoredForObject
+	t.Cleanup(func() { warnStateRefIgnoredForObject = orig })
+	warnStateRefIgnoredForObject = func(fn string) {
+		fmt.Fprintf(&captured, "warn:%s\n", fn)
+	}
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return nil, errors.New("mock short-circuit")
+		},
+	}
+	var state AgentState
+	type payload struct {
+		X int `json:"x"`
+	}
+	_, _ = StreamObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStateRef(&state),
+	)
+	if !strings.Contains(captured.String(), "warn:StreamObject") {
+		t.Errorf("expected warn:StreamObject; got %q", captured.String())
+	}
+}
+
+// TestAgentState_Observe_NilReceiver covers the nil-receiver safety path
+// (documented contract: a nil *AgentState Observe returns the zero state).
+// Spike FIX 41 coverage pass - previously uncovered.
+func TestAgentState_Observe_NilReceiver(t *testing.T) {
+	var s *AgentState
+	kind, step := s.Observe()
+	if kind != StepStarting || step != 0 {
+		t.Errorf("nil-receiver Observe()=(%v,%d); want (StepStarting,0)", kind, step)
+	}
+}
+
+// TestStepKind_String covers the StepKind.String() humanizer. Spike
+// FIX 41 coverage pass - previously at 0%.
+func TestStepKind_String(t *testing.T) {
+	cases := map[StepKind]string{
+		StepStarting:      "starting",
+		StepLLMInFlight:   "llm-in-flight",
+		StepStepFinished:  "step-finished",
+		StepToolExecuting: "tool-executing",
+		StepIdle:          "idle",
+		StepKind(999):     "unknown",
+	}
+	for k, want := range cases {
+		if got := k.String(); got != want {
+			t.Errorf("StepKind(%d).String()=%q; want %q", int(k), got, want)
+		}
+	}
+}
+
+// TestDefaultWarnStateRefIgnored_AllBranches covers StreamObject + default
+// fn-name branches of defaultWarnStateRefIgnoredForObject to complete
+// coverage of the warn switch. GenerateObject is covered by the sibling
+// TestGenerateObject_StateRefWarn_OnceDefault.
+func TestDefaultWarnStateRefIgnored_AllBranches(t *testing.T) {
+	streamObjectStateRefWarned.Store(false)
+	origStderr := osStderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	osStderr = w
+	t.Cleanup(func() { osStderr = origStderr })
+
+	// StreamObject branch - CAS once.
+	defaultWarnStateRefIgnoredForObject("StreamObject")
+	defaultWarnStateRefIgnoredForObject("StreamObject")
+	// Default branch (unreachable in production, guarded in tests) --
+	// fires unconditionally.
+	defaultWarnStateRefIgnoredForObject("UnknownEntryPoint")
+	_ = w.Close()
+
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+	got := buf.String()
+	if n := strings.Count(got, "WithStateRef is not supported in StreamObject"); n != 1 {
+		t.Errorf("StreamObject warn count=%d; want 1", n)
+	}
+	if !strings.Contains(got, "WithStateRef is not supported in UnknownEntryPoint") {
+		t.Errorf("default-branch warn missing; got %q", got)
+	}
+}
+
+// TestGenerateObject_StateRefWarn_OnceDefault exercises the real
+// defaultWarnStateRefIgnoredForObject path and verifies the CAS-guarded
+// once-per-process semantics by redirecting osStderr to a pipe.
+func TestGenerateObject_StateRefWarn_OnceDefault(t *testing.T) {
+	// Reset both once flags so counters start clean. Matches FIX 33
+	// reset caveat: no t.Parallel() on this or its siblings.
+	generateObjectStateRefWarned.Store(false)
+	streamObjectStateRefWarned.Store(false)
+
+	// Swap osStderr for a pipe so we can capture writes.
+	origStderr := osStderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	osStderr = w
+	t.Cleanup(func() { osStderr = origStderr })
+
+	// Call the default warn twice; second call must be a no-op.
+	defaultWarnStateRefIgnoredForObject("GenerateObject")
+	defaultWarnStateRefIgnoredForObject("GenerateObject")
+	_ = w.Close()
+
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+
+	got := buf.String()
+	want := "goai: WithStateRef is not supported in GenerateObject"
+	if !strings.Contains(got, want) {
+		t.Fatalf("warning missing; got %q want substring %q", got, want)
+	}
+	// Exactly one occurrence - CompareAndSwap blocks the second.
+	if n := strings.Count(got, want); n != 1 {
+		t.Errorf("warning fired %d times; want 1 (CAS-guarded once)", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FIX 44 - ctx-cancel mid-stream on single-shot + StateRef reaches Idle.
+// ---------------------------------------------------------------------------
+
+// TestAgentState_StreamText_SingleShot_CtxCancel_ReachesIdle verifies that
+// when the caller cancels ctx mid-stream on a single-shot StreamText call
+// wired with WithStateRef, the consume goroutine still terminates cleanly
+// and publishes StepIdle so pollers are not stuck at StepLLMInFlight. No
+// goroutine leak.
+func TestAgentState_StreamText_SingleShot_CtxCancel_ReachesIdle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Provider stream emits chunks then closes. We use Result() (nil/nil
+	// branch in consume) so consume checks ctx.Err() after each chunk.
+	// Cancel ctx before consume runs; when consume processes the first
+	// chunk and hits its post-switch ctx check, it returns - advancing
+	// StateRef to StepIdle.
+	providerCh := make(chan provider.StreamChunk, 2)
+	providerCh <- provider.StreamChunk{Type: provider.ChunkText, Text: "hi"}
+	providerCh <- provider.StreamChunk{Type: provider.ChunkText, Text: "post-cancel"}
+	close(providerCh)
+
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return &provider.StreamResult{Stream: providerCh}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var state AgentState
+	stream, err := StreamText(ctx, model,
+		WithPrompt("go"),
+		WithMaxSteps(1),
+		WithStateRef(&state),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel ctx before Result() starts consume. consume's per-iteration
+	// nil/nil branch will observe ctx.Err() != nil after processing the
+	// first chunk and return early, exercising the mid-stream-cancel
+	// StepIdle transition.
+	cancel()
+	_ = stream.Result()
+	// Err must surface the ctx error.
+	if gotErr := stream.Err(); !errors.Is(gotErr, context.Canceled) {
+		t.Errorf("stream.Err()=%v; want context.Canceled", gotErr)
+	}
+
+	kind, step := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state kind=%v; want StepIdle after ctx-cancel mid-stream", kind)
+	}
+	if step != 1 {
+		t.Errorf("state step=%d; want 1 (monotonic: StepLLMInFlight=1 → StepIdle=1)", step)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FIX 45 - mid-stream ChunkError on single-shot still reaches Idle.
+// ---------------------------------------------------------------------------
+
+// TestAgentState_StreamText_SingleShot_ChunkError_ReachesIdle verifies that
+// a provider emitting a ChunkError mid-stream leaves AgentState at
+// StepIdle and does not leak the consume goroutine.
+func TestAgentState_StreamText_SingleShot_ChunkError_ReachesIdle(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	boom := errors.New("mid-stream boom")
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "partial"},
+				provider.StreamChunk{Type: provider.ChunkError, Error: boom},
+				// No ChunkFinish - provider aborted.
+			), nil
+		},
+	}
+
+	var state AgentState
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(1),
+		WithStateRef(&state),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.Stream() {
+	}
+	// stream.Err() should surface the mid-stream error.
+	if gotErr := stream.Err(); !errors.Is(gotErr, boom) {
+		t.Errorf("stream.Err()=%v; want %v", gotErr, boom)
+	}
+	kind, step := state.Observe()
+	if kind != StepIdle {
+		t.Errorf("state kind=%v; want StepIdle after mid-stream ChunkError", kind)
+	}
+	if step != 1 {
+		t.Errorf("state step=%d; want 1 (monotonic; single-shot stream step is 1)", step)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FIX 46 - combined WithStopWhen + WithStateRef independent warnings.
+// ---------------------------------------------------------------------------
+
+// TestGenerateObject_BothWarnings_FireOnceEach_WhenBothPassed verifies that
+// passing BOTH WithStopWhen and WithStateRef in the SAME call emits BOTH
+// warnings once each (idempotent across a second call). Compare with
+// TestGenerateObject_Warnings_LatchesAreIndependent below, which exercises
+// cross-latch independence (one option at a time across calls).
+func TestGenerateObject_BothWarnings_FireOnceEach_WhenBothPassed(t *testing.T) {
+	// Reset both latches (FIX 33 caveat - no t.Parallel).
+	generateObjectStopWhenWarned.Store(false)
+	generateObjectStateRefWarned.Store(false)
+
+	origStderr := osStderr
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		t.Fatalf("pipe: %v", perr)
+	}
+	osStderr = w
+	t.Cleanup(func() { osStderr = origStderr })
+
+	model := &mockModel{
+		id: "t",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return nil, errors.New("mock short-circuit")
+		},
+	}
+	var state AgentState
+	type payload struct {
+		X int `json:"x"`
+	}
+
+	// First call: both warnings fire.
+	_, _ = GenerateObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+		WithStateRef(&state),
+	)
+	// Second call: both latches already tripped - zero additional warnings.
+	_, _ = GenerateObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+		WithStateRef(&state),
+	)
+
+	_ = w.Close()
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+	got := buf.String()
+
+	stopWhenWant := "goai: WithStopWhen is not supported in GenerateObject"
+	stateRefWant := "goai: WithStateRef is not supported in GenerateObject"
+	if n := strings.Count(got, stopWhenWant); n != 1 {
+		t.Errorf("WithStopWhen warning fired %d times across 2 calls; want 1; full stderr=%q", n, got)
+	}
+	if n := strings.Count(got, stateRefWant); n != 1 {
+		t.Errorf("WithStateRef warning fired %d times across 2 calls; want 1; full stderr=%q", n, got)
+	}
+}
+
+// TestStreamObject_BothWarnings_FireOnceEach_WhenBothPassed is the StreamObject
+// twin of the GenerateObject both-warnings test above.
+func TestStreamObject_BothWarnings_FireOnceEach_WhenBothPassed(t *testing.T) {
+	streamObjectStopWhenWarned.Store(false)
+	streamObjectStateRefWarned.Store(false)
+
+	origStderr := osStderr
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		t.Fatalf("pipe: %v", perr)
+	}
+	osStderr = w
+	t.Cleanup(func() { osStderr = origStderr })
+
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return nil, errors.New("mock short-circuit")
+		},
+	}
+	var state AgentState
+	type payload struct {
+		X int `json:"x"`
+	}
+
+	_, _ = StreamObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+		WithStateRef(&state),
+	)
+	_, _ = StreamObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+		WithStateRef(&state),
+	)
+
+	_ = w.Close()
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+	got := buf.String()
+
+	stopWhenWant := "goai: WithStopWhen is not supported in StreamObject"
+	stateRefWant := "goai: WithStateRef is not supported in StreamObject"
+	if n := strings.Count(got, stopWhenWant); n != 1 {
+		t.Errorf("WithStopWhen warning fired %d times across 2 calls; want 1; full stderr=%q", n, got)
+	}
+	if n := strings.Count(got, stateRefWant); n != 1 {
+		t.Errorf("WithStateRef warning fired %d times across 2 calls; want 1; full stderr=%q", n, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FIX 51 - cross-latch independence. The StopWhen latch must NOT affect the
+// StateRef latch and vice versa when the options are passed one at a time
+// across a sequence of calls.
+// ---------------------------------------------------------------------------
+
+// TestGenerateObject_Warnings_LatchesAreIndependent proves each of the two
+// once-latches (StopWhen, StateRef) advances on its own and does not
+// cross-trip the other. Sequence: call 1 with only WithStopWhen → exactly
+// one "WithStopWhen" warning (no "WithStateRef"). Call 2 with only
+// WithStateRef → exactly one "WithStateRef" warning (no additional
+// "WithStopWhen"). Call 3 with both → zero additional warnings.
+func TestGenerateObject_Warnings_LatchesAreIndependent(t *testing.T) {
+	generateObjectStopWhenWarned.Store(false)
+	generateObjectStateRefWarned.Store(false)
+
+	origStderr := osStderr
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		t.Fatalf("pipe: %v", perr)
+	}
+	osStderr = w
+	t.Cleanup(func() { osStderr = origStderr })
+
+	model := &mockModel{
+		id: "t",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return nil, errors.New("mock short-circuit")
+		},
+	}
+	var state AgentState
+	type payload struct {
+		X int `json:"x"`
+	}
+
+	// Call 1: WithStopWhen only.
+	_, _ = GenerateObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+	)
+	// Call 2: WithStateRef only (StopWhen latch already tripped; StateRef latch fresh).
+	_, _ = GenerateObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStateRef(&state),
+	)
+	// Call 3: both - both latches now tripped; no new warnings.
+	_, _ = GenerateObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+		WithStateRef(&state),
+	)
+
+	_ = w.Close()
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+	got := buf.String()
+
+	stopWhenWant := "goai: WithStopWhen is not supported in GenerateObject"
+	stateRefWant := "goai: WithStateRef is not supported in GenerateObject"
+	if n := strings.Count(got, stopWhenWant); n != 1 {
+		t.Errorf("WithStopWhen warning fired %d times across 3 calls; want 1; full stderr=%q", n, got)
+	}
+	if n := strings.Count(got, stateRefWant); n != 1 {
+		t.Errorf("WithStateRef warning fired %d times across 3 calls; want 1; full stderr=%q", n, got)
+	}
+}
+
+// TestStreamObject_Warnings_LatchesAreIndependent is the StreamObject twin.
+func TestStreamObject_Warnings_LatchesAreIndependent(t *testing.T) {
+	streamObjectStopWhenWarned.Store(false)
+	streamObjectStateRefWarned.Store(false)
+
+	origStderr := osStderr
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		t.Fatalf("pipe: %v", perr)
+	}
+	osStderr = w
+	t.Cleanup(func() { osStderr = origStderr })
+
+	model := &mockModel{
+		id: "t",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return nil, errors.New("mock short-circuit")
+		},
+	}
+	var state AgentState
+	type payload struct {
+		X int `json:"x"`
+	}
+
+	_, _ = StreamObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+	)
+	_, _ = StreamObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStateRef(&state),
+	)
+	_, _ = StreamObject[payload](t.Context(), model,
+		WithPrompt("go"),
+		WithStopWhen(func([]StepResult) bool { return false }),
+		WithStateRef(&state),
+	)
+
+	_ = w.Close()
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+	got := buf.String()
+
+	stopWhenWant := "goai: WithStopWhen is not supported in StreamObject"
+	stateRefWant := "goai: WithStateRef is not supported in StreamObject"
+	if n := strings.Count(got, stopWhenWant); n != 1 {
+		t.Errorf("WithStopWhen warning fired %d times across 3 calls; want 1; full stderr=%q", n, got)
+	}
+	if n := strings.Count(got, stateRefWant); n != 1 {
+		t.Errorf("WithStateRef warning fired %d times across 3 calls; want 1; full stderr=%q", n, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FIX 47 - step counter monotonicity on error after StepLLMInFlight.
+// ---------------------------------------------------------------------------
+
+// TestAgentState_StreamText_ErrorAfterLLMInFlight_MonotonicStep pins the
+// FIX 47 invariant: once goai has advertised (StepLLMInFlight, N) via the
+// StateRef, no subsequent store may regress the step counter below N.
+// Before FIX 47, the initial DoStream error path published (StepIdle, 0)
+// immediately after (StepLLMInFlight, 1), so a racing poller could observe
+// step 1 → 0.
+func TestAgentState_StreamText_ErrorAfterLLMInFlight_MonotonicStep(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Single-shot path (MaxSteps=1, no tools).
+	t.Run("single-shot/DoStream-error", func(t *testing.T) {
+		model := &mockModel{
+			id: "t",
+			streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+				return nil, errors.New("upstream refused")
+			},
+		}
+		var state AgentState
+		_, err := StreamText(t.Context(), model,
+			WithPrompt("go"),
+			WithMaxSteps(1),
+			WithStateRef(&state),
+		)
+		if err == nil {
+			t.Fatal("expected error from failing DoStream")
+		}
+		kind, step := state.Observe()
+		if kind != StepIdle {
+			t.Errorf("state kind=%v; want StepIdle", kind)
+		}
+		if step != 1 {
+			t.Errorf("state step=%d; want 1 (monotonic: LLMInFlight=1 → Idle=1, no regression to 0)", step)
+		}
+	})
+
+	// Multi-step tool-loop path: initial DoStream failure.
+	t.Run("tool-loop/initial-DoStream-error", func(t *testing.T) {
+		model := &mockModel{
+			id: "t",
+			streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+				return nil, errors.New("upstream refused")
+			},
+		}
+		var state AgentState
+		_, err := StreamText(t.Context(), model,
+			WithPrompt("go"),
+			WithMaxSteps(5),
+			WithTools(Tool{
+				Name:    "noop",
+				Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+			}),
+			WithStateRef(&state),
+		)
+		if err == nil {
+			t.Fatal("expected error from failing DoStream")
+		}
+		kind, step := state.Observe()
+		if kind != StepIdle {
+			t.Errorf("state kind=%v; want StepIdle", kind)
+		}
+		if step != 1 {
+			t.Errorf("state step=%d; want 1 (monotonic)", step)
+		}
+	})
+
+	// GenerateText: DoGenerate error on step 1 must NOT regress step 1 → 0.
+	t.Run("generate-text/DoGenerate-error", func(t *testing.T) {
+		model := &mockModel{
+			id: "t",
+			generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+				return nil, errors.New("upstream refused")
+			},
+		}
+		var state AgentState
+		_, err := GenerateText(t.Context(), model,
+			WithPrompt("go"),
+			WithMaxSteps(1),
+			WithStateRef(&state),
+		)
+		if err == nil {
+			t.Fatal("expected error from failing DoGenerate")
+		}
+		kind, step := state.Observe()
+		if kind != StepIdle {
+			t.Errorf("state kind=%v; want StepIdle", kind)
+		}
+		if step != 1 {
+			t.Errorf("state step=%d; want 1 (monotonic: LLMInFlight=1 → Idle=1)", step)
+		}
+	})
+
+	// Aggressive stress: many concurrent pollers must never observe step
+	// going backwards across the LLMInFlight → Idle transition.
+	t.Run("race/many-pollers-observe-monotonic-step", func(t *testing.T) {
+		for trial := 0; trial < 50; trial++ {
+			model := &mockModel{
+				id: "t",
+				streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+					return nil, errors.New("boom")
+				},
+			}
+			var state AgentState
+			var pollerWG sync.WaitGroup
+			stop := make(chan struct{})
+			var violated atomic.Bool
+			for i := 0; i < 4; i++ {
+				pollerWG.Add(1)
+				go func() {
+					defer pollerWG.Done()
+					var lastStep int
+					for {
+						select {
+						case <-stop:
+							return
+						default:
+						}
+						_, s := state.Observe()
+						if s < lastStep {
+							violated.Store(true)
+							return
+						}
+						lastStep = s
+					}
+				}()
+			}
+			_, _ = StreamText(t.Context(), model,
+				WithPrompt("go"),
+				WithMaxSteps(1),
+				WithStateRef(&state),
+			)
+			close(stop)
+			pollerWG.Wait()
+			if violated.Load() {
+				t.Fatalf("trial %d: poller observed step regression", trial)
+			}
+		}
+	})
+
+	// FIX 50: the single-shot (MaxSteps=1) race subtest above is tautological
+	// for the load-bearing monotonicity path - a single-shot failure has
+	// highestInflightStep == len(steps) (both effectively 1), so the
+	// `highestInflightStep > finalStep` branch in the StepIdle defer is
+	// never exercised. This subtest exercises the genuine mid-loop case:
+	// step 1 succeeds with a tool call (steps gets length 1), then step 2's
+	// DoStream errors BEFORE a StepResult is appended (len(steps) stays 1,
+	// highestInflightStep reaches 2). Pollers must observe step monotonically
+	// advance from 1 → 2 at Idle, never regressing.
+	t.Run("race/mid-loop-error-monotonic-step", func(t *testing.T) {
+		for trial := 0; trial < 50; trial++ {
+			var callCount atomic.Int32
+			model := &mockModel{
+				id: "t",
+				streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+					n := callCount.Add(1)
+					if n == 1 {
+						// Step 1: success with one tool call → tool executes,
+						// loop proceeds to step 2.
+						return streamFromChunks(
+							provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "ping", ToolInput: `{}`},
+							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
+						), nil
+					}
+					// Step 2+: DoStream itself fails (error before any StepResult).
+					return nil, errors.New("step2 upstream refused")
+				},
+			}
+			var state AgentState
+			var pollerWG sync.WaitGroup
+			stop := make(chan struct{})
+			var violated atomic.Bool
+			var maxObserved atomic.Int32
+			for i := 0; i < 8; i++ {
+				pollerWG.Add(1)
+				go func() {
+					defer pollerWG.Done()
+					var lastStep int
+					for {
+						select {
+						case <-stop:
+							return
+						default:
+						}
+						_, s := state.Observe()
+						if s < lastStep {
+							violated.Store(true)
+							return
+						}
+						if int32(s) > maxObserved.Load() {
+							maxObserved.Store(int32(s))
+						}
+						lastStep = s
+					}
+				}()
+			}
+			stream, err := StreamText(t.Context(), model,
+				WithPrompt("go"),
+				WithMaxSteps(3),
+				WithTools(Tool{
+					Name:        "ping",
+					Description: "ping",
+					InputSchema: json.RawMessage(`{"type":"object"}`),
+					Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+						return "pong", nil
+					},
+				}),
+				WithStateRef(&state),
+			)
+			// StreamText returns (stream, nil) even if a subsequent step
+			// errors - the error surfaces via ChunkError inside the stream.
+			if err != nil {
+				// Unexpected: step 1 succeeded so StreamText should have
+				// returned a live stream.
+				close(stop)
+				pollerWG.Wait()
+				t.Fatalf("trial %d: unexpected initial StreamText error: %v", trial, err)
+			}
+			// Drain the stream so the background goroutine completes and
+			// publishes StepIdle. Without this, the tool-loop goroutine is
+			// still running when we check final state below.
+			for range stream.Stream() {
+			}
+			// Additionally wait for the done signal - raw channel close
+			// fires BEFORE StepIdle store (documented in WithStateRef godoc).
+			_ = stream.Err()
+			close(stop)
+			pollerWG.Wait()
+			if violated.Load() {
+				t.Fatalf("trial %d: poller observed step regression across LLMInFlight→Idle transition", trial)
+			}
+			kind, finalStep := state.Observe()
+			if kind != StepIdle {
+				t.Errorf("trial %d: final kind=%v; want StepIdle", trial, kind)
+			}
+			// FIX 47 invariant: finalStep must reflect the highest
+			// announced in-flight step (2), NOT len(steps) (which is 1
+			// because step 2 erred before a StepResult was appended).
+			if finalStep < 2 {
+				t.Errorf("trial %d: finalStep=%d; want >= 2 (highestInflightStep tracked step-2 announcement)", trial, finalStep)
+			}
+			// Sanity: pollers must have seen the advance to step 2 at
+			// some point (not merely read it once at exit).
+			if maxObserved.Load() < 2 {
+				t.Errorf("trial %d: maxObserved=%d; pollers never saw step 2 advancing", trial, maxObserved.Load())
+			}
+		}
+	})
+}

--- a/agent_state_test.go
+++ b/agent_state_test.go
@@ -1925,6 +1925,37 @@ func TestStepKind_String(t *testing.T) {
 	}
 }
 
+// TestDefaultWarnStopWhenIgnored_AllBranches covers StreamObject + default
+// fn-name branches of defaultWarnStopWhenIgnoredForObject to complete
+// coverage of the warn switch. GenerateObject is covered by tests in
+// object_test.go that exercise the public WithStopWhen option.
+func TestDefaultWarnStopWhenIgnored_AllBranches(t *testing.T) {
+	streamObjectStopWhenWarned.Store(false)
+	origStderr := osStderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	osStderr = w
+	t.Cleanup(func() { osStderr = origStderr })
+
+	defaultWarnStopWhenIgnoredForObject("StreamObject")
+	defaultWarnStopWhenIgnoredForObject("StreamObject")
+	defaultWarnStopWhenIgnoredForObject("UnknownEntryPoint")
+	_ = w.Close()
+
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+	got := buf.String()
+	if n := strings.Count(got, "WithStopWhen is not supported in StreamObject"); n != 1 {
+		t.Errorf("StreamObject warn count=%d; want 1", n)
+	}
+	if !strings.Contains(got, "WithStopWhen is not supported in UnknownEntryPoint") {
+		t.Errorf("default-branch warn missing; got %q", got)
+	}
+}
+
 // TestDefaultWarnStateRefIgnored_AllBranches covers StreamObject + default
 // fn-name branches of defaultWarnStateRefIgnoredForObject to complete
 // coverage of the warn switch. GenerateObject is covered by the sibling

--- a/generate.go
+++ b/generate.go
@@ -1005,22 +1005,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			}
 		}
 
-		// StepsExhausted: true only when MaxSteps was reached AND the last step
-		// still had tool calls pending (model wanted to continue but was cut short).
-		// WithStopWhen break at exact MaxSteps boundary must NOT flip this. Only
-		// overwrite stopCause when it is still empty (loop fell through without
-		// any break) - otherwise StopCauseEmpty / StopCauseAbort / Predicate etc.
-		// would be silently reclassified as MaxSteps.
-		if !hookStopped && stopCause == "" && len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
-			stepsExhausted = true
-			stopCause = provider.StopCauseMaxSteps
-		}
-		// If the loop fell through without any break setting a cause (e.g.
-		// MaxSteps boundary with the last step having no pending tool calls),
-		// default to natural.
-		if stopCause == "" {
-			stopCause = provider.StopCauseNatural
-		}
+		stopCause, stepsExhausted = finalizeStopCause(hookStopped, stopCause, steps, o.MaxSteps)
 
 		// Set responseMessages before emitting ChunkFinish (safe: ts.buildResult reads
 		// responseMessages only after doneCh closes, which happens after out is closed).
@@ -1390,13 +1375,9 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	// that is intentionally dropped here for clarity. Streaming keeps the
 	// extra guard because its loop has a Natural-case break that sets
 	// stopCause without setting hookStopped - see streamWithToolLoop.
-	if !hookStopped && len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
-		tr.StepsExhausted = true
-		stopCause = provider.StopCauseMaxSteps
-	}
-	if stopCause == "" {
-		stopCause = provider.StopCauseNatural
-	}
+	var stepsExhausted bool
+	stopCause, stepsExhausted = finalizeStopCause(hookStopped, stopCause, steps, o.MaxSteps)
+	tr.StepsExhausted = stepsExhausted
 	tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
 	fireOnFinish(o.OnFinish, FinishInfo{
 		StepsExhausted: tr.StepsExhausted,
@@ -1412,6 +1393,24 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 // stopSafe evaluates a StopCondition with recover. A panicking predicate is
 // treated as "do not stop" and logged to stderr (consistent with how
 // OnBeforeStep / OnStepFinish handle panics).
+// finalizeStopCause classifies the terminal StopCause when the tool loop
+// exits by natural termination (no break set a cause). It encapsulates the
+// post-loop MaxSteps-exhaustion guard and the StopCauseNatural default so
+// both GenerateText and streamWithToolLoop share one implementation.
+//
+// Returns the resolved StopCause and whether MaxSteps was exhausted.
+func finalizeStopCause(hookStopped bool, current provider.StopCause, steps []StepResult, maxSteps int) (provider.StopCause, bool) {
+	stepsExhausted := false
+	if !hookStopped && current == "" && len(steps) >= maxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
+		stepsExhausted = true
+		current = provider.StopCauseMaxSteps
+	}
+	if current == "" {
+		current = provider.StopCauseNatural
+	}
+	return current, stepsExhausted
+}
+
 func stopSafe(pred StopCondition, steps []StepResult) (stop bool) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/generate.go
+++ b/generate.go
@@ -92,6 +92,36 @@ type StepResult struct {
 	// ToolCalls requested in this step.
 	ToolCalls []provider.ToolCall
 
+	// ToolResults contains one entry per completed ToolCall in this step,
+	// populated AFTER executeToolsParallel returns and BEFORE WithStopWhen
+	// is evaluated. Ordering matches ToolCalls element-for-element.
+	//
+	// Empty when the step had no tool calls or when the loop exits before
+	// executing tools (e.g. MaxSteps reached with pending tool calls that
+	// never ran, or StopCauseNoExecutableTools).
+	//
+	// Mirrors Vercel AI SDK's DefaultStepResult.toolResults so predicates
+	// passed to WithStopWhen can inspect tool outputs (matching the
+	// placement documented on StopCondition).
+	//
+	// Streaming visibility: consumers using StreamText who read raw
+	// chunks via stream.Stream() cannot observe per-step ToolResults in
+	// real time. The ChunkStepFinish chunk with stepSource="goai" is
+	// emitted BEFORE tools execute (so ToolResults is empty at that
+	// point); the subsequent goai-internal "goai-tool-results" chunk
+	// that backfills ToolResults is consumed by the stream reducer and
+	// NOT re-emitted to the raw chunk channel. To observe ToolResults
+	// per step from a streaming call, use one of:
+	//   - stream.Result() after the stream closes (Steps[].ToolResults
+	//     is fully populated).
+	//   - OnToolCall hook (fires synchronously after each tool Execute
+	//     returns with per-call detail).
+	//   - OnAfterToolExecute hook (same timing as OnToolCall, richer
+	//     metadata).
+	// The OnStepFinish hook always receives a StepResult with an EMPTY
+	// ToolResults slice because tools execute AFTER the hook fires.
+	ToolResults []provider.ToolResult
+
 	// FinishReason for this step.
 	FinishReason provider.FinishReason
 
@@ -114,7 +144,7 @@ type StepResult struct {
 // the context. Discarding a TextStream without consuming leaks goroutines.
 //
 // It provides three consumption modes (Stream, TextStream, Result).
-// Stream() and TextStream() are mutually exclusive -- only call one.
+// Stream() and TextStream() are mutually exclusive - only call one.
 // Result() can always be called, including after Stream() or TextStream(),
 // to get the accumulated final result.
 type TextStream struct {
@@ -134,6 +164,13 @@ type TextStream struct {
 	onStepFinish []func(StepResult)
 	onFinish     []func(FinishInfo)
 	startTime    time.Time
+
+	// stateRef, when non-nil, is transitioned to StepIdle when the consume
+	// goroutine returns. Only set by the single-shot StreamText path
+	// (streamWithToolLoop owns its own StateRef lifecycle inline). A nil
+	// stateRef is a no-op; AgentState.set handles nil receiver safely.
+	// See FIX 34.
+	stateRef *AgentState
 
 	// Accumulated state (written by consume goroutine, read after doneCh closes).
 	text             strings.Builder
@@ -169,7 +206,7 @@ func newTextStream(ctx context.Context, source <-chan provider.StreamChunk) *Tex
 }
 
 // Stream returns a channel that emits raw StreamChunks from the provider.
-// Mutually exclusive with TextStream() -- only call one streaming method.
+// Mutually exclusive with TextStream() - only call one streaming method.
 func (ts *TextStream) Stream() <-chan provider.StreamChunk {
 	ch := make(chan provider.StreamChunk, 64)
 	ts.consumeOnce.Do(func() {
@@ -179,7 +216,7 @@ func (ts *TextStream) Stream() <-chan provider.StreamChunk {
 	if ts.rawCh != nil {
 		return ts.rawCh
 	}
-	// Called after TextStream() consumed the source -- return closed channel.
+	// Called after TextStream() consumed the source - return closed channel.
 	close(ch)
 	return ch
 }
@@ -187,7 +224,7 @@ func (ts *TextStream) Stream() <-chan provider.StreamChunk {
 // TextStream returns the underlying channel of text chunks.
 // Note: this method has the same name as the containing type (TextStream);
 // call it as stream.TextStream() to receive the channel.
-// Mutually exclusive with Stream() -- only call one streaming method.
+// Mutually exclusive with Stream() - only call one streaming method.
 func (ts *TextStream) TextStream() <-chan string {
 	ch := make(chan string, 64)
 	ts.consumeOnce.Do(func() {
@@ -197,7 +234,7 @@ func (ts *TextStream) TextStream() <-chan string {
 	if ts.textCh != nil {
 		return ts.textCh
 	}
-	// Called after Stream() consumed the source -- return closed channel.
+	// Called after Stream() consumed the source - return closed channel.
 	close(ch)
 	return ch
 }
@@ -227,6 +264,18 @@ func (ts *TextStream) Err() error {
 
 func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<- string) {
 	defer close(ts.doneCh)
+	// FIX 34: transition StateRef to StepIdle as the consume goroutine
+	// exits. Single-shot StreamText wires this (stateRef is nil for the
+	// multi-step streamWithToolLoop path, which owns its own StateRef
+	// transitions inline). Deferred second from the top so it runs just
+	// before close(doneCh) - after all user hooks (OnResponse, OnStepFinish,
+	// OnFinish) have fired, so a poller that observes StepIdle can assume
+	// all hooks have already returned. Step count is 1 for a single-shot
+	// stream (the one DoStream call), regardless of whether the provider
+	// emitted any chunks.
+	if ts.stateRef != nil {
+		defer func() { ts.stateRef.set(StepIdle, 1) }()
+	}
 	if ts.timeoutCancel != nil {
 		defer ts.timeoutCancel()
 	}
@@ -247,6 +296,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				TotalSteps:   1,
 				TotalUsage:   ts.usage,
 				FinishReason: ts.finishReason,
+				StoppedBy:    provider.StopCauseNatural,
 			})
 		}()
 	}
@@ -343,6 +393,16 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 			ts.stepToolCalls = append(ts.stepToolCalls, tc)
 
 		case provider.ChunkStepFinish:
+			// GoAI-emitted tool-results backfill: update the last completed
+			// step's ToolResults (FIX 7 streaming parity). Emitted after
+			// executeToolsParallel returns so ts.steps exposes the same data
+			// the sync path's StepResult.ToolResults carries.
+			if stepSource, _ := chunk.Metadata["stepSource"].(string); stepSource == "goai-tool-results" {
+				if trs, ok := chunk.Metadata["toolResults"].([]provider.ToolResult); ok && len(ts.steps) > 0 {
+					ts.steps[len(ts.steps)-1].ToolResults = trs
+				}
+				continue
+			}
 			// GoAI-emitted step boundaries: build per-step StepResult.
 			if stepSource, _ := chunk.Metadata["stepSource"].(string); stepSource == "goai" {
 				ts.currentStep++
@@ -572,9 +632,13 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		ctx, timeoutCancel = context.WithTimeout(ctx, o.Timeout)
 	}
 
+	// AgentState: initial. o.StateRef may be nil (set is a no-op).
+	o.StateRef.set(StepStarting, 0)
+
 	// --- Step 1 DoStream: synchronous (preserves (nil, error) contract) ---
 	// This ensures StreamText ALWAYS returns (nil, error) when the first DoStream
 	// fails, regardless of MaxSteps. Eliminates the split error contract.
+	o.StateRef.set(StepLLMInFlight, 1)
 	for _, fn := range o.OnRequest {
 		fn(RequestInfo{
 			Ctx:          ctx,
@@ -594,6 +658,10 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		if timeoutCancel != nil {
 			timeoutCancel()
 		}
+		// FIX 47: preserve step=1 on error - monotonicity. The store above
+		// already moved the step counter to 1 (StepLLMInFlight, 1); a poller
+		// observing between the two stores must not see step regress to 0.
+		o.StateRef.set(StepIdle, 1)
 		// OnRequest/OnResponse: not recover-wrapped (caller's goroutine).
 		// OnStepFinish: always recover-wrapped (prevents losing accumulated results).
 		// Inside goroutines: all hooks recover-wrapped.
@@ -618,15 +686,55 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		if timeoutCancel != nil {
 			defer timeoutCancel()
 		}
-
 		var totalUsage provider.Usage
 		var lastFinishReason provider.FinishReason
 		var lastResponse provider.ResponseMetadata
 		var lastReasoning []provider.Part
 		var steps []StepResult
 		var stepsExhausted bool
-		firstStep := true       // true only for step 1 (already have firstResult)
-		stepStart := step1Start // goroutine-local start time per step
+		var hookStopped bool              // true iff WithStopWhen or OnBeforeStep.Stop broke the loop
+		var stopCause provider.StopCause  // classifies how the loop exited (FIX 5)
+		firstStep := true                 // true only for step 1 (already have firstResult)
+		stepStart := step1Start           // goroutine-local start time per step
+
+		// highestInflightStep tracks the maximum step counter announced via
+		// o.StateRef.set(StepLLMInFlight, ...). The deferred StepIdle publish
+		// uses max(len(steps), highestInflightStep) so the observable step
+		// value never regresses (FIX 47 monotonicity: if a mid-loop step
+		// errors before being appended to `steps`, len(steps) lags behind
+		// highestInflightStep; the defer must publish the larger value).
+		//
+		// There are TWO writes to highestInflightStep in this function, and
+		// both are intentional (FIX 54 + FIX 55):
+		//
+		//   1. The `= 1` assignment below (pre-loop): mirrors the
+		//      o.StateRef.set(StepLLMInFlight, 1) call that happens BEFORE
+		//      this goroutine starts (see the pre-goroutine set call
+		//      earlier in streamWithToolLoop). This guarantees the deferred
+		//      StepIdle publish has something >= 1 to report even if the
+		//      goroutine exits before entering the loop body (e.g. panic
+		//      recovery, pre-loop early exit).
+		//   2. The `= step` assignment in the firstStep branch (loop body):
+		//      refactor-safety for future changes that move the step-1
+		//      StepLLMInFlight announcement inside the loop. If such a
+		//      refactor happens, write #1 should be deleted; write #2
+		//      continues to maintain the invariant from inside the loop.
+		//
+		// Both writes together ensure the invariant "highestInflightStep
+		// reflects the latest StepLLMInFlight announcement" holds on every
+		// path the defer can fire from.
+		highestInflightStep := 0
+		highestInflightStep = 1
+		// Ensure any exit path (break, return, panic-recover-above, natural
+		// termination) leaves the observable state as Idle. Use closure-captured
+		// steps so the final step count is visible to pollers.
+		defer func() {
+			finalStep := len(steps)
+			if highestInflightStep > finalStep {
+				finalStep = highestInflightStep
+			}
+			o.StateRef.set(StepIdle, finalStep)
+		}()
 
 		for step := 1; step <= o.MaxSteps; step++ {
 			var result *provider.StreamResult
@@ -635,6 +743,12 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				// Step 1: use the already-obtained firstResult.
 				result = firstResult
 				firstStep = false
+				// FIX 54: record the step-1 announcement inside the loop body
+				// so the invariant "every StepLLMInFlight has a matching
+				// highestInflightStep write" holds from step 1. The actual
+				// atomic store happened before the goroutine; this is the
+				// in-loop bookkeeping companion.
+				highestInflightStep = step
 			} else {
 				// Steps 2+: OnBeforeStep hook (can inject messages or stop loop).
 				if o.OnBeforeStep != nil {
@@ -652,6 +766,9 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 						})
 					}()
 					if bsr.Stop {
+						// Semantic parity with WithStopWhen: mark as hookStopped.
+						hookStopped = true
+						stopCause = provider.StopCauseBeforeStep
 						break
 					}
 					if len(bsr.ExtraMessages) > 0 {
@@ -679,6 +796,8 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				}
 
 				stepStart = time.Now()
+				o.StateRef.set(StepLLMInFlight, step)
+				highestInflightStep = step
 				var err error
 				result, err = withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
 					return model.DoStream(ctx, params)
@@ -705,7 +824,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 					// messages are lost. Callers should check Err() and not rely on ResponseMessages
 					// when the stream has errors.
 					provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: err})
-					provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: lastFinishReason, Usage: totalUsage})
+					provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: lastFinishReason, Usage: totalUsage, StoppedBy: provider.StopCauseAbort})
 					// Fire OnFinish so observability hooks can close spans/flush traces.
 					lastFinish := provider.FinishReason("")
 					if len(steps) > 0 {
@@ -715,6 +834,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 						TotalSteps:   len(steps),
 						TotalUsage:   totalUsage,
 						FinishReason: lastFinish,
+						StoppedBy:    provider.StopCauseAbort,
 					})
 					return
 				}
@@ -722,12 +842,12 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 
 			ds := drainStep(ctx, result.Stream, out)
 			if ds.err != nil {
-				// responseMessages intentionally not set on error -- buildResult falls back to
+				// responseMessages intentionally not set on error - buildResult falls back to
 				// a minimal assistant message from accumulated text. Intermediate tool round-trip
 				// messages are lost. Callers should check Err() and not rely on ResponseMessages
 				// when the stream has errors.
 				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: ds.err})
-				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, Usage: totalUsage})
+				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, Usage: totalUsage, StoppedBy: provider.StopCauseAbort})
 				// Fire OnFinish so observability hooks can close spans/flush traces.
 				// Without this, OTel root spans leak and Langfuse traces are lost.
 				lastFinish := provider.FinishReason("")
@@ -738,14 +858,19 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 					TotalSteps:   len(steps),
 					TotalUsage:   totalUsage,
 					FinishReason: lastFinish,
+					StoppedBy:    provider.StopCauseAbort,
 				})
 				return
 			}
 
 			// Guard: skip empty step (provider closed channel without sending
 			// any meaningful chunks, e.g., after a ChunkError). Prevents emitting
-			// a phantom empty StepResult and ChunkStepFinish.
+			// a phantom empty StepResult and ChunkStepFinish. This is not an
+			// error path (a separate ChunkError path covers real errors) - use
+			// StopCauseEmpty so consumers can distinguish a no-op response from
+			// an abort.
 			if ds.text == "" && len(ds.toolCalls) == 0 && ds.finishReason == "" {
+				stopCause = provider.StopCauseEmpty
 				break
 			}
 
@@ -778,9 +903,13 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			}
 			steps = append(steps, stepResult)
 			totalUsage = addUsage(totalUsage, ds.usage)
-			lastFinishReason = ds.finishReason
 			lastResponse = ds.response
 			lastReasoning = ds.reasoning
+
+			// AgentState: the step's stream has fully drained; tool exec and
+			// stop-predicate evaluation have not started yet. Pollers observing
+			// in this window must see StepStepFinished, not StepLLMInFlight.
+			o.StateRef.set(StepStepFinished, step)
 
 			// OnStepFinish (recover-wrapped).
 			for _, fn := range o.OnStepFinish {
@@ -796,10 +925,14 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 
 			// Normalize: providers that send empty/wrong finish_reason with tool calls
 			// (MiniMax, Azure MaaS deepseek, etc.) would cause the loop to exit early.
-			// The presence of tool calls is authoritative.
+			// The presence of tool calls is authoritative. Must run BEFORE capturing
+			// lastFinishReason so the final ChunkFinish carries a non-empty reason
+			// even when providers (gemini, bedrock-sonnet, azure-sonnet) emit empty
+			// finish_reason alongside tool calls.
 			if len(ds.toolCalls) > 0 && ds.finishReason != provider.FinishToolCalls {
 				ds.finishReason = provider.FinishToolCalls
 			}
+			lastFinishReason = ds.finishReason
 
 			// --- Emit ChunkStepFinish ---
 			// Set Response directly on the chunk (StreamChunk.Response is a plain struct
@@ -816,32 +949,77 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				},
 			})
 
-			// --- Exit conditions (same as GenerateText, generate.go:464) ---
-			if ds.finishReason != provider.FinishToolCalls || len(ds.toolCalls) == 0 || len(toolMap) == 0 {
+			// --- Exit conditions (same as GenerateText) ---
+			// Note: streamWithToolLoop is only entered when len(toolMap) > 0
+			// (guarded at StreamText entry - see generate.go:992), and toolMap
+			// is immutable for the lifetime of the call. The "no executable
+			// tools" exit therefore cannot be reached here; StopCauseNoExecutableTools
+			// is a sync-only cause (GenerateText). See StopCauseNoExecutableTools
+			// godoc in provider/types.go.
+			if ds.finishReason != provider.FinishToolCalls || len(ds.toolCalls) == 0 {
+				stopCause = provider.StopCauseNatural
 				break
 			}
 
 			// --- Execute tools in parallel ---
-			toolMsgs := executeToolsParallel(ctx, ds.toolCalls, toolMap, step, toolHooks{
+			o.StateRef.set(StepToolExecuting, step)
+			toolMsgs, toolResults := executeToolsParallel(ctx, ds.toolCalls, toolMap, step, toolHooks{
 				sequential:      o.SequentialTools,
 				onToolCallStart: o.OnToolCallStart,
 				onToolCall:      o.OnToolCall,
 				onBeforeExecute: o.OnBeforeToolExecute,
 				onAfterExecute:  o.OnAfterToolExecute,
 			})
+			// Attach ToolResults to the step BEFORE the stop predicate sees it
+			// (FIX 7 / Vercel DefaultStepResult parity). steps[-1] is this step.
+			steps[len(steps)-1].ToolResults = toolResults
+
+			// Notify the consumer (TextStream.consume) that this step now has
+			// tool results so ts.steps[len-1].ToolResults can be backfilled.
+			// We reuse ChunkStepFinish with a distinguishing stepSource tag so
+			// existing provider-internal ChunkStepFinish handling is untouched.
+			provider.TrySend(ctx, out, provider.StreamChunk{
+				Type: provider.ChunkStepFinish,
+				Metadata: map[string]any{
+					"stepSource":  "goai-tool-results",
+					"toolResults": toolResults,
+				},
+			})
 
 			// --- Append messages for next step ---
 			params.Messages = appendToolRoundTrip(params.Messages, ds.text, ds.reasoning, ds.toolCalls, toolMsgs)
-			// Clear ToolChoice so model can freely respond on subsequent steps (matches generate.go:471).
+			// Clear ToolChoice so model can freely respond on subsequent steps.
 			// Set on every iteration for simplicity; idempotent after step 1.
 			params.ToolChoice = ""
+
+			// WithStopWhen (Vercel parity): evaluated AFTER this step's tool
+			// executions complete and the tool-result messages have been
+			// folded into params.Messages. ResponseMessages built on break
+			// here is a valid replay transcript (matching tool_use /
+			// tool_result pairs). Matches
+			// vercel-ai/packages/ai/src/generate-text/generate-text.ts.
+			if o.StopWhen != nil && stopSafe(o.StopWhen, steps) {
+				hookStopped = true
+				stopCause = provider.StopCausePredicate
+				break
+			}
 		}
 
 		// StepsExhausted: true only when MaxSteps was reached AND the last step
 		// still had tool calls pending (model wanted to continue but was cut short).
-		// If the last step finished naturally (no tool calls), it's not exhausted.
-		if len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
+		// WithStopWhen break at exact MaxSteps boundary must NOT flip this. Only
+		// overwrite stopCause when it is still empty (loop fell through without
+		// any break) - otherwise StopCauseEmpty / StopCauseAbort / Predicate etc.
+		// would be silently reclassified as MaxSteps.
+		if !hookStopped && stopCause == "" && len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
 			stepsExhausted = true
+			stopCause = provider.StopCauseMaxSteps
+		}
+		// If the loop fell through without any break setting a cause (e.g.
+		// MaxSteps boundary with the last step having no pending tool calls),
+		// default to natural.
+		if stopCause == "" {
+			stopCause = provider.StopCauseNatural
 		}
 
 		// Set responseMessages before emitting ChunkFinish (safe: ts.buildResult reads
@@ -854,6 +1032,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			TotalSteps:     len(steps),
 			TotalUsage:     totalUsage,
 			FinishReason:   lastFinishReason,
+			StoppedBy:      stopCause,
 		})
 
 		// Emit final ChunkFinish with total usage and last step Response metadata.
@@ -862,6 +1041,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			FinishReason: lastFinishReason,
 			Usage:        totalUsage,
 			Response:     lastResponse,
+			StoppedBy:    stopCause,
 		})
 	}()
 
@@ -874,13 +1054,24 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 // tool loop. The initial DoStream failure still returns (nil, error). Subsequent step
 // errors flow through the stream as ChunkError chunks; check stream.Err() after consuming.
 func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Option) (*TextStream, error) {
+	// Apply options FIRST so o.StateRef is populated before any early return.
+	// This guarantees pollers waiting for StepIdle do not deadlock when we
+	// return (nil, err) before the streaming goroutine starts (e.g. nil model,
+	// empty prompt, initial DoStream failure).
+	o := applyOptions(opts...)
+
 	if model == nil {
+		// Transition StepStarting→StepIdle for any observer so pollers do not deadlock.
+		o.StateRef.set(StepStarting, 0)
+		o.StateRef.set(StepIdle, 0)
 		return nil, errors.New("goai: model must not be nil")
 	}
 
-	o := applyOptions(opts...)
-
 	if o.Prompt == "" && len(o.Messages) == 0 {
+		// Pre-loop validation error must still transition any observer to
+		// StepIdle so pollers waiting on it do not deadlock.
+		o.StateRef.set(StepStarting, 0)
+		o.StateRef.set(StepIdle, 0)
 		return nil, errors.New("goai: prompt or messages must not be empty")
 	}
 
@@ -896,6 +1087,14 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	}
 
 	params := buildParams(o)
+
+	// FIX 34: single-shot StreamText never touched StateRef. Pollers using
+	// WithStateRef(&state) + WithMaxSteps(1) (or no executable tools) got
+	// stuck at the zero value (StepStarting, 0) forever. Transition through
+	// StepStarting → StepLLMInFlight here; StepIdle is deferred in consume
+	// (see ts.stateRef assignment below).
+	o.StateRef.set(StepStarting, 0)
+	o.StateRef.set(StepLLMInFlight, 1)
 
 	for _, fn := range o.OnRequest {
 		fn(RequestInfo{
@@ -916,6 +1115,14 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 		if timeoutCancel != nil {
 			timeoutCancel()
 		}
+		// FIX 34: DoStream failed before the consume goroutine could be
+		// started, so the consume-based StepIdle defer will never run.
+		// Transition to StepIdle inline so pollers waiting for it do not
+		// deadlock. FIX 47: preserve step=1 (the step we just set to
+		// LLMInFlight) instead of regressing to 0 - pollers observing
+		// between the StepLLMInFlight store above and this store must
+		// see a monotonically non-decreasing step counter.
+		o.StateRef.set(StepIdle, 1)
 		for _, fn := range o.OnResponse {
 			info := ResponseInfo{Latency: time.Since(start), Error: err}
 			var apiErr *APIError
@@ -933,6 +1140,10 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	ts.onStepFinish = o.OnStepFinish
 	ts.onFinish = o.OnFinish
 	ts.startTime = start
+	// FIX 34: hand StateRef ownership to the consume goroutine; it will
+	// transition to StepIdle when the stream drains / errors. Only set on
+	// the single-shot path; streamWithToolLoop manages StateRef inline.
+	ts.stateRef = o.StateRef
 	return ts, nil
 }
 
@@ -940,11 +1151,34 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 // When tools with Execute functions are provided and MaxSteps > 1,
 // it automatically runs a tool loop: generate → execute tools → re-generate.
 func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Option) (*TextResult, error) {
+	// Apply options FIRST so o.StateRef is populated before any early return.
+	// Registered BEFORE nil-model / prompt validation so pre-loop error returns
+	// also transition observers to StepIdle (otherwise pollers waiting for
+	// StepIdle would deadlock on validation errors).
+	o := applyOptions(opts...)
+
+	var steps []StepResult
+	// highestInflightStep tracks the largest step index we have announced
+	// via StepLLMInFlight. Used by the StepIdle defer to enforce
+	// monotonicity (FIX 47): if step N's DoGenerate errors before the
+	// step is appended to `steps`, len(steps) is N-1 but we already
+	// advertised StepLLMInFlight at N, so the final StepIdle must carry
+	// max(len(steps), highestInflightStep) to avoid a step-counter
+	// regression visible to pollers.
+	var highestInflightStep int
+	// AgentState: initial (StepStarting, 0). set() is a no-op when o.StateRef is nil.
+	o.StateRef.set(StepStarting, 0)
+	defer func() {
+		finalStep := len(steps)
+		if highestInflightStep > finalStep {
+			finalStep = highestInflightStep
+		}
+		o.StateRef.set(StepIdle, finalStep)
+	}()
+
 	if model == nil {
 		return nil, errors.New("goai: model must not be nil")
 	}
-
-	o := applyOptions(opts...)
 
 	if o.Prompt == "" && len(o.Messages) == 0 {
 		return nil, errors.New("goai: prompt or messages must not be empty")
@@ -962,8 +1196,9 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	// Build tool lookup for auto loop.
 	toolMap := buildToolMap(o.Tools)
 
-	var steps []StepResult
 	var totalUsage provider.Usage
+	var hookStopped bool             // true iff WithStopWhen or OnBeforeStep.Stop broke the loop
+	var stopCause provider.StopCause // classifies how the loop exited (FIX 5)
 
 	for step := 1; step <= o.MaxSteps; step++ {
 		// OnBeforeStep: step 2+ only (step 1 has no prior tool results to act on).
@@ -982,6 +1217,11 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 				})
 			}()
 			if bsr.Stop {
+				// Semantic parity with WithStopWhen: mark as hookStopped so
+				// post-loop StepsExhausted derivation does not mistake a
+				// hook-driven break at the MaxSteps boundary for natural exhaustion.
+				hookStopped = true
+				stopCause = provider.StopCauseBeforeStep
 				break
 			}
 			if len(bsr.ExtraMessages) > 0 {
@@ -1001,6 +1241,8 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		}
 
 		start := time.Now()
+		o.StateRef.set(StepLLMInFlight, step)
+		highestInflightStep = step
 		result, err := withRetry(ctx, o.MaxRetries, func() (*provider.GenerateResult, error) {
 			return model.DoGenerate(ctx, params)
 		})
@@ -1037,6 +1279,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: lastFinish,
+				StoppedBy:    provider.StopCauseAbort,
 			})
 			return nil, err
 		}
@@ -1053,6 +1296,11 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		}
 		steps = append(steps, stepResult)
 		totalUsage = addUsage(totalUsage, result.Usage)
+
+		// AgentState: LLM call for this step is complete; tool exec and
+		// stop-predicate evaluation have not started yet. Pollers observing
+		// in this window must see StepStepFinished, not StepLLMInFlight.
+		o.StateRef.set(StepStepFinished, step)
 
 		for _, fn := range o.OnStepFinish {
 			func(f func(StepResult)) {
@@ -1079,10 +1327,18 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		if result.FinishReason != provider.FinishToolCalls || len(result.ToolCalls) == 0 || len(toolMap) == 0 {
 			tr := buildTextResult(steps, totalUsage)
 			tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
+			// Distinguish "model stopped on its own" from "model wants more
+			// tool calls but no tool has Execute" (FIX 11). Both exit cleanly
+			// but mean very different things to consumers.
+			cause := provider.StopCauseNatural
+			if len(result.ToolCalls) > 0 && len(toolMap) == 0 {
+				cause = provider.StopCauseNoExecutableTools
+			}
 			fireOnFinish(o.OnFinish, FinishInfo{
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: tr.FinishReason,
+				StoppedBy:    cause,
 			})
 			return tr, nil
 		}
@@ -1091,16 +1347,33 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// Clear tool_choice after the first tool step so the model can freely
 		// produce a text response on subsequent steps.
 		params.ToolChoice = ""
-		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
+		o.StateRef.set(StepToolExecuting, step)
+		toolMessages, toolResults := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
 			sequential:      o.SequentialTools,
 			onToolCallStart: o.OnToolCallStart,
 			onToolCall:      o.OnToolCall,
 			onBeforeExecute: o.OnBeforeToolExecute,
 			onAfterExecute:  o.OnAfterToolExecute,
 		})
+		// Attach ToolResults to the step BEFORE the stop predicate sees it
+		// (FIX 7 / Vercel DefaultStepResult parity). steps[-1] is this step.
+		steps[len(steps)-1].ToolResults = toolResults
 
 		// Append assistant message with tool calls + tool result messages.
 		params.Messages = appendToolRoundTrip(params.Messages, result.Text, nil, result.ToolCalls, toolMessages)
+
+		// WithStopWhen (Vercel parity): evaluated AFTER this step's LLM call
+		// AND its tool executions complete. The tool-result messages are
+		// already folded into params.Messages, so ResponseMessages produced
+		// when the loop breaks here is a valid replay transcript (assistant
+		// tool_use paired with matching tool_result). Matches
+		// vercel-ai/packages/ai/src/generate-text/generate-text.ts where
+		// stopWhen() gates the next iteration only after tools have run.
+		if o.StopWhen != nil && stopSafe(o.StopWhen, steps) {
+			hookStopped = true
+			stopCause = provider.StopCausePredicate
+			break
+		}
 	}
 
 	// Post-loop: reachable when MaxSteps was exhausted OR when OnBeforeStep.Stop=true
@@ -1109,8 +1382,20 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	// short). This matches StreamText's conditional logic and correctly distinguishes
 	// "hook stopped" (StepsExhausted=false) from "max steps" (StepsExhausted=true).
 	tr := buildTextResult(steps, totalUsage)
-	if len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
+	// In the sync path every early-exit cause (Natural / NoExecutableTools /
+	// Abort) returns immediately inside the loop, so the only way we reach
+	// here with stopCause != "" is via a hookStopped break (BeforeStep /
+	// Predicate). The hookStopped guard alone is therefore sufficient; the
+	// former `stopCause == ""` check was a redundant belt-and-suspenders
+	// that is intentionally dropped here for clarity. Streaming keeps the
+	// extra guard because its loop has a Natural-case break that sets
+	// stopCause without setting hookStopped - see streamWithToolLoop.
+	if !hookStopped && len(steps) >= o.MaxSteps && len(steps) > 0 && len(steps[len(steps)-1].ToolCalls) > 0 {
 		tr.StepsExhausted = true
+		stopCause = provider.StopCauseMaxSteps
+	}
+	if stopCause == "" {
+		stopCause = provider.StopCauseNatural
 	}
 	tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
 	fireOnFinish(o.OnFinish, FinishInfo{
@@ -1118,11 +1403,33 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		TotalSteps:     len(steps),
 		TotalUsage:     totalUsage,
 		FinishReason:   tr.FinishReason,
+		StoppedBy:      stopCause,
 	})
 	return tr, nil
 }
 
 // fireOnFinish calls all OnFinish hooks with individual panic recovery.
+// stopSafe evaluates a StopCondition with recover. A panicking predicate is
+// treated as "do not stop" and logged to stderr (consistent with how
+// OnBeforeStep / OnStepFinish handle panics).
+func stopSafe(pred StopCondition, steps []StepResult) (stop bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "goai: recovered panic in StopWhen predicate: %v\n", r)
+			stop = false
+		}
+	}()
+	// Pass a shallow defensive copy so predicates cannot re-order or truncate
+	// the internal slice. NOTE: this is a TOP-LEVEL copy only - nested slices
+	// (StepResult.ToolCalls, StepResult.ToolResults, StepResult.Content) are
+	// ALIASED into the caller's view. Predicates MUST treat the StepResult
+	// contents as read-only; mutating nested slices corrupts goai internal
+	// state and is a contract violation. Deep-clone would be prohibitively
+	// expensive per-step for a feature (predicate side-effects) that is not
+	// a supported use case.
+	return pred(slices.Clone(steps))
+}
+
 func fireOnFinish(hooks []func(FinishInfo), info FinishInfo) {
 	for _, fn := range hooks {
 		func(f func(FinishInfo)) {
@@ -1193,7 +1500,7 @@ func executeToolsParallel(
 	toolMap map[string]Tool,
 	step int,
 	hooks toolHooks,
-) []provider.Message {
+) ([]provider.Message, []provider.ToolResult) {
 
 	results := make([]toolOutput, len(calls))
 	var wg sync.WaitGroup
@@ -1425,7 +1732,39 @@ func executeToolsParallel(
 	if !hooks.sequential {
 		wg.Wait()
 	}
-	return buildToolMessages(calls, results)
+	return buildToolMessages(calls, results), buildToolResults(calls, results)
+}
+
+// buildToolResults converts raw tool outputs into structured provider.ToolResult
+// values (one per call, in call order). The Output string mirrors exactly what
+// buildToolMessages places in the tool-result message content so consumers can
+// correlate predicate input with the on-wire transcript.
+func buildToolResults(calls []provider.ToolCall, results []toolOutput) []provider.ToolResult {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]provider.ToolResult, len(calls))
+	for i, tc := range calls {
+		r := results[i]
+		tr := provider.ToolResult{
+			ToolCallID: tc.ID,
+			ToolName:   tc.Name,
+			Error:      r.err,
+			IsError:    r.err != nil,
+		}
+		if r.err != nil {
+			errStr := r.err.Error()
+			runes := []rune(errStr)
+			if len(runes) > 500 {
+				errStr = string(runes[:500]) + "..."
+			}
+			tr.Output = "error: " + errStr
+		} else {
+			tr.Output = r.result
+		}
+		out[i] = tr
+	}
+	return out
 }
 
 // buildToolMessages converts tool call results to provider messages.
@@ -1519,17 +1858,23 @@ func buildTextResult(steps []StepResult, totalUsage provider.Usage) *TextResult 
 
 // buildResponseMessages constructs the full ResponseMessages from the tool round-trip
 // messages (delta between original and final params.Messages) and the steps.
-// The delta contains assistant+tool messages for each step where appendToolRoundTrip
-// ran. When the loop exits normally (final step produces text, no tool calls), that
-// final assistant message is NOT in the delta, so we append it. When MaxSteps is
-// exhausted and the last step still has tool calls, appendToolRoundTrip already added
-// the assistant+tool messages for that step , appending again would duplicate.
 //
-// Consecutive tool messages are merged into a single message because some providers
-// require parallel tool results in a single message (not split across multiple messages).
+// With Vercel-parity StopWhen placement (evaluated AFTER tool execution and
+// appendToolRoundTrip), the delta always contains the assistant + tool-result
+// messages for every completed step whose LLM response carried tool calls --
+// including the last step on a StopWhen break and at MaxSteps exhaustion. The
+// only case the delta is missing the last step's assistant message is a
+// natural termination (last step produced text with no tool calls): that
+// message is appended here.
 //
-// The reasoning parameter provides thinking/reasoning parts for the final assistant
-// message (streaming path only; GenerateText passes nil).
+// Consecutive tool messages are merged into a single message because some
+// providers require parallel tool results in a single message (not split
+// across multiple messages).
+//
+// The reasoning parameter provides thinking/reasoning parts for the final
+// assistant message (streaming path only; GenerateText passes nil). It is
+// only applied when the delta is empty or the last step had no tool calls
+// (i.e. when we are actually building the final assistant message here).
 func buildResponseMessages(roundTripDelta []provider.Message, steps []StepResult, reasoning []provider.Part) []provider.Message {
 	if len(steps) == 0 {
 		return nil
@@ -1540,17 +1885,14 @@ func buildResponseMessages(roundTripDelta []provider.Message, steps []StepResult
 	}
 	msgs := mergeToolMessages(roundTripDelta)
 	if len(last.ToolCalls) > 0 {
-		// MaxSteps exhausted: appendToolRoundTrip already added this step's
-		// assistant + tool messages to the delta. Skip to avoid duplication.
-		// Invariant: len(last.ToolCalls) > 0 implies appendToolRoundTrip ran for the
-		// last step. This holds because the loop only exits early (before appendToolRoundTrip)
-		// when FinishReason != FinishToolCalls or ToolCalls is empty , in both cases
-		// last.ToolCalls would be empty.
+		// Delta already contains this step's assistant + tool-result messages
+		// (appendToolRoundTrip ran before loop break). Avoid duplication.
 		return msgs
 	}
+	// Natural termination: last step produced text with no tool calls - its
+	// assistant message is NOT yet in the delta.
 	finalMsg := buildFinalAssistantMessages(last.Text, last.ToolCalls, reasoning)
-	msgs = append(msgs, finalMsg...)
-	return msgs
+	return append(msgs, finalMsg...)
 }
 
 // mergeToolMessages merges consecutive tool-role messages into single messages.

--- a/generate_test.go
+++ b/generate_test.go
@@ -589,7 +589,7 @@ func TestBuildParams_ToolExecuteNotIncluded(t *testing.T) {
 	}))
 	params := buildParams(opts)
 
-	// provider.ToolDefinition should not have Execute -- verify by checking fields exist.
+	// provider.ToolDefinition should not have Execute - verify by checking fields exist.
 	if len(params.Tools) != 1 {
 		t.Fatalf("expected 1 tool, got %d", len(params.Tools))
 	}
@@ -871,7 +871,7 @@ func TestGenerateText_ToolLoop_MultiStep(t *testing.T) {
 }
 
 func TestGenerateText_ToolLoop_MaxStepsReached(t *testing.T) {
-	// Model always requests tool calls -- should stop at MaxSteps.
+	// Model always requests tool calls - should stop at MaxSteps.
 	callCount := 0
 	model := &mockModel{
 		id: "test",
@@ -1071,7 +1071,7 @@ func TestGenerateText_ToolLoop_NoExecuteNoLoop(t *testing.T) {
 			Name:        "read",
 			Description: "Read a file",
 			InputSchema: json.RawMessage(`{"type":"object"}`),
-			// No Execute -- tool definitions only, loop managed externally.
+			// No Execute - tool definitions only, loop managed externally.
 		}),
 	)
 	if err != nil {
@@ -1797,7 +1797,7 @@ func TestExecuteToolsParallel_ContextCancelled(t *testing.T) {
 
 	// With parallel execution, all tools run via goroutines and complete.
 	// The cancelled context is passed to Execute, but the tool ignores it.
-	msgs := executeToolsParallel(ctx, calls, toolMap, 1, toolHooks{})
+	msgs, _ := executeToolsParallel(ctx, calls, toolMap, 1, toolHooks{})
 	if len(msgs) != 2 {
 		t.Errorf("expected 2 messages (parallel execution completes all), got %d", len(msgs))
 	}
@@ -5167,7 +5167,7 @@ func TestGenerateText_ResponseMessages_NoToolExecute(t *testing.T) {
 			Name:        "search",
 			Description: "Search the web",
 			InputSchema: json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}}}`),
-			// No Execute function -- tool loop should not proceed.
+			// No Execute function - tool loop should not proceed.
 		}),
 	)
 	if err != nil {

--- a/generate_test.go
+++ b/generate_test.go
@@ -5954,3 +5954,112 @@ func TestGenerateText_ResponseMessages_EmptyResponse(t *testing.T) {
 		t.Errorf("ResponseMessages = %v, want nil for empty response", result.ResponseMessages)
 	}
 }
+
+// TestFinalizeStopCause covers the post-loop classifier. The two branches it
+// exposes (MaxSteps guard and the StopCauseNatural default) are unreachable
+// through GenerateText / streamWithToolLoop's public paths because every
+// early-exit path sets stopCause and the loop's natural termination trips
+// the MaxSteps guard. Testing the helper directly locks in the intended
+// behavior and gives coverage for both branches.
+func TestFinalizeStopCause(t *testing.T) {
+	stepWithTools := StepResult{ToolCalls: []provider.ToolCall{{ID: "1"}}}
+	stepWithoutTools := StepResult{}
+
+	cases := []struct {
+		name           string
+		hookStopped    bool
+		current        provider.StopCause
+		steps          []StepResult
+		maxSteps       int
+		wantCause      provider.StopCause
+		wantExhausted  bool
+	}{
+		{
+			name:          "max-steps guard trips",
+			current:       "",
+			steps:         []StepResult{stepWithTools, stepWithTools},
+			maxSteps:      2,
+			wantCause:     provider.StopCauseMaxSteps,
+			wantExhausted: true,
+		},
+		{
+			name:          "hook-stopped suppresses max-steps guard",
+			hookStopped:   true,
+			current:       provider.StopCausePredicate,
+			steps:         []StepResult{stepWithTools, stepWithTools},
+			maxSteps:      2,
+			wantCause:     provider.StopCausePredicate,
+			wantExhausted: false,
+		},
+		{
+			name:          "existing cause skips guard",
+			current:       provider.StopCauseEmpty,
+			steps:         []StepResult{stepWithTools},
+			maxSteps:      1,
+			wantCause:     provider.StopCauseEmpty,
+			wantExhausted: false,
+		},
+		{
+			name:          "last step without tool calls falls through to natural default",
+			current:       "",
+			steps:         []StepResult{stepWithoutTools},
+			maxSteps:      1,
+			wantCause:     provider.StopCauseNatural,
+			wantExhausted: false,
+		},
+		{
+			name:          "empty steps falls through to natural default",
+			current:       "",
+			steps:         nil,
+			maxSteps:      1,
+			wantCause:     provider.StopCauseNatural,
+			wantExhausted: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCause, gotExhausted := finalizeStopCause(tc.hookStopped, tc.current, tc.steps, tc.maxSteps)
+			if gotCause != tc.wantCause {
+				t.Errorf("cause = %q, want %q", gotCause, tc.wantCause)
+			}
+			if gotExhausted != tc.wantExhausted {
+				t.Errorf("exhausted = %v, want %v", gotExhausted, tc.wantExhausted)
+			}
+		})
+	}
+}
+
+// TestBuildToolResults covers the empty-calls short-circuit and the >500-rune
+// error-message truncation path. Neither is reachable through the public
+// GenerateText / StreamText paths: executeToolsParallel only invokes
+// buildToolResults when at least one tool call exists, and tool errors in
+// practice are bounded well below 500 runes.
+func TestBuildToolResults(t *testing.T) {
+	t.Run("empty calls returns nil", func(t *testing.T) {
+		got := buildToolResults(nil, nil)
+		if got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("error longer than 500 runes is truncated", func(t *testing.T) {
+		longMsg := strings.Repeat("x", 600)
+		calls := []provider.ToolCall{{ID: "c1", Name: "t"}}
+		results := []toolOutput{{err: errors.New(longMsg)}}
+		got := buildToolResults(calls, results)
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		if !strings.HasPrefix(got[0].Output, "error: ") {
+			t.Errorf("Output prefix = %q, want 'error: ' prefix", got[0].Output)
+		}
+		if !strings.HasSuffix(got[0].Output, "...") {
+			t.Errorf("truncated Output should end with '...'; got %q", got[0].Output[len(got[0].Output)-10:])
+		}
+		// 500 truncated runes + "error: " prefix + "..." suffix.
+		wantLen := len("error: ") + 500 + len("...")
+		if len(got[0].Output) != wantLen {
+			t.Errorf("Output len = %d, want %d", len(got[0].Output), wantLen)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.25.0
 
 require golang.org/x/oauth2 v0.36.0
 
-require cloud.google.com/go/compute/metadata v0.3.0 // indirect
+require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=

--- a/hooks.go
+++ b/hooks.go
@@ -112,6 +112,14 @@ type ToolCallInfo struct {
 // Multiple callbacks are called in registration order. Each callback is individually
 // panic-recovered in all paths (GenerateText, StreamText, GenerateObject, StreamObject).
 // A panic in one callback does not prevent subsequent callbacks from firing.
+//
+// Timing: OnStepFinish fires after the LLM call for the step returns and
+// BEFORE any tool executions for that step run. The StepResult passed to
+// the hook therefore always carries an EMPTY ToolResults slice - even in
+// the sync (GenerateText) path. To observe tool results as they complete,
+// use OnToolCall or OnAfterToolExecute; to see the full populated
+// StepResult.ToolResults after tools ran, inspect the TextResult.Steps
+// slice returned by GenerateText or stream.Result().
 func WithOnStepFinish(fn func(StepResult)) Option {
 	return func(o *options) { o.OnStepFinish = append(o.OnStepFinish, fn) }
 }
@@ -123,7 +131,7 @@ func WithOnStepFinish(fn func(StepResult)) Option {
 type FinishInfo struct {
 	// StepsExhausted is true when MaxSteps was reached while the model still
 	// requested tool calls. This is the authoritative signal for "max_steps"
-	// termination -- it is not available from any per-step hook.
+	// termination - it is not available from any per-step hook.
 	StepsExhausted bool
 
 	// TotalSteps is the number of generation steps executed.
@@ -134,6 +142,17 @@ type FinishInfo struct {
 
 	// FinishReason from the last step.
 	FinishReason provider.FinishReason
+
+	// StoppedBy classifies how the loop terminated: natural model exit,
+	// MaxSteps exhaustion, WithStopWhen predicate, OnBeforeStep.Stop,
+	// an error-driven abort, an empty provider stream, or a model
+	// requesting tool calls with no executable tools configured.
+	// Possible values: "natural", "max-steps", "predicate", "before-step",
+	// "abort", "empty" (streaming only), "no-executable-tools" (sync only).
+	// Useful when FinishReason alone is ambiguous (e.g. a StopWhen break
+	// on a tool-calls step reports FinishToolCalls but
+	// StoppedBy=="predicate"). May be empty on pre-loop error paths.
+	StoppedBy provider.StopCause
 }
 
 // WithOnFinish adds a callback invoked once after all generation steps complete.
@@ -372,7 +391,7 @@ func WithOnBeforeStep(fn func(BeforeStepInfo) BeforeStepResult) Option {
 // returns a replacement. This enables observability packages to add side-effects without
 // replacing the user's hook.
 //
-// The wrapper MUST return the user hook's result verbatim when delegating -- accidentally
+// The wrapper MUST return the user hook's result verbatim when delegating - accidentally
 // zeroing the struct suppresses tool executions or input overrides. When the existing
 // hook is nil, return a zero BeforeToolExecuteResult (no skip, no override).
 //
@@ -388,11 +407,11 @@ func WrapOnBeforeToolExecute(wrapper func(existing func(BeforeToolExecuteInfo) B
 
 // WrapOnAfterToolExecute returns an Option that wraps the existing OnAfterToolExecute hook.
 // The wrapper function receives the current hook (may be nil) and returns a replacement.
-// The wrapper MUST return the user hook's result verbatim -- an empty AfterToolExecuteResult
+// The wrapper MUST return the user hook's result verbatim - an empty AfterToolExecuteResult
 // has special semantics (empty Output preserves original, nil Error preserves original).
 // When the existing hook is nil, return a zero AfterToolExecuteResult.
 //
-// Ordering hazard: same as WrapOnBeforeToolExecute -- apply after user hooks.
+// Ordering hazard: same as WrapOnBeforeToolExecute - apply after user hooks.
 func WrapOnAfterToolExecute(wrapper func(existing func(AfterToolExecuteInfo) AfterToolExecuteResult) func(AfterToolExecuteInfo) AfterToolExecuteResult) Option {
 	return func(o *options) {
 		o.OnAfterToolExecute = wrapper(o.OnAfterToolExecute)
@@ -404,7 +423,7 @@ func WrapOnAfterToolExecute(wrapper func(existing func(AfterToolExecuteInfo) Aft
 // The wrapper MUST forward the user hook's Stop and ExtraMessages fields verbatim.
 // When the existing hook is nil, return a zero BeforeStepResult (no stop, no messages).
 //
-// Ordering hazard: same as WrapOnBeforeToolExecute -- apply after user hooks.
+// Ordering hazard: same as WrapOnBeforeToolExecute - apply after user hooks.
 func WrapOnBeforeStep(wrapper func(existing func(BeforeStepInfo) BeforeStepResult) func(BeforeStepInfo) BeforeStepResult) Option {
 	return func(o *options) {
 		o.OnBeforeStep = wrapper(o.OnBeforeStep)

--- a/object.go
+++ b/object.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/zendev-sh/goai/provider"
@@ -18,6 +19,84 @@ import (
 // osStderr holds os.Stderr at package level so ObjectStream methods can write to
 // stderr despite their receiver being named "os", which shadows the os package.
 var osStderr = os.Stderr
+
+// Per-function once flags for GenerateObject and StreamObject warnings
+// (FIX 12). A single package-global once would fire only once total across
+// both functions, silencing the warning for whichever function is called
+// second - even though the caller passed WithStopWhen to a different entry
+// point. Each function now emits its warning at most once per process.
+//
+// Implementation (FIX 21): uses atomic.Bool CAS instead of sync.Once so that
+// tests can reset the flag cleanly without the "reassign a sync.Once" hazard
+// (which is technically unsound if observed concurrently by another goroutine).
+// atomic.Bool.Store(false) is a well-defined reset. The warn function itself
+// is also swappable via warnStopWhenIgnoredForObject for tests that want to
+// inject a capture instead of stderr plumbing.
+//
+// FIX 33 - reset caveat: unlike sync.Once, a CAS-guarded atomic.Bool can be
+// reset with Store(false). This is safe ONLY when no other goroutine may
+// concurrently call defaultWarnStopWhenIgnoredForObject (i.e. the reset site
+// externally serializes with all warn callers). Tests in this package call
+// Store(false) from the test goroutine while the warning code path is
+// quiescent; they do NOT use t.Parallel() for exactly this reason. DO NOT
+// add t.Parallel() to any test that resets these flags, and DO NOT reset
+// these flags from production code.
+var (
+	generateObjectStopWhenWarned atomic.Bool
+	streamObjectStopWhenWarned   atomic.Bool
+	generateObjectStateRefWarned atomic.Bool
+	streamObjectStateRefWarned   atomic.Bool
+)
+
+// warnStopWhenIgnoredForObject is a package-level function variable so that
+// tests can swap in a capture implementation if needed. Production code path
+// uses defaultWarnStopWhenIgnoredForObject.
+var warnStopWhenIgnoredForObject = defaultWarnStopWhenIgnoredForObject
+
+// warnStateRefIgnoredForObject mirrors warnStopWhenIgnoredForObject: a
+// package-level function variable swappable in tests. Production path uses
+// defaultWarnStateRefIgnoredForObject. See FIX 35.
+var warnStateRefIgnoredForObject = defaultWarnStateRefIgnoredForObject
+
+func defaultWarnStopWhenIgnoredForObject(fn string) {
+	msg := fmt.Sprintf("goai: WithStopWhen is not supported in %s (ignored)\n", fn)
+	switch fn {
+	case "GenerateObject":
+		if generateObjectStopWhenWarned.CompareAndSwap(false, true) {
+			_, _ = fmt.Fprint(osStderr, msg)
+		}
+	case "StreamObject":
+		if streamObjectStopWhenWarned.CompareAndSwap(false, true) {
+			_, _ = fmt.Fprint(osStderr, msg)
+		}
+	default:
+		// Unknown call site: print once per call (should never happen - all
+		// call sites pass a hard-coded literal).
+		_, _ = fmt.Fprint(osStderr, msg)
+	}
+}
+
+// defaultWarnStateRefIgnoredForObject is invoked from GenerateObject and
+// StreamObject when the caller passed WithStateRef. Those functions do not
+// run a multi-step tool loop worth polling, so the AgentState would be
+// stuck at its zero value (StepStarting, 0) forever - a subtle deadlock for
+// pollers. One-shot stderr warning matches the WithStopWhen-in-object
+// convention above (FIX 35). The FIX 33 reset caveat applies identically.
+func defaultWarnStateRefIgnoredForObject(fn string) {
+	msg := fmt.Sprintf("goai: WithStateRef is not supported in %s (ignored - AgentState will not advance)\n", fn)
+	switch fn {
+	case "GenerateObject":
+		if generateObjectStateRefWarned.CompareAndSwap(false, true) {
+			_, _ = fmt.Fprint(osStderr, msg)
+		}
+	case "StreamObject":
+		if streamObjectStateRefWarned.CompareAndSwap(false, true) {
+			_, _ = fmt.Fprint(osStderr, msg)
+		}
+	default:
+		_, _ = fmt.Fprint(osStderr, msg)
+	}
+}
 
 // ObjectResult is the final result of a structured output generation.
 type ObjectResult[T any] struct {
@@ -88,7 +167,7 @@ func newObjectStream[T any](ctx context.Context, source <-chan provider.StreamCh
 
 // PartialObjectStream returns a channel that emits partial objects as JSON accumulates.
 // Each emitted value has progressively more fields populated.
-// Mutually exclusive with Result() -- only call one consumption method first.
+// Mutually exclusive with Result() - only call one consumption method first.
 func (os *ObjectStream[T]) PartialObjectStream() <-chan *T {
 	ch := make(chan *T, 64)
 	os.consumeOnce.Do(func() {
@@ -98,7 +177,7 @@ func (os *ObjectStream[T]) PartialObjectStream() <-chan *T {
 	if os.partialCh != nil {
 		return os.partialCh
 	}
-	// Called after Result() consumed the source -- return closed channel.
+	// Called after Result() consumed the source - return closed channel.
 	close(ch)
 	return ch
 }
@@ -171,6 +250,7 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 				TotalSteps:   1,
 				TotalUsage:   os.usage,
 				FinishReason: os.finishReason,
+				StoppedBy:    provider.StopCauseNatural,
 			})
 		}()
 	}
@@ -301,13 +381,20 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 //
 // If MaxSteps is exhausted before a "stop" step occurs, an error is returned.
 // This differs slightly from Vercel AI SDK, which returns a partial result with
-// a nil output field — in Go, returning an error is the idiomatic equivalent.
+// a nil output field - in Go, returning an error is the idiomatic equivalent.
 func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, opts ...Option) (*ObjectResult[T], error) {
 	if model == nil {
 		return nil, errors.New("goai: model must not be nil")
 	}
 
 	o := applyOptions(opts...)
+
+	if o.StopWhen != nil {
+		warnStopWhenIgnoredForObject("GenerateObject")
+	}
+	if o.StateRef != nil {
+		warnStateRefIgnoredForObject("GenerateObject")
+	}
 
 	if o.Prompt == "" && len(o.Messages) == 0 {
 		return nil, errors.New("goai: prompt or messages must not be empty")
@@ -329,7 +416,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 
 	params := buildParams(o)
 	originalLen := len(params.Messages)
-	// ResponseFormat is set upfront and sent on every step — the model decides
+	// ResponseFormat is set upfront and sent on every step - the model decides
 	// when to call tools vs return structured JSON. This mirrors Vercel AI SDK
 	// where output parsing happens only on the step with finishReason "stop".
 	params.ResponseFormat = &provider.ResponseFormat{
@@ -411,6 +498,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: lastFinish,
+				StoppedBy:    provider.StopCauseAbort,
 			})
 			return nil, err
 		}
@@ -458,6 +546,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: result.FinishReason,
+				StoppedBy:    provider.StopCauseNatural,
 			})
 			return &ObjectResult[T]{
 				Object:           obj,
@@ -470,11 +559,11 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 			}, nil
 		}
 
-		// Model requested tool calls — execute them and continue.
+		// Model requested tool calls - execute them and continue.
 		// Clear tool_choice after the first tool step so the model can freely
 		// produce structured output on subsequent steps.
 		params.ToolChoice = ""
-		toolMessages := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
+		toolMessages, _ := executeToolsParallel(ctx, result.ToolCalls, toolMap, step, toolHooks{
 			sequential:      o.SequentialTools,
 			onToolCallStart: o.OnToolCallStart,
 			onToolCall:      o.OnToolCall,
@@ -484,7 +573,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		params.Messages = appendToolRoundTrip(params.Messages, result.Text, nil, result.ToolCalls, toolMessages)
 	}
 
-	// MaxSteps exhausted with tool calls still pending — no structured output produced.
+	// MaxSteps exhausted with tool calls still pending - no structured output produced.
 	lastFinish := provider.FinishReason("")
 	if len(steps) > 0 {
 		lastFinish = steps[len(steps)-1].FinishReason
@@ -494,6 +583,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		TotalSteps:     len(steps),
 		TotalUsage:     totalUsage,
 		FinishReason:   lastFinish,
+		StoppedBy:      provider.StopCauseMaxSteps,
 	})
 	return nil, fmt.Errorf("goai: max steps (%d) reached without producing structured output", o.MaxSteps)
 }
@@ -511,6 +601,13 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 	}
 
 	o := applyOptions(opts...)
+
+	if o.StopWhen != nil {
+		warnStopWhenIgnoredForObject("StreamObject")
+	}
+	if o.StateRef != nil {
+		warnStateRefIgnoredForObject("StreamObject")
+	}
 
 	if o.Prompt == "" && len(o.Messages) == 0 {
 		return nil, errors.New("goai: prompt or messages must not be empty")

--- a/object_test.go
+++ b/object_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -1267,7 +1268,7 @@ func TestObjectStream_PartialObjectStreamAfterResult(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Call Result() first -- this consumes the source.
+	// Call Result() first - this consumes the source.
 	result, err := stream.Result()
 	if err != nil {
 		t.Fatal(err)
@@ -1276,7 +1277,7 @@ func TestObjectStream_PartialObjectStreamAfterResult(t *testing.T) {
 		t.Errorf("Object.Name = %q, want Alice", result.Object.Name)
 	}
 
-	// Now call PartialObjectStream() -- should return a closed channel (0 items).
+	// Now call PartialObjectStream() - should return a closed channel (0 items).
 	ch := stream.PartialObjectStream()
 	count := 0
 	for range ch {
@@ -1440,7 +1441,7 @@ func TestGenerateObject_ToolLoop(t *testing.T) {
 		t.Error("tool result not present in final step messages")
 	}
 
-	// ResponseFormat is set on every call — the mock returns FinishToolCalls on
+	// ResponseFormat is set on every call - the mock returns FinishToolCalls on
 	// step 1 because real providers call tools even when ResponseFormat is present,
 	// deferring JSON output until they have enough information.
 }
@@ -1466,7 +1467,7 @@ func TestGenerateObject_ToolLoop_MaxSteps1_NoLoop(t *testing.T) {
 	toolExecuted := false
 	result, err := GenerateObject[simpleObject](t.Context(), model,
 		WithPrompt("generate"),
-		// MaxSteps defaults to 1 — no explicit WithMaxSteps needed.
+		// MaxSteps defaults to 1 - no explicit WithMaxSteps needed.
 		WithTools(Tool{
 			Name:        "unused_tool",
 			Description: "never called",
@@ -1507,7 +1508,7 @@ func TestGenerateObject_ToolLoop_StopsEarlyWhenNoToolCalls(t *testing.T) {
 				t.Error("ResponseFormat must be set on every step")
 			}
 			if callCount > 1 {
-				t.Fatalf("unexpected call count %d — should have stopped after step 1", callCount)
+				t.Fatalf("unexpected call count %d - should have stopped after step 1", callCount)
 			}
 			// Model decides it doesn't need tools, returns JSON directly.
 			return &provider.GenerateResult{
@@ -1520,7 +1521,7 @@ func TestGenerateObject_ToolLoop_StopsEarlyWhenNoToolCalls(t *testing.T) {
 
 	result, err := GenerateObject[simpleObject](t.Context(), model,
 		WithPrompt("generate"),
-		WithMaxSteps(5), // high limit — model stops on its own after 1 call
+		WithMaxSteps(5), // high limit - model stops on its own after 1 call
 		WithTools(Tool{
 			Name:        "some_tool",
 			Description: "some tool",
@@ -1550,7 +1551,7 @@ func TestGenerateObject_ToolLoop_MaxStepsExhausted(t *testing.T) {
 	model := &mockModel{
 		id: "test",
 		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
-			// Always requests a tool call — never produces stop.
+			// Always requests a tool call - never produces stop.
 			return &provider.GenerateResult{
 				FinishReason: provider.FinishToolCalls,
 				ToolCalls:    []provider.ToolCall{{ID: "c", Name: "t", Input: json.RawMessage(`{}`)}},
@@ -2182,5 +2183,107 @@ func TestStreamObject_ResponseMessages(t *testing.T) {
 	}
 	if msg.Content[0].Text != `{"name":"Alice","age":30}` {
 		t.Errorf("ResponseMessages[0].Content[0].Text = %q, want JSON output", msg.Content[0].Text)
+	}
+}
+
+// TestGenerateObject_StopWhenIgnored verifies FIX 3 + FIX 12: passing
+// WithStopWhen to GenerateObject / StreamObject emits a one-shot stderr
+// warning per entry point (separate sync.Once for each) and does not affect
+// behaviour.
+func TestGenerateObject_StopWhenIgnored(t *testing.T) {
+	// NOT parallel-safe: mutates package-global warn state (atomic flags +
+	// osStderr). Must not run with t.Parallel() and any test that races on
+	// these globals would interfere. The atomic.Bool.Store(false) reset
+	// (FIX 21) replaces the earlier sync.Once reassignment, which was
+	// technically unsound if observed concurrently.
+	origStderr := osStderr
+	// Reset BOTH warn flags for this test so the warnings actually fire
+	// regardless of earlier calls in other tests in this package (FIX 12).
+	generateObjectStopWhenWarned.Store(false)
+	streamObjectStopWhenWarned.Store(false)
+	t.Cleanup(func() { osStderr = origStderr })
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	osStderr = w
+
+	// Simple GenerateObject call with WithStopWhen - predicate must be ignored.
+	genModel := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{
+				Text:         `{"name":"Alice","age":30}`,
+				FinishReason: provider.FinishStop,
+				Usage:        provider.Usage{InputTokens: 1, OutputTokens: 1},
+			}, nil
+		},
+	}
+	_, err = GenerateObject[simpleObject](t.Context(), genModel,
+		WithPrompt("x"),
+		WithStopWhen(func(_ []StepResult) bool { return true }),
+	)
+	if err != nil {
+		t.Fatalf("GenerateObject: %v", err)
+	}
+
+	// Second GenerateObject call - warning must NOT repeat (per-function sync.Once).
+	_, _ = GenerateObject[simpleObject](t.Context(), genModel,
+		WithPrompt("x"),
+		WithStopWhen(func(_ []StepResult) bool { return true }),
+	)
+
+	// FIX 12: a StreamObject call must emit its OWN warning - the
+	// GenerateObject call above must not have silenced it.
+	streamModel := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			ch := make(chan provider.StreamChunk, 4)
+			ch <- provider.StreamChunk{Type: provider.ChunkText, Text: `{"name":"Alice","age":30}`}
+			ch <- provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop}
+			close(ch)
+			return &provider.StreamResult{Stream: ch}, nil
+		},
+	}
+	so, err := StreamObject[simpleObject](t.Context(), streamModel,
+		WithPrompt("x"),
+		WithStopWhen(func(_ []StepResult) bool { return true }),
+	)
+	if err != nil {
+		t.Fatalf("StreamObject: %v", err)
+	}
+	// Drain the partial-object stream so the goroutine exits cleanly.
+	for range so.PartialObjectStream() {
+	}
+	if _, err := so.Result(); err != nil {
+		t.Fatalf("StreamObject Result: %v", err)
+	}
+
+	// Second StreamObject call - per-function sync.Once must suppress.
+	so2, err := StreamObject[simpleObject](t.Context(), streamModel,
+		WithPrompt("x"),
+		WithStopWhen(func(_ []StepResult) bool { return true }),
+	)
+	if err != nil {
+		t.Fatalf("StreamObject 2: %v", err)
+	}
+	for range so2.PartialObjectStream() {
+	}
+
+	_ = w.Close()
+	osStderr = origStderr
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	got := string(buf[:n])
+	if !strings.Contains(got, "WithStopWhen is not supported in GenerateObject") {
+		t.Errorf("stderr did not contain GenerateObject warning; got=%q", got)
+	}
+	if !strings.Contains(got, "WithStopWhen is not supported in StreamObject") {
+		t.Errorf("stderr did not contain StreamObject warning; got=%q", got)
+	}
+	// Two distinct warnings, one per entry point, no duplicates.
+	if n := strings.Count(got, "not supported"); n != 2 {
+		t.Errorf("warning emitted %d times, want 2 (one per entry point); stderr=%q", n, got)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -132,6 +132,14 @@ type options struct {
 
 	// EmbeddingProviderOptions are provider-specific parameters for embedding requests.
 	EmbeddingProviderOptions map[string]any
+
+	// StopWhen, when non-nil, is evaluated after each step in the tool loop.
+	// Returning true exits the loop cleanly. See WithStopWhen.
+	StopWhen StopCondition
+
+	// StateRef, when non-nil, receives atomic state updates as the tool loop
+	// progresses. See WithStateRef / AgentState.
+	StateRef *AgentState
 }
 
 // defaultOptions returns options with sensible defaults.

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -911,4 +911,15 @@ func TestToolResult_JSONRoundTrip(t *testing.T) {
 			t.Errorf("Error message = %q; want %q", got.Error.Error(), sentinel.Error())
 		}
 	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		// Outer syntax must be valid so the runtime dispatches into our
+		// UnmarshalJSON method; a type mismatch inside (array where an
+		// object is expected) forces the inner json.Unmarshal call to fail
+		// and exercise the error-return path.
+		var got provider.ToolResult
+		if err := got.UnmarshalJSON([]byte(`[1,2,3]`)); err == nil {
+			t.Fatalf("expected error for type-mismatched JSON, got nil")
+		}
+	})
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -387,7 +388,7 @@ func TestCachedTokenSourceNoExpiry(t *testing.T) {
 		return &provider.Token{Value: "forever"}, nil // zero ExpiresAt
 	})
 
-	// Zero ExpiresAt means "no expiry" -- token is cached indefinitely.
+	// Zero ExpiresAt means "no expiry" - token is cached indefinitely.
 	_, _ = ts.Token(t.Context())
 	_, _ = ts.Token(t.Context())
 	if callCount != 1 {
@@ -644,3 +645,270 @@ func TestCachedTokenSource_InvalidateDuringFetch(t *testing.T) {
 	}
 }
 
+
+// TestToolResult_JSONMarshal_ErrorAsString verifies FIX 19: ToolResult.Error
+// (an interface) marshals as a string via err.Error() rather than the default
+// "{}" that encoding/json emits for zero-populated error interfaces.
+// Observability and logging consumers need the message to be human-readable.
+func TestToolResult_JSONMarshal_ErrorAsString(t *testing.T) {
+	t.Run("error populated", func(t *testing.T) {
+		tr := provider.ToolResult{
+			ToolCallID: "tc1",
+			ToolName:   "bash",
+			Output:     "error: boom",
+			Error:      errors.New("boom"),
+			IsError:    true,
+		}
+		b, err := json.Marshal(tr)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got["Error"] != "boom" {
+			t.Errorf("Error field = %v, want %q", got["Error"], "boom")
+		}
+		if got["IsError"] != true {
+			t.Errorf("IsError = %v, want true", got["IsError"])
+		}
+		if got["ToolCallID"] != "tc1" {
+			t.Errorf("ToolCallID = %v, want tc1", got["ToolCallID"])
+		}
+	})
+	t.Run("error nil omitted", func(t *testing.T) {
+		tr := provider.ToolResult{
+			ToolCallID: "tc2",
+			ToolName:   "echo",
+			Output:     "ok",
+			IsError:    false,
+		}
+		b, err := json.Marshal(tr)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, present := got["Error"]; present {
+			t.Errorf("Error field should be omitted when nil; got %v", got["Error"])
+		}
+	})
+}
+
+// TestToolResult_IsErrorInvariant verifies FIX 25: IsError is always
+// equivalent to (Error != nil). This is an ergonomic convenience field;
+// if it ever diverged from Error != nil, predicates branching on IsError
+// would see different behaviour from predicates branching on Error.
+//
+// Spot-check the invariant on two ToolResult construction shapes that
+// mirror buildToolResults output: one successful (no Error, IsError=false)
+// and one error (Error != nil, IsError=true).
+func TestToolResult_IsErrorInvariant(t *testing.T) {
+	cases := []provider.ToolResult{
+		{ToolCallID: "tc-ok", ToolName: "t", Output: "ok", Error: nil, IsError: false},
+		{ToolCallID: "tc-err", ToolName: "t", Output: "error: x", Error: errors.New("x"), IsError: true},
+	}
+	for _, tr := range cases {
+		if tr.IsError != (tr.Error != nil) {
+			t.Errorf("ToolResult{ID=%s}: IsError=%v but (Error!=nil)=%v - invariant broken", tr.ToolCallID, tr.IsError, tr.Error != nil)
+		}
+	}
+}
+
+// TestStopCause_IsValid verifies FIX 23: IsValid returns true only for the
+// seven declared StopCause constants, false for empty and arbitrary values.
+func TestStopCause_IsValid(t *testing.T) {
+	valid := []provider.StopCause{
+		provider.StopCauseNatural,
+		provider.StopCauseMaxSteps,
+		provider.StopCausePredicate,
+		provider.StopCauseBeforeStep,
+		provider.StopCauseAbort,
+		provider.StopCauseEmpty,
+		provider.StopCauseNoExecutableTools,
+	}
+	for _, c := range valid {
+		if !c.IsValid() {
+			t.Errorf("StopCause %q IsValid=false, want true", c)
+		}
+	}
+	invalid := []provider.StopCause{"", "unknown", "Natural", "bogus", "max_steps"}
+	for _, c := range invalid {
+		if c.IsValid() {
+			t.Errorf("StopCause %q IsValid=true, want false", c)
+		}
+	}
+}
+
+// TestToolResult_JSONRoundTrip verifies FIX 28: ToolResult survives a
+// MarshalJSON → UnmarshalJSON cycle with the IsError ↔ (Error != nil)
+// invariant preserved. Without UnmarshalJSON, the Error string produced
+// by MarshalJSON deserialized into a nil interface - silently breaking
+// the invariant for any consumer that persists ToolResults as JSON.
+func TestToolResult_JSONRoundTrip(t *testing.T) {
+	t.Run("error populated round-trips", func(t *testing.T) {
+		orig := provider.ToolResult{
+			ToolCallID: "tc1",
+			ToolName:   "bash",
+			Output:     "error: boom",
+			Error:      errors.New("boom"),
+			IsError:    true,
+		}
+		b, err := json.Marshal(orig)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got provider.ToolResult
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.ToolCallID != orig.ToolCallID {
+			t.Errorf("ToolCallID = %q, want %q", got.ToolCallID, orig.ToolCallID)
+		}
+		if got.ToolName != orig.ToolName {
+			t.Errorf("ToolName = %q, want %q", got.ToolName, orig.ToolName)
+		}
+		if got.Output != orig.Output {
+			t.Errorf("Output = %q, want %q", got.Output, orig.Output)
+		}
+		if got.Error == nil {
+			t.Fatalf("Error is nil after round-trip; want non-nil (invariant broken)")
+		}
+		if got.Error.Error() != "boom" {
+			t.Errorf("Error.Error() = %q, want %q", got.Error.Error(), "boom")
+		}
+		if !got.IsError {
+			t.Errorf("IsError = false, want true (invariant IsError == Error!=nil broken)")
+		}
+	})
+
+	t.Run("error nil round-trips", func(t *testing.T) {
+		orig := provider.ToolResult{
+			ToolCallID: "tc2",
+			ToolName:   "echo",
+			Output:     "ok",
+			IsError:    false,
+		}
+		b, err := json.Marshal(orig)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got provider.ToolResult
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Error != nil {
+			t.Errorf("Error = %v, want nil", got.Error)
+		}
+		if got.IsError {
+			t.Errorf("IsError = true, want false (invariant broken)")
+		}
+		if got.Output != "ok" {
+			t.Errorf("Output = %q, want %q", got.Output, "ok")
+		}
+	})
+
+	t.Run("IsError true with empty Error synthesizes placeholder", func(t *testing.T) {
+		// A hand-crafted JSON with IsError=true but no Error string must
+		// still preserve the invariant on unmarshal (synthesize error).
+		data := []byte(`{"ToolCallID":"tc3","ToolName":"x","Output":"y","IsError":true}`)
+		var got provider.ToolResult
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Error == nil {
+			t.Errorf("Error is nil but IsError=true; invariant broken (placeholder not synthesized)")
+		}
+		if !got.IsError {
+			t.Errorf("IsError = false, want true")
+		}
+	})
+
+	t.Run("Error string present forces IsError true", func(t *testing.T) {
+		// Defensive: IsError=false but Error non-empty → coerce IsError=true.
+		data := []byte(`{"ToolCallID":"tc4","ToolName":"x","Output":"y","Error":"oops","IsError":false}`)
+		var got provider.ToolResult
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Error == nil || got.Error.Error() != "oops" {
+			t.Errorf("Error = %v, want error with message %q", got.Error, "oops")
+		}
+		if !got.IsError {
+			t.Errorf("IsError = false, want true (coerced)")
+		}
+	})
+
+	// FIX 39: empty-string error messages must round-trip faithfully. The
+	// previous encoding used `omitempty` on Error, which dropped ""; the
+	// resurrected ToolResult was a placeholder (`"tool error (no message)"`)
+	// instead of the original empty message. A pointer-to-string alias
+	// distinguishes "key absent" from "empty string present".
+	t.Run("FIX 39: empty-string error round-trips faithfully", func(t *testing.T) {
+		orig := provider.ToolResult{
+			ToolCallID: "tc5",
+			ToolName:   "x",
+			Output:     "y",
+			Error:      errors.New(""),
+			IsError:    true,
+		}
+		b, err := json.Marshal(orig)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		// Wire form must carry the Error key even though the value is "".
+		if !strings.Contains(string(b), `"Error":""`) {
+			t.Fatalf("wire form missing explicit empty Error key; got %s", string(b))
+		}
+		var got provider.ToolResult
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Error == nil {
+			t.Fatalf("Error nil after round-trip; want non-nil with empty message")
+		}
+		if got.Error.Error() != "" {
+			t.Errorf("Error message = %q; want %q (empty-string fidelity lost - FIX 39 regression)", got.Error.Error(), "")
+		}
+		if !got.IsError {
+			t.Errorf("IsError = false; want true")
+		}
+	})
+
+	// FIX 40: sentinel identity is NOT preserved across JSON round-trip.
+	// Documented limitation: callers branching on errors.Is(r.Error,
+	// ErrSentinel) after JSON persistence will see false. This test pins
+	// the documented behavior so a future refactor that introduces a
+	// registry-based reconstruction updates godoc at the same time.
+	t.Run("FIX 40: sentinel identity is not preserved (documented)", func(t *testing.T) {
+		sentinel := errors.New("well-known sentinel")
+		orig := provider.ToolResult{
+			ToolCallID: "tc6",
+			ToolName:   "x",
+			Output:     "y",
+			Error:      sentinel,
+			IsError:    true,
+		}
+		b, err := json.Marshal(orig)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got provider.ToolResult
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Error == nil {
+			t.Fatalf("Error nil after round-trip")
+		}
+		if errors.Is(got.Error, sentinel) {
+			t.Fatalf("errors.Is(sentinel) returned true after JSON round-trip; documented FIX 40 limitation unexpectedly lifted - update godoc")
+		}
+		// Message is preserved even though identity is not.
+		if got.Error.Error() != sentinel.Error() {
+			t.Errorf("Error message = %q; want %q", got.Error.Error(), sentinel.Error())
+		}
+	})
+}

--- a/provider/types.go
+++ b/provider/types.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 )
 
 // TrySend sends a chunk to the output channel, returning false if the context
@@ -200,7 +201,14 @@ type StreamChunk struct {
 	// Usage (for ChunkFinish, may also appear on ChunkStepFinish).
 	Usage Usage
 
-	// Error (for ChunkError).
+	// Error carries the provider/goai error when Type == ChunkError.
+	//   - Nil for all non-ChunkError chunk types.
+	//   - May wrap APIError, NetworkError, or plain errors produced by the
+	//     provider or goai's tool loop (e.g. tool execution failures that are
+	//     surfaced as chunks rather than returned via Err()).
+	//   - Providers set this field directly; consumers should use
+	//     errors.Is / errors.As to branch on specific error categories rather
+	//     than comparing error values.
 	Error error
 
 	// Response metadata (populated on ChunkFinish with ID, Model from the provider).
@@ -208,6 +216,102 @@ type StreamChunk struct {
 
 	// Metadata for provider-specific data (e.g. thoughtSignature).
 	Metadata map[string]any
+
+	// StoppedBy classifies how the tool loop terminated. Only meaningful on
+	// the final ChunkFinish emitted by goai's tool loop. Values:
+	//
+	//	""                     - single-step provider chunk or unknown
+	//	"natural"              - the loop ended because the model did not request
+	//	                         additional tool calls (FinishStop or equivalent)
+	//	"max-steps"            - MaxSteps was reached while tool calls were still
+	//	                         pending (StepsExhausted)
+	//	"predicate"            - WithStopWhen predicate returned true
+	//	"before-step"          - OnBeforeStep hook returned Stop=true
+	//	"abort"                - the stream terminated on an error path
+	//	"empty"                - provider closed its stream with no chunks
+	//	                         (streaming-only; see StopCauseEmpty godoc)
+	//	"no-executable-tools"  - model returned tool calls but no tool in the
+	//	                         configured set has an Execute function
+	//	                         (sync-only; see StopCauseNoExecutableTools godoc)
+	StoppedBy StopCause
+}
+
+// StopCause classifies how a multi-step tool loop terminated. It is carried
+// on the final ChunkFinish emitted by goai's loop and on FinishInfo so sync
+// consumers (OnFinish hook) and stream consumers both see a consistent
+// signal. Provider-level chunks leave this empty.
+type StopCause string
+
+const (
+	// StopCauseNatural indicates the loop ended because the model did not
+	// request further tool calls.
+	StopCauseNatural StopCause = "natural"
+	// StopCauseMaxSteps indicates MaxSteps was reached with tool calls still pending.
+	StopCauseMaxSteps StopCause = "max-steps"
+	// StopCausePredicate indicates WithStopWhen returned true.
+	StopCausePredicate StopCause = "predicate"
+	// StopCauseBeforeStep indicates OnBeforeStep returned Stop=true.
+	StopCauseBeforeStep StopCause = "before-step"
+	// StopCauseAbort indicates the stream terminated on an error path.
+	StopCauseAbort StopCause = "abort"
+	// StopCauseEmpty indicates the provider closed its stream without sending
+	// any meaningful chunks (no text, no tool calls, no finish reason). This
+	// is not an error path; it is a distinct no-op response that consumers may
+	// want to treat differently from both "natural" (model completed) and
+	// "abort" (error).
+	//
+	// Emission scope (FIX 38 - narrowed): emitted only by the streaming
+	// multi-step tool-loop path (`streamWithToolLoop`, entered when
+	// MaxSteps>1 AND at least one configured tool has an Execute function).
+	// Sync (GenerateText / DoGenerate) paths do not emit this cause.
+	// Streaming single-shot paths (MaxSteps=1 or no executable tools, which
+	// bypass streamWithToolLoop) ALSO do not emit this cause - they hardcode
+	// StopCauseNatural regardless of chunk content, consistent with
+	// Vercel's single-iteration streaming behavior. Consumers that need a
+	// distinct "empty response" signal on single-shot streams should
+	// inspect len(TextResult.Text) and len(TextResult.ToolCalls) directly.
+	// A latent semantic question (should single-shot empty streams also
+	// emit StopCauseEmpty?) is tracked at the fireOnFinish call site in
+	// generate.go - see FIX 32 TODO.
+	StopCauseEmpty StopCause = "empty"
+	// StopCauseNoExecutableTools indicates the model returned tool calls but
+	// no tool in the configured tool set has an Execute function. The loop
+	// cannot proceed (there is nothing to execute) and exits cleanly. This is
+	// semantically distinct from StopCauseNatural ("model stopped on its
+	// own") because here the model still wants to continue but the consumer
+	// has not provided executable tools.
+	//
+	// Emission scope: sync-only (GenerateText). StreamText does NOT emit this
+	// cause because the streaming tool-loop path (streamWithToolLoop) is only
+	// entered when at least one executable tool is configured; a streaming
+	// call with zero executable tools takes the single-shot path and reports
+	// StopCauseNatural. Consumers needing a uniform signal across sync and
+	// stream can inspect ToolCalls on the last step and treat a non-empty
+	// list with no corresponding Execute function as equivalent.
+	StopCauseNoExecutableTools StopCause = "no-executable-tools"
+)
+
+// IsValid reports whether s is one of the StopCause constants declared in
+// this package. The empty string ("") is NOT considered valid (it is used
+// internally as a sentinel for "not yet classified" and to mark
+// provider-level chunks that predate the loop classifier).
+//
+// Consumers may use IsValid to defend against typos or downstream code
+// that constructs a StopCause from arbitrary text (StopCause is a string
+// alias so construction of unknown values cannot be prevented by the type
+// system alone).
+func (s StopCause) IsValid() bool {
+	switch s {
+	case StopCauseNatural,
+		StopCauseMaxSteps,
+		StopCausePredicate,
+		StopCauseBeforeStep,
+		StopCauseAbort,
+		StopCauseEmpty,
+		StopCauseNoExecutableTools:
+		return true
+	}
+	return false
 }
 
 // Message represents a conversation message.
@@ -293,6 +397,143 @@ type ToolCall struct {
 	// Metadata carries provider-specific data that must be preserved across
 	// tool round-trips (e.g., Google's thoughtSignature).
 	Metadata map[string]any
+}
+
+// ToolResult represents the outcome of executing a single tool call.
+//
+// It is a structured companion to the tool_result message content: where
+// tool-result messages carry the string payload destined for the LLM, a
+// ToolResult exposes the same information to in-process consumers (e.g.
+// StopCondition predicates) without forcing them to parse message parts.
+//
+// Output is the exact string sent back to the model (stringified JSON for
+// structured results, or "error: <detail>" when the tool call failed).
+// Error is non-nil iff the tool returned an error or panicked; IsError is
+// true in the same condition and is provided for ergonomics when
+// predicates only need the boolean signal.
+type ToolResult struct {
+	// ToolCallID matches the ID of the originating ToolCall.
+	ToolCallID string
+
+	// ToolName is the name of the tool that was invoked.
+	ToolName string
+
+	// Output is the stringified result sent to the model. For failed calls
+	// this is "error: <message>" (matching what the tool-result message
+	// carries); predicates should inspect Error or IsError to distinguish
+	// errors from deliberately empty successful outputs.
+	Output string
+
+	// Error is the error returned by the tool's Execute function, or
+	// goai.ErrUnknownTool when the model requested a tool not in the
+	// configured set. Nil on success.
+	//
+	// The standard encoding/json package cannot marshal the error
+	// interface directly (it would emit "{}"). ToolResult implements
+	// MarshalJSON to surface Error as a string ("Error.Error()") in
+	// JSON output so the field is useful in observability / logging.
+	Error error
+
+	// IsError is a convenience boolean equivalent to Error != nil.
+	IsError bool
+}
+
+// MarshalJSON implements json.Marshaler so that ToolResult round-trips
+// through encoding/json in a useful form. The Error field (an interface)
+// would otherwise marshal as "{}"; we emit it as a string using
+// err.Error(). All other fields use their natural JSON representation.
+//
+// FIX 39 - empty-string error fidelity. When r.Error is non-nil but
+// r.Error.Error() == "" (e.g. errors.New("")), we still emit the Error
+// key (as "") and IsError=true. Previously the Error field had
+// `omitempty`, so an empty message was dropped and UnmarshalJSON
+// resurrected a synthesized placeholder instead of honoring the empty
+// message the producer sent. Emitting Error unconditionally when
+// IsError is true preserves the exact string (including "") across
+// round-trips. Producers who never use empty-message errors are
+// unaffected: the wire form gains at most one `"Error":""` field.
+//
+// FIX 40 - sentinel identity is NOT preserved. If the producer set
+// r.Error to a sentinel (e.g. ErrUnknownTool from this package),
+// UnmarshalJSON reconstructs a plain errors.New(msg); callers doing
+// `errors.Is(r.Error, ErrUnknownTool)` after a JSON round-trip will get
+// false. Reconstructing sentinels from strings requires a registry and
+// is out of scope. Consumers relying on sentinel-based dispatch should
+// either avoid JSON round-trips for that data or add an out-of-band
+// error-code field.
+func (r ToolResult) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		ToolCallID string `json:"ToolCallID"`
+		ToolName   string `json:"ToolName"`
+		Output     string `json:"Output"`
+		// FIX 39: pointer alias with omitempty so "" round-trips faithfully.
+		//   - nil *string    → field absent in wire form (when r.Error == nil)
+		//   - non-nil *string → field emitted (even if the pointee is "")
+		// omitempty is load-bearing: it drops the key when the pointer is nil.
+		// MarshalJSON below always assigns a non-nil *string whenever
+		// r.Error != nil (even Error.Error() == ""), so the "Error":"" case
+		// is emitted intentionally and survives UnmarshalJSON.
+		Error   *string `json:"Error,omitempty"`
+		IsError bool    `json:"IsError"`
+	}
+	a := alias{
+		ToolCallID: r.ToolCallID,
+		ToolName:   r.ToolName,
+		Output:     r.Output,
+		IsError:    r.IsError,
+	}
+	if r.Error != nil {
+		s := r.Error.Error()
+		a.Error = &s
+	}
+	return json.Marshal(a)
+}
+
+// UnmarshalJSON implements json.Unmarshaler so that ToolResult round-trips
+// through encoding/json. The Error field was marshaled as a string (see
+// MarshalJSON); here we reconstruct it via errors.New when present and
+// preserve the invariant IsError == (Error != nil). If the JSON explicitly
+// sets IsError=true but has no Error key, we synthesize a placeholder
+// error so the invariant is preserved; conversely if Error is set but
+// IsError is false, we coerce IsError to true.
+//
+// FIX 39 uses a pointer-to-string alias so that a producer's empty
+// Error value ("") is distinguishable from "key absent entirely"
+// (nil pointer). Empty string preserves the producer's errors.New("")
+// faithfully; nil + IsError=true falls back to the placeholder.
+// FIX 40: sentinel identity is not recovered (see MarshalJSON godoc).
+func (r *ToolResult) UnmarshalJSON(data []byte) error {
+	type alias struct {
+		ToolCallID string  `json:"ToolCallID"`
+		ToolName   string  `json:"ToolName"`
+		Output     string  `json:"Output"`
+		Error      *string `json:"Error,omitempty"`
+		IsError    bool    `json:"IsError"`
+	}
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	r.ToolCallID = a.ToolCallID
+	r.ToolName = a.ToolName
+	r.Output = a.Output
+	switch {
+	case a.Error != nil:
+		// FIX 39: empty-string error messages round-trip faithfully.
+		// Previous code (non-pointer alias + omitempty) conflated
+		// "absent" with "empty string", causing errors.New("") to
+		// resurrect as a synthesized placeholder.
+		r.Error = errors.New(*a.Error)
+		r.IsError = true
+	case a.IsError:
+		// Explicit IsError=true with no Error key: synthesize placeholder.
+		r.Error = errors.New("tool error (no message)")
+		r.IsError = true
+	default:
+		r.Error = nil
+		r.IsError = false
+	}
+	return nil
 }
 
 // Usage tracks token consumption for a request.


### PR DESCRIPTION
## Summary
- Adds `AgentState` + `WithStateRef` for race-free, atomically-packed (kind, step) observation of the tool loop with a monotonic step counter across error paths.
- Adds `WithStopWhen(StopCondition)` with Vercel-parity placement (evaluated after each step's tool execution, before the next LLM call). Predicate receives a shallow clone of steps and is panic-recovered.
- Adds `StopCause` / `StoppedBy` on `FinishInfo` and final `ChunkFinish` (values: natural, max-steps, predicate, before-step, abort, empty, no-executable-tools).
- Adds `provider.ToolResult` attached to `StepResult.ToolResults`, with JSON round-trip; mirrored in streaming via an internal backfill chunk so `TextResult.Steps` matches the sync path.
- `GenerateObject` / `StreamObject` emit a one-shot stderr warning and ignore `WithStopWhen` / `WithStateRef`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass, pre-commit 90% coverage gate pass)
- [ ] Verify downstream consumer integration with `WithStateRef` polling
- [ ] Verify `WithStopWhen` predicate placement matches Vercel behavior for a real provider