### PR TITLE
feat: add terminal StepKinds and SetTerminal CAS on AgentState

### DIFF
--- a/agent_state.go
+++ b/agent_state.go
@@ -36,11 +36,37 @@ const (
 	// and exited when all parallel tool calls return.
 	StepToolExecuting
 
-	// StepIdle indicates the tool loop has terminated (either naturally, by
-	// MaxSteps exhaustion, by OnBeforeStep.Stop, or by WithStopWhen returning
-	// true). Once StepIdle is observed, the state will not transition again.
+	// StepIdle indicates the tool loop has terminated INTERNALLY (either
+	// naturally, by MaxSteps exhaustion, by OnBeforeStep.Stop, or by
+	// WithStopWhen returning true). StepIdle is the post-tool-loop "wake
+	// eligible" parking state - consumers may inject work and re-enter
+	// GenerateText. It is NOT a terminal state: a consumer may transition
+	// to one of the three terminal kinds below via SetTerminal once the
+	// owning goroutine has decided no further work will run.
 	StepIdle
+
+	// StepDone is a terminal state set by the consumer when the runner
+	// completed naturally (no error, no ctx cancel, no panic). After
+	// StepDone, the state never transitions again. SetTerminal enforces
+	// this via CAS.
+	StepDone
+
+	// StepCancelled is a terminal state set by the consumer when the
+	// runner exited due to context cancellation (ctx.Err() != nil) or a
+	// caller-requested cancel signal. Terminal; sticky.
+	StepCancelled
+
+	// StepError is a terminal state set by the consumer when the runner
+	// returned a non-nil error (or recovered a panic). Terminal; sticky.
+	StepError
 )
+
+// IsTerminal reports whether k is one of the three terminal states
+// (StepDone / StepCancelled / StepError). Pollers use this to decide
+// whether further state mutation is possible.
+func (k StepKind) IsTerminal() bool {
+	return k == StepDone || k == StepCancelled || k == StepError
+}
 
 // String returns a human-readable name for the kind.
 func (k StepKind) String() string {
@@ -55,6 +81,12 @@ func (k StepKind) String() string {
 		return "tool-executing"
 	case StepIdle:
 		return "idle"
+	case StepDone:
+		return "done"
+	case StepCancelled:
+		return "cancelled"
+	case StepError:
+		return "error"
 	default:
 		return "unknown"
 	}
@@ -113,6 +145,45 @@ func (s *AgentState) set(kind StepKind, step int) {
 	}
 	packed := (uint64(uint32(step)) << 32) | uint64(uint32(kind))
 	s.packed.Store(packed)
+}
+
+// SetTerminal transitions the state to one of {StepDone, StepCancelled,
+// StepError} via compare-and-swap. The transition succeeds only if the
+// current state is non-terminal (i.e. !IsTerminal); a second SetTerminal
+// call on an already-terminal state is a no-op and returns false. The
+// step counter is preserved across the transition so pollers reading
+// (kind, step) on a terminal state still see the highest step number
+// reached. Returns true if this call performed the transition, false
+// otherwise.
+//
+// Intended caller: the consumer that owns the AgentState lifetime (e.g.
+// zenflow's AgentRunner.Run on exit, mapping ctx.Err() / panic-recover
+// to Cancelled / Error and the natural return path to Done). goai's own
+// hooks NEVER call SetTerminal - the consumer is the sole writer of
+// terminal states, satisfying the plan §4.2 #4 single-writer rule.
+//
+// Passing a non-terminal kind panics: the API is intentionally narrow
+// to prevent misuse (e.g. SetTerminal(StepLLMInFlight) would corrupt
+// the lifecycle).
+func (s *AgentState) SetTerminal(kind StepKind) bool {
+	if s == nil {
+		return false
+	}
+	if !kind.IsTerminal() {
+		panic(fmt.Errorf("goai: SetTerminal requires a terminal kind (Done/Cancelled/Error), got %s", kind))
+	}
+	for {
+		v := s.packed.Load()
+		curKind := StepKind(uint32(v))
+		if curKind.IsTerminal() {
+			return false
+		}
+		step := uint32(v >> 32)
+		next := (uint64(step) << 32) | uint64(uint32(kind))
+		if s.packed.CompareAndSwap(v, next) {
+			return true
+		}
+	}
 }
 
 // WithStateRef exposes goai's tool-loop lifecycle state via an

--- a/agent_state_test.go
+++ b/agent_state_test.go
@@ -1916,6 +1916,9 @@ func TestStepKind_String(t *testing.T) {
 		StepStepFinished:  "step-finished",
 		StepToolExecuting: "tool-executing",
 		StepIdle:          "idle",
+		StepDone:          "done",
+		StepCancelled:     "cancelled",
+		StepError:         "error",
 		StepKind(999):     "unknown",
 	}
 	for k, want := range cases {

--- a/agent_state_test.go
+++ b/agent_state_test.go
@@ -2621,3 +2621,121 @@ func TestAgentState_StreamText_ErrorAfterLLMInFlight_MonotonicStep(t *testing.T)
 		}
 	})
 }
+
+// TestAgentState_TerminalCAS verifies that SetTerminal:
+//  1. transitions a non-terminal state to the requested terminal kind,
+//  2. preserves the step counter across the transition,
+//  3. is sticky: a second call returns false and does not change state,
+//  4. panics on a non-terminal kind argument.
+func TestAgentState_TerminalCAS(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	t.Run("Done", func(t *testing.T) {
+		var s AgentState
+		s.set(StepIdle, 7)
+		if !s.SetTerminal(StepDone) {
+			t.Fatal("SetTerminal(StepDone) returned false on Idle state; want true")
+		}
+		k, step := s.Observe()
+		if k != StepDone {
+			t.Errorf("kind=%v; want StepDone", k)
+		}
+		if step != 7 {
+			t.Errorf("step=%d; want 7 (preserved)", step)
+		}
+		if !k.IsTerminal() {
+			t.Error("StepDone.IsTerminal()=false")
+		}
+	})
+
+	t.Run("Cancelled", func(t *testing.T) {
+		var s AgentState
+		s.set(StepLLMInFlight, 3)
+		if !s.SetTerminal(StepCancelled) {
+			t.Fatal("SetTerminal(StepCancelled) returned false; want true")
+		}
+		k, step := s.Observe()
+		if k != StepCancelled {
+			t.Errorf("kind=%v; want StepCancelled", k)
+		}
+		if step != 3 {
+			t.Errorf("step=%d; want 3", step)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		var s AgentState
+		s.set(StepToolExecuting, 2)
+		if !s.SetTerminal(StepError) {
+			t.Fatal("SetTerminal(StepError) returned false; want true")
+		}
+		k, _ := s.Observe()
+		if k != StepError {
+			t.Errorf("kind=%v; want StepError", k)
+		}
+	})
+
+	t.Run("StickyAfterFirstTransition", func(t *testing.T) {
+		var s AgentState
+		s.set(StepIdle, 1)
+		if !s.SetTerminal(StepDone) {
+			t.Fatal("first SetTerminal returned false")
+		}
+		// Subsequent attempts to override must be rejected.
+		if s.SetTerminal(StepCancelled) {
+			t.Error("SetTerminal(StepCancelled) on a Done state returned true; want false (sticky)")
+		}
+		if s.SetTerminal(StepError) {
+			t.Error("SetTerminal(StepError) on a Done state returned true; want false (sticky)")
+		}
+		k, _ := s.Observe()
+		if k != StepDone {
+			t.Errorf("kind=%v after rejected overrides; want StepDone preserved", k)
+		}
+	})
+
+	t.Run("PanicsOnNonTerminal", func(t *testing.T) {
+		var s AgentState
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("SetTerminal(StepIdle) did not panic")
+			}
+		}()
+		s.SetTerminal(StepIdle)
+	})
+
+	t.Run("NilReceiverNoop", func(t *testing.T) {
+		var s *AgentState
+		if s.SetTerminal(StepDone) {
+			t.Error("nil receiver SetTerminal returned true; want false")
+		}
+	})
+
+	t.Run("ConcurrentRaceSingleWinner", func(t *testing.T) {
+		var s AgentState
+		s.set(StepIdle, 5)
+		const N = 50
+		var wg sync.WaitGroup
+		var winners atomic.Int32
+		for range N {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if s.SetTerminal(StepDone) {
+					winners.Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+		if w := winners.Load(); w != 1 {
+			t.Errorf("got %d winners on concurrent SetTerminal; want exactly 1", w)
+		}
+		k, step := s.Observe()
+		if k != StepDone {
+			t.Errorf("kind=%v; want StepDone", k)
+		}
+		if step != 5 {
+			t.Errorf("step=%d; want 5 preserved", step)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds three sticky terminal `StepKind`s — `StepDone`, `StepCancelled`, `StepError` — distinct from the non-terminal `StepIdle` parking state.
- `AgentState.SetTerminal(kind)` uses CAS so only the first caller wins; subsequent calls are no-ops and return `false`. The step counter is preserved across the transition so pollers on a terminal state still see the highest step reached.
- Intended caller is the consumer that owns `AgentState` lifetime (e.g. zenflow `AgentRunner.Run`), mapping `ctx.Err()` / panic-recover / natural return to Cancelled / Error / Done. goai itself never writes terminal states, preserving the single-writer rule.
- Adds `StepKind.IsTerminal()` helper and `String()` entries for the new kinds.

## Test plan

- [x] `go test -race -run TestAgentState_TerminalCAS .` covers: per-kind transition, step preservation, stickiness, nil-receiver no-op, panic on non-terminal arg, 50-goroutine single-winner race.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] Pre-commit 90% coverage gate passes.