### PR TITLE
feat: surface reasoning text on TextResult and StepResult

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,11 @@ go test ./provider/openai/  # Test single package
 
 ## Architecture
 
-GoAI is a Go SDK for AI applications - one API across 24+ LLM providers. Inspired by Vercel AI SDK, adapted to Go idioms.
+GoAI is a Go SDK for AI applications - one API across 25+ LLM providers. Inspired by Vercel AI SDK, adapted to Go idioms.
 
 ```
 goai/
-├── generate.go             # GenerateText, StreamText, ResponseMessages
+├── generate.go             # GenerateText, StreamText
 ├── object.go               # GenerateObject[T], StreamObject[T]
 ├── embed.go                # Embed, EmbedMany
 ├── image.go                # GenerateImage
@@ -55,7 +55,7 @@ goai/
 ├── observability/
 │   ├── langfuse/           # Langfuse observability integration (separate go.mod)
 │   └── otel/               # OpenTelemetry tracing and metrics (separate go.mod)
-├── examples/               # 28 runnable examples (including 7 MCP examples)
+├── examples/               # 31 runnable examples (30 with main.go + chat, agent-loop)
 └── bench/                  # Performance benchmarks (GoAI vs Vercel AI SDK)
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 - **Structured output**: `GenerateObject[T]` auto-generates JSON Schema from Go types via reflection
 - **Streaming**: Real-time text and partial object streaming via channels
 - **Dynamic auth**: `TokenSource` interface for OAuth, rotating keys, cloud IAM, with `CachedTokenSource` for TTL-based caching
-- **Prompt caching**: Automatic cache control for supported providers (Anthropic, Bedrock, MiniMax)
+- **Prompt caching**: Automatic cache control for supported providers (Anthropic, Bedrock)
 - **Citations/sources**: Grounding and inline citations from xAI, Perplexity, Google, OpenAI
-- **Web search**: Built-in web search tools for OpenAI, Anthropic, Google, Groq. Model decides when to search
-- **Code execution**: Server-side Python sandboxes via OpenAI, Anthropic, Google. No local setup
+- **Web search**: Built-in web search tools for OpenAI, Anthropic, Google, Groq, xAI. Model decides when to search
+- **Code execution**: Server-side Python sandboxes via OpenAI, Anthropic, Google, xAI. No local setup
 - **Computer use**: Anthropic computer, bash, text editor tools for autonomous desktop interaction
 - **20 provider-defined tools**: Web fetch, file search, image generation, X search, and more - [full list](#provider-defined-tools)
 - **MCP client**: Connect to any MCP server (stdio, HTTP, SSE), auto-convert tools for use with GoAI
@@ -408,7 +408,7 @@ result, err := goai.GenerateText(ctx, model, goai.WithPrompt("Hello"))
 | RunPod     | any vLLM model                                               | -                                                          | -             | `RUNPOD_API_KEY`, TokenSource                                                                      | Unit | `provider/runpod`     |
 | Cloudflare | `@cf/meta/*`, `@cf/openai/gpt-oss-*`, `@cf/qwen/*`           | `@cf/baai/bge-*`                                           | -             | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_BASE_URL`, TokenSource                | Unit | `provider/cloudflare` |
 | FPT Cloud  | `Qwen3-*`, `Llama-*`, `gpt-oss-*`, `GLM-*`, `gemma-*`        | `bge-*`, `gte-*`, `multilingual-e5-*`                      | -             | `FPT_API_KEY`, `FPT_REGION` (`global`/`jp`), `FPT_BASE_URL`, TokenSource                           | Unit | `provider/fptcloud`   |
-| NVIDIA NIM | `nvidia/llama-*`, `nvidia/nemotron-*`                       | `nvidia/nv-embed-*`                                         | -             | `NVIDIA_API_KEY`, `NVIDIA_BASE_URL`, TokenSource                                                    | Full | `provider/nvidia`     |
+| NVIDIA NIM | `nvidia/llama-*`, `nvidia/nemotron-*`                        | `nvidia/nv-embed-*`                                        | -             | `NVIDIA_API_KEY`, `NVIDIA_BASE_URL`, TokenSource                                                   | Full | `provider/nvidia`     |
 | Compat     | any OpenAI-compatible                                        | any                                                        | -             | configurable                                                                                       | Unit | `provider/compat`     |
 
 **E2E column**: "Full" = tested with real API calls. "Unit" = tested with mock HTTP servers (100% coverage).
@@ -429,7 +429,7 @@ Last run: 2026-03-27. 104 models tested (generate + stream).
 | Mistral (5)  | `mistral-small-latest`, `mistral-large-latest`, `devstral-small-2507`, `codestral-latest`, `magistral-medium-latest`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | Cerebras (1) | `llama3.1-8b`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | MiniMax (4)  | `MiniMax-M2.7`, `MiniMax-M2.5`, `MiniMax-M2.1`, `MiniMax-M2` (generate + stream + tools + thinking)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| NVIDIA (1)   | `meta/llama-3.3-70b-instruct`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| NVIDIA (1)   | `meta/llama-3.3-70b-instruct`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
 </details>
 
@@ -541,41 +541,42 @@ fmt.Printf("Model used: %s\n", result.Response.Model)
 
 ### Generation Options
 
-| Option                    | Description                              | Default          |
-| ------------------------- | ---------------------------------------- | ---------------- |
-| `WithSystem(s)`           | System prompt                            | -                |
-| `WithPrompt(s)`           | Single user message                      | -                |
-| `WithMessages(...)`       | Conversation history                     | -                |
-| `WithTools(...)`          | Available tools                          | -                |
-| `WithMaxOutputTokens(n)`  | Response length limit                    | provider default |
-| `WithTemperature(t)`      | Randomness (0.0-2.0)                     | provider default |
-| `WithTopP(p)`             | Nucleus sampling                         | provider default |
-| `WithTopK(k)`             | Top-K sampling                           | provider default |
-| `WithFrequencyPenalty(p)` | Frequency penalty                        | provider default |
-| `WithPresencePenalty(p)`  | Presence penalty                         | provider default |
-| `WithSeed(s)`             | Deterministic generation                 | -                |
-| `WithStopSequences(...)`  | Stop triggers                            | -                |
-| `WithMaxSteps(n)`         | Tool loop iterations                     | 1 (no loop)      |
-| `WithMaxRetries(n)`       | Retries on 429/5xx                       | 2                |
-| `WithTimeout(d)`          | Overall timeout                          | none             |
-| `WithHeaders(h)`          | Per-request HTTP headers                 | -                |
-| `WithProviderOptions(m)`  | Provider-specific params                 | -                |
-| `WithPromptCaching(b)`    | Enable prompt caching                    | false            |
-| `WithToolChoice(tc)`      | "auto", "none", "required", or tool name | -                |
+| Option                          | Description                              | Default          |
+| ------------------------------- | ---------------------------------------- | ---------------- |
+| `WithSystem(s)`                 | System prompt                            | -                |
+| `WithPrompt(s)`                 | Single user message                      | -                |
+| `WithMessages(...)`             | Conversation history                     | -                |
+| `WithTools(...)`                | Available tools                          | -                |
+| `WithMaxOutputTokens(n)`        | Response length limit                    | provider default |
+| `WithTemperature(t)`            | Randomness (0.0-2.0)                     | provider default |
+| `WithTopP(p)`                   | Nucleus sampling                         | provider default |
+| `WithTopK(k)`                   | Top-K sampling                           | provider default |
+| `WithFrequencyPenalty(p)`       | Frequency penalty                        | provider default |
+| `WithPresencePenalty(p)`        | Presence penalty                         | provider default |
+| `WithSeed(s)`                   | Deterministic generation                 | -                |
+| `WithStopSequences(...)`        | Stop triggers                            | -                |
+| `WithMaxSteps(n)`               | Tool loop iterations                     | 1 (no loop)      |
+| `WithSequentialToolExecution()` | Execute tools one at a time              | parallel         |
+| `WithMaxRetries(n)`             | Retries on 429/5xx                       | 2                |
+| `WithTimeout(d)`                | Overall timeout                          | none             |
+| `WithHeaders(h)`                | Per-request HTTP headers                 | -                |
+| `WithProviderOptions(m)`        | Provider-specific params                 | -                |
+| `WithPromptCaching(b)`          | Enable prompt caching                    | false            |
+| `WithToolChoice(tc)`            | "auto", "none", "required", or tool name | -                |
 
 ### Lifecycle Hooks
 
-| Option                          | Description                                                      |
-| ------------------------------- | ---------------------------------------------------------------- |
-| `WithOnRequest(fn)`             | Called before each API call                                      |
-| `WithOnResponse(fn)`            | Called after each API call                                       |
-| `WithOnToolCallStart(fn)`       | Called before each tool execution begins                         |
-| `WithOnToolCall(fn)`            | Called after each tool execution                                 |
-| `WithOnStepFinish(fn)`          | Called after each tool loop step                                 |
-| `WithOnFinish(fn)`              | Called once after all steps complete (carries `StepsExhausted`)  |
-| `WithOnBeforeToolExecute(fn)`   | Intercept before tool Execute -- can skip, override ctx/input    |
-| `WithOnAfterToolExecute(fn)`    | Intercept after tool Execute -- can modify output/error          |
-| `WithOnBeforeStep(fn)`          | Intercept before step 2+ -- can inject messages or stop loop    |
+| Option                        | Description                                                     |
+| ----------------------------- | --------------------------------------------------------------- |
+| `WithOnRequest(fn)`           | Called before each API call                                     |
+| `WithOnResponse(fn)`          | Called after each API call                                      |
+| `WithOnToolCallStart(fn)`     | Called before each tool execution begins                        |
+| `WithOnToolCall(fn)`          | Called after each tool execution                                |
+| `WithOnStepFinish(fn)`        | Called after each tool loop step                                |
+| `WithOnFinish(fn)`            | Called once after all steps complete (carries `StepsExhausted`) |
+| `WithOnBeforeToolExecute(fn)` | Intercept before tool Execute -- can skip, override ctx/input   |
+| `WithOnAfterToolExecute(fn)`  | Intercept after tool Execute -- can modify output/error         |
+| `WithOnBeforeStep(fn)`        | Intercept before step 2+ -- can inject messages or stop loop    |
 
 ### Structured Output Options
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,16 +13,16 @@
 
 ### Providers (24+)
 
-| Category         | Providers                                           |
-| ---------------- | --------------------------------------------------- |
-| Flagship         | OpenAI, Anthropic, Google (Gemini + Imagen)         |
-| Cloud platforms  | AWS Bedrock (SigV4), Azure OpenAI, Google Vertex AI |
-| Fast inference   | Groq, Cerebras, Fireworks, Together, DeepInfra      |
-| Specialized      | Mistral, xAI, DeepSeek, Cohere, Perplexity, MiniMax |
-| Aggregators      | OpenRouter                                          |
+| Category         | Providers                                            |
+| ---------------- | ---------------------------------------------------- |
+| Flagship         | OpenAI, Anthropic, Google (Gemini + Imagen)          |
+| Cloud platforms  | AWS Bedrock (SigV4), Azure OpenAI, Google Vertex AI  |
+| Fast inference   | Groq, Cerebras, Fireworks, Together, DeepInfra       |
+| Specialized      | Mistral, xAI, DeepSeek, Cohere, Perplexity, MiniMax  |
+| Aggregators      | OpenRouter                                           |
 | Edge / regional  | Cloudflare Workers AI, FPT Smart Cloud (Global + JP) |
-| Local/Serverless | Ollama, vLLM, RunPod                                |
-| Bring your own   | `compat.Chat()` for any OpenAI-compatible endpoint  |
+| Local/Serverless | Ollama, vLLM, RunPod                                 |
+| Bring your own   | `compat.Chat()` for any OpenAI-compatible endpoint   |
 
 ### SDK features
 
@@ -61,33 +61,39 @@
 
 ## v0.6.0
 
-| Feature                    | Description                                                                       |
-| -------------------------- | --------------------------------------------------------------------------------- |
+| Feature                    | Description                                                                             |
+| -------------------------- | --------------------------------------------------------------------------------------- |
 | **OpenTelemetry tracing**  | Full tracing for generations, tool calls, and multi-step loops via `observability/otel` |
-| **OpenTelemetry metrics**  | Token usage, request duration, and error rate metrics with GenAI semantic conventions |
-| **Context propagation**    | `RequestInfo.Ctx` carries trace context through provider calls                    |
-| **Langfuse data race fix** | Fixed concurrent map access in Langfuse observability integration                 |
+| **OpenTelemetry metrics**  | Token usage, request duration, and error rate metrics with GenAI semantic conventions   |
+| **Context propagation**    | `RequestInfo.Ctx` carries trace context through provider calls                          |
+| **Langfuse data race fix** | Fixed concurrent map access in Langfuse observability integration                       |
 
 ## v0.7.0
 
-| Feature                      | Description                                                                                   |
-| ---------------------------- | --------------------------------------------------------------------------------------------- |
-| **Cloudflare Workers AI**    | New provider with chat + embeddings. OpenAI-compatible endpoints, account-ID URL building, optional AI Gateway override via `WithBaseURL` |
-| **FPT Smart Cloud**          | New provider (FPT AI Marketplace) with chat + embeddings. `WithRegion("global"/"jp")` for Japan / Global routing |
+| Feature                   | Description                                                                                                                               |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cloudflare Workers AI** | New provider with chat + embeddings. OpenAI-compatible endpoints, account-ID URL building, optional AI Gateway override via `WithBaseURL` |
+| **FPT Smart Cloud**       | New provider (FPT AI Marketplace) with chat + embeddings. `WithRegion("global"/"jp")` for Japan / Global routing                          |
 
-## v0.7.1 - Current release
+## v0.7.1
 
-| Feature                           | Description                                                                                   |
-| --------------------------------- | --------------------------------------------------------------------------------------------- |
+| Feature                            | Description                                                                                                                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **OpenAI-compat factory refactor** | `openaicompat.NewChatModel` / `NewEmbeddingModel` absorb HTTP dispatch, token resolution, env-var plumbing from 14 provider packages. ~1,400 LOC removed. Public API unchanged |
+
+## v0.7.2 - Current release
+
+| Feature        | Description                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| **NVIDIA NIM** | New provider (OpenAI-compatible, chat + embeddings). E2E tested with `meta/llama-3.3-70b-instruct` |
 
 ### Planned
 
-| Feature       | Description                                           |
-| ------------- | ----------------------------------------------------- |
-| Output.array  | Stream validated array elements incrementally         |
-| Output.choice | Convenience enum selection wrapper                    |
-| ~~`goai/otel`~~   | ~~Pre-built OpenTelemetry integration (optional import)~~ **Shipped** in `observability/otel` |
+| Feature         | Description                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| Output.array    | Stream validated array elements incrementally                                                 |
+| Output.choice   | Convenience enum selection wrapper                                                            |
+| ~~`goai/otel`~~ | ~~Pre-built OpenTelemetry integration (optional import)~~ **Shipped** in `observability/otel` |
 
 ### v1.0.0 - Stable API
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-GoAI is a Go SDK for AI applications. One unified API across 24+ LLM providers. Inspired by the Vercel AI SDK, adapted to Go idioms (generics, interfaces, channels).
+GoAI is a Go SDK for AI applications. One unified API across 25+ LLM providers. Inspired by the Vercel AI SDK, adapted to Go idioms (generics, interfaces, channels).
 
 - **Package**: `github.com/zendev-sh/goai`
 - **Go version**: 1.25+

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -279,6 +279,14 @@ Sets the retry count for transient errors (429, 503, 5xx).
 func WithMaxRetries(n int) Option
 ```
 
+**Parameters:**
+
+| Value     | Behavior                                                                                          |
+| --------- | ------------------------------------------------------------------------------------------------- |
+| `n >= 0`  | Retry up to `n` times.                                                                            |
+| `n == -1` | Unlimited retries (useful when the application manages its own timeout/cancellation via context). |
+| `n < -1`  | Clamped to `0` (no retries).                                                                      |
+
 **Default:** `2`. Retries use exponential backoff. Only retryable errors trigger retry (see [Errors](errors.md)).
 
 ### WithTimeout

--- a/generate.go
+++ b/generate.go
@@ -38,6 +38,13 @@ type TextResult struct {
 	// compatibility. Use Steps[n].Text for text-only content excluding reasoning.
 	Text string
 
+	// Reasoning is the model's accumulated thinking/reasoning text
+	// across all steps (PartReasoning). Populated for both GenerateText
+	// and StreamText when the provider returns reasoning content (e.g.
+	// Anthropic extended thinking on Bedrock). Empty when reasoning is
+	// disabled or unsupported.
+	Reasoning string
+
 	// ToolCalls requested by the model in the final step.
 	ToolCalls []provider.ToolCall
 
@@ -88,6 +95,11 @@ type StepResult struct {
 	// Text generated in this step (excludes reasoning tokens).
 	// For StreamText, reasoning is included in TextResult.Text but excluded here.
 	Text string
+
+	// Reasoning is the consolidated thinking/reasoning text for this
+	// step (PartReasoning, signature stripped). Populated for both
+	// GenerateText and StreamText when the provider returns reasoning.
+	Reasoning string
 
 	// ToolCalls requested in this step.
 	ToolCalls []provider.ToolCall
@@ -415,6 +427,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				ts.steps = append(ts.steps, StepResult{
 					Number:           ts.currentStep,
 					Text:             ts.stepText.String(),
+					Reasoning:        ts.reasoningBuf.String(),
 					ToolCalls:        ts.stepToolCalls,
 					FinishReason:     chunk.FinishReason,
 					Usage:            chunk.Usage,
@@ -539,11 +552,20 @@ func (ts *TextStream) buildResult() *TextResult {
 		result.Steps = ts.steps
 		// Match GenerateText: ToolCalls is the LAST step's tool calls, not all steps'.
 		result.ToolCalls = ts.steps[len(ts.steps)-1].ToolCalls
+		// Aggregate per-step reasoning so streaming TextResult exposes
+		// the same .Reasoning field as GenerateText.
+		var reasoningAll strings.Builder
+		for _, s := range ts.steps {
+			reasoningAll.WriteString(s.Reasoning)
+		}
+		result.Reasoning = reasoningAll.String()
 	} else if text != "" || len(ts.toolCalls) > 0 || ts.finishReason != "" {
 		// Single-step fallback (no multi-step ChunkStepFinish received, but data exists).
+		stepReasoning := ts.reasoningBuf.String()
 		result.Steps = []StepResult{{
 			Number:           1,
 			Text:             ts.stepText.String(),
+			Reasoning:        stepReasoning,
 			ToolCalls:        ts.toolCalls,
 			FinishReason:     ts.finishReason,
 			Usage:            ts.usage,
@@ -551,6 +573,7 @@ func (ts *TextStream) buildResult() *TextResult {
 			Sources:          ts.sources,
 			ProviderMetadata: ts.providerMetadata,
 		}}
+		result.Reasoning = stepReasoning
 	}
 	// No data: Steps is nil.
 
@@ -894,6 +917,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			stepResult := StepResult{
 				Number:           step,
 				Text:             ds.text,
+				Reasoning:        ds.reasoningText,
 				ToolCalls:        ds.toolCalls,
 				FinishReason:     ds.finishReason,
 				Usage:            ds.usage,
@@ -1272,6 +1296,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		stepResult := StepResult{
 			Number:           step,
 			Text:             result.Text,
+			Reasoning:        result.Reasoning,
 			ToolCalls:        result.ToolCalls,
 			FinishReason:     result.FinishReason,
 			Usage:            result.Usage,
@@ -1837,6 +1862,13 @@ func buildTextResult(steps []StepResult, totalUsage provider.Usage) *TextResult 
 	for _, s := range steps {
 		allText.WriteString(s.Text)
 	}
+	// Accumulate reasoning text from all steps. Concatenated as-is so
+	// callers see the same boundaries the steps had; consumers wanting
+	// per-step reasoning can iterate Steps directly.
+	var allReasoning strings.Builder
+	for _, s := range steps {
+		allReasoning.WriteString(s.Reasoning)
+	}
 	// Collect sources from all steps.
 	var allSources []provider.Source
 	for _, s := range steps {
@@ -1845,6 +1877,7 @@ func buildTextResult(steps []StepResult, totalUsage provider.Usage) *TextResult 
 
 	return &TextResult{
 		Text:             allText.String(),
+		Reasoning:        allReasoning.String(),
 		ToolCalls:        last.ToolCalls,
 		Steps:            steps,
 		TotalUsage:       totalUsage,
@@ -1942,9 +1975,10 @@ func buildFinalAssistantMessages(text string, toolCalls []provider.ToolCall, rea
 }
 
 type drainResult struct {
-	text      string          // text-only (ChunkText), used for appendToolRoundTrip
-	reasoning []provider.Part // reasoning/thinking parts, echoed back for providers that require it (e.g. Bedrock)
-	toolCalls []provider.ToolCall
+	text          string          // text-only (ChunkText), used for appendToolRoundTrip
+	reasoning     []provider.Part // reasoning/thinking parts, echoed back for providers that require it (e.g. Bedrock)
+	reasoningText string          // consolidated reasoning text (PartReasoning), surfaced via StepResult.Reasoning
+	toolCalls     []provider.ToolCall
 	usage            provider.Usage
 	finishReason     provider.FinishReason
 	sources          []provider.Source
@@ -2077,6 +2111,7 @@ func drainStep(
 	}
 
 	dr.text = textBuf.String()
+	dr.reasoningText = reasoningBuf.String()
 
 	// Consolidate reasoning fragments into one Part (text + signature metadata)
 	// so the codec serializes a single complete block.

--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -579,9 +579,10 @@ type chatResponse struct {
 	Choices []struct {
 		Index   int `json:"index"`
 		Message struct {
-			Role        string          `json:"role"`
-			Content     json.RawMessage `json:"content"`
-			ToolCalls   []struct {
+			Role             string          `json:"role"`
+			Content          json.RawMessage `json:"content"`
+			ReasoningContent string          `json:"reasoning_content,omitempty"`
+			ToolCalls        []struct {
 				ID       string `json:"id"`
 				Type     string `json:"type"`
 				Function struct {
@@ -632,6 +633,7 @@ func ParseResponse(body []byte) (*provider.GenerateResult, error) {
 	if len(resp.Choices) > 0 {
 		choice := resp.Choices[0]
 		result.Text = extractTextContent(choice.Message.Content)
+		result.Reasoning = choice.Message.ReasoningContent
 		result.FinishReason = mapFinishReason(choice.FinishReason)
 
 		for _, tc := range choice.Message.ToolCalls {

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -1171,6 +1171,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 
 	// Extract text, tool calls, reasoning, and citations.
 	var textParts []string
+	var reasoningParts []string
 	var providerMeta map[string]any
 	for _, block := range resp.Content {
 		switch block.Type {
@@ -1217,6 +1218,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 		case "thinking":
 			if block.Thinking != "" {
 				// Reasoning text is not appended to result.Text -- it's metadata.
+				reasoningParts = append(reasoningParts, block.Thinking)
 				if providerMeta == nil {
 					providerMeta = map[string]any{}
 				}
@@ -1244,6 +1246,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 		}
 	}
 	result.Text = strings.Join(textParts, "")
+	result.Reasoning = strings.Join(reasoningParts, "")
 
 	// Usage.
 	if resp.Usage != nil {

--- a/provider/bedrock/converse.go
+++ b/provider/bedrock/converse.go
@@ -407,6 +407,7 @@ func parseConverseResponse(body []byte) (*provider.GenerateResult, error) {
 
 	// Parse content blocks.
 	var reasoningParts []map[string]any
+	var reasoningTextBuf strings.Builder
 	for _, raw := range resp.Output.Message.Content {
 		var block map[string]any
 		if err := json.Unmarshal(raw, &block); err != nil {
@@ -432,6 +433,7 @@ func parseConverseResponse(body []byte) (*provider.GenerateResult, error) {
 				part := map[string]any{"type": "reasoning"}
 				if text, ok := rt["text"].(string); ok {
 					part["text"] = text
+					reasoningTextBuf.WriteString(text)
 				}
 				if sig, ok := rt["signature"].(string); ok {
 					part["signature"] = sig
@@ -447,6 +449,14 @@ func parseConverseResponse(body []byte) (*provider.GenerateResult, error) {
 				reasoningParts = append(reasoningParts, part)
 			}
 		}
+	}
+
+	// Surface concatenated reasoning text on the top-level result so
+	// callers (goai TextResult.Reasoning) can render thinking in the
+	// non-streaming path. Signatures + redacted blocks remain in
+	// ProviderMetadata for replay.
+	if reasoningTextBuf.Len() > 0 {
+		result.Reasoning = reasoningTextBuf.String()
 	}
 
 	// Store reasoning metadata and additional response fields in ProviderMetadata.

--- a/provider/cohere/cohere.go
+++ b/provider/cohere/cohere.go
@@ -546,8 +546,10 @@ func parseChatResponse(body []byte) (*provider.GenerateResult, error) {
 	}
 	result.Text = strings.Join(textParts, "")
 	if len(reasoningParts) > 0 {
+		joined := strings.Join(reasoningParts, "")
+		result.Reasoning = joined
 		result.ProviderMetadata = map[string]map[string]any{
-			"cohere": {"reasoning": strings.Join(reasoningParts, "")},
+			"cohere": {"reasoning": joined},
 		}
 	}
 

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -816,6 +816,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 	}
 
 	var textParts []string
+	var reasoningParts []string
 	var providerMeta map[string]any
 	var callIndex int
 	for _, part := range candidate.Content.Parts {
@@ -835,6 +836,8 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 				}
 			}
 			result.ToolCalls = append(result.ToolCalls, tc)
+		} else if part.Thought && part.Text != "" {
+			reasoningParts = append(reasoningParts, part.Text)
 		} else if !part.Thought && part.Text != "" {
 			textParts = append(textParts, part.Text)
 		}
@@ -848,6 +851,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 		}
 	}
 	result.Text = strings.Join(textParts, "")
+	result.Reasoning = strings.Join(reasoningParts, "")
 
 	// Attach provider metadata if we have thoughtSignatures.
 	if providerMeta != nil {

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -1662,6 +1662,33 @@ func TestParseResponsesResult_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestParseResponsesResult_ReasoningSummary(t *testing.T) {
+	body := `{
+		"id": "resp-1",
+		"model": "o3",
+		"status": "completed",
+		"output": [
+			{"type": "reasoning", "summary": [
+				{"type": "summary_text", "text": "Step one. "},
+				{"type": "summary_text", "text": "Step two."}
+			]},
+			{"type": "message", "content": [{"type": "output_text", "text": "answer"}]}
+		],
+		"usage": {"input_tokens": 1, "output_tokens": 1}
+	}`
+
+	result, err := parseResponsesResult([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "answer" {
+		t.Errorf("Text = %q, want %q", result.Text, "answer")
+	}
+	if result.Reasoning != "Step one. Step two." {
+		t.Errorf("Reasoning = %q, want %q", result.Reasoning, "Step one. Step two.")
+	}
+}
+
 func TestParseResponsesResult_CachedTokens(t *testing.T) {
 	body := `{
 		"id": "resp-1",

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -879,6 +879,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 
 	// Extract text, tool calls, sources, logprobs from output.
 	var textParts []string
+	var reasoningParts []string
 	var hasFunctionCall bool
 	providerMeta := map[string]any{}
 	var allLogprobs []any
@@ -920,6 +921,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 		case "reasoning":
 			for _, s := range item.Summary {
 				if s.Text != "" {
+					reasoningParts = append(reasoningParts, s.Text)
 					reasoning, _ := providerMeta["reasoning"].([]map[string]any)
 					providerMeta["reasoning"] = append(reasoning, map[string]any{
 						"type": s.Type,
@@ -931,6 +933,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 	}
 
 	result.Text = strings.Join(textParts, "")
+	result.Reasoning = strings.Join(reasoningParts, "")
 
 	if len(allLogprobs) > 0 {
 		providerMeta["logprobs"] = allLogprobs

--- a/provider/types.go
+++ b/provider/types.go
@@ -129,6 +129,12 @@ type GenerateResult struct {
 	// Text is the generated text content.
 	Text string
 
+	// Reasoning is the model's thinking/reasoning text (when extended
+	// thinking is enabled). Excludes signatures and redacted blocks —
+	// those remain in ProviderMetadata for replay. Empty when the
+	// provider does not return reasoning or thinking is disabled.
+	Reasoning string
+
 	// ToolCalls requested by the model.
 	ToolCalls []ToolCall
 


### PR DESCRIPTION
## Summary
- Adds `Reasoning` field to `provider.GenerateResult`, `goai.StepResult`, and `goai.TextResult` so callers can render extended-thinking output without parsing `ProviderMetadata`.
- Wires it through every provider that returns thinking/reasoning — both non-streaming and streaming paths now expose the same field.
- Refreshes docs: 25+ provider count, NVIDIA NIM entry on the roadmap (v0.7.2), documents `WithMaxRetries(-1)` for unlimited retries, adds `WithSequentialToolExecution` row, and assorted table formatting.

## Providers covered (non-streaming)
- `provider/bedrock` — Converse `reasoningContent` blocks
- `provider/anthropic` — direct Messages API `thinking` blocks
- `provider/openai` — Responses API `reasoning.summary` entries
- `provider/google` — Gemini parts with `thought=true`
- `provider/cohere` — `thinking` content blocks (reuses existing join)
- `internal/openaicompat` — `message.reasoning_content` (DeepSeek and other OpenAI-compatible reasoning models)

Streaming paths were already covered via `PartReasoning` aggregation in `goai.drainStep` / `TextStream`, so callers now get the same `.Reasoning` field on `TextResult` regardless of provider or mode. Signatures and redacted blocks remain in `ProviderMetadata` for replay.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [ ] Manual: real Bedrock / Anthropic / Gemini / OpenAI Responses calls with thinking enabled and assert `result.Reasoning` is non-empty for both `GenerateText` and `StreamText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)