### PR TITLE
fix(azure): drop api-version query on v1 GA path

### DIFF
--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -32,7 +32,7 @@ Azure hosts models from multiple providers. `azure.Chat()` automatically routes 
 
 | Model Type                         | Routing                            | Endpoint Format                                            |
 | ---------------------------------- | ---------------------------------- | ---------------------------------------------------------- |
-| OpenAI (GPT, o-series, codex)      | `openai.Chat()` + URL rewrite      | `{endpoint}/openai/v1{path}?api-version={version}`         |
+| OpenAI (GPT, o-series, codex)      | `openai.Chat()` + URL rewrite      | `{endpoint}/openai/v1{path}` (v1 GA, no api-version)       |
 | Claude                             | `anthropic.Chat()`                 | `{resource}.services.ai.azure.com/anthropic`               |
 | All others (DeepSeek, Llama, etc.) | `openai.Chat()` + Chat Completions | `{resource}.services.ai.azure.com/models/chat/completions` |
 
@@ -168,7 +168,7 @@ When using `WithTokenSource`, the provider sends `Authorization: Bearer {token}`
 | `WithEndpoint(url)`          | `string`               | Azure endpoint URL. Falls back to `AZURE_OPENAI_ENDPOINT`, or constructed from `AZURE_RESOURCE_NAME`. |
 | `WithHeaders(h)`             | `map[string]string`    | Additional HTTP headers.                                                                              |
 | `WithHTTPClient(c)`          | `*http.Client`         | Custom HTTP client.                                                                                   |
-| `WithAPIVersion(v)`          | `string`               | API version query parameter. Default: `"2025-03-01-preview"`.                                         |
+| `WithAPIVersion(v)`          | `string`               | `api-version` query parameter. Only honoured on the legacy deployment-based path (opt in via `WithDeploymentBasedURLs(true)`); the v1 GA path drops it per Azure spec. Default: `"2025-03-01-preview"`. |
 | `WithDeploymentBasedURLs(b)` | `bool`                 | Use legacy deployment-based URL format. Default: `false`.                                             |
 
 ### Environment Variables
@@ -182,17 +182,25 @@ When using `WithTokenSource`, the provider sends `Authorization: Bearer {token}`
 
 ## URL Format
 
-**Default**:
+**Default** (v1 GA):
 
 ```
-{endpoint}/openai/v1{path}?api-version={version}
+{endpoint}/openai/v1{path}
 ```
+
+The v1 GA path does not accept the `api-version` query parameter. Azure's v1 spec explicitly removed it; sending it is rejected by spec-strict resources with `"API version not supported"`. Preview features on the v1 path opt in via custom headers (e.g. `aoai-evals: preview`) or via path segments containing `alpha`/`beta`. See Azure's [API version lifecycle](https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle).
 
 **Legacy deployment-based** (enabled with `WithDeploymentBasedURLs(true)`):
 
 ```
 {endpoint}/openai/deployments/{model}{path}?api-version={version}
 ```
+
+Use the legacy path when:
+
+- Your Azure resource doesn't yet expose the v1 GA path.
+- You need to pin a specific dated `api-version` (only honoured here).
+- You're talking to a spec-strict resource that rejects the v1 GA path for a particular model deployment (observed for some GPT-5 deployments).
 
 OpenAI models support both Chat Completions (`/chat/completions`) and Responses API (`/responses`) paths. Non-OpenAI models are forced to use Chat Completions via an internal wrapper.
 

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -83,24 +83,42 @@ func WithHTTPClient(c *http.Client) Option {
 	}
 }
 
-// WithAPIVersion sets the Azure OpenAI API version used in the api-version
-// query parameter. Defaults to "2025-03-01-preview".
+// WithAPIVersion sets the Azure OpenAI API version used in the
+// `api-version` query parameter. Defaults to "2025-03-01-preview".
+//
+// IMPORTANT: api-version is ONLY honoured on the legacy deployment-based
+// path (opt in via WithDeploymentBasedURLs(true)). Azure's v1 GA spec
+// removed the parameter ("v1 API simplifies authentication, removes the
+// need for dated `api-version` parameters"); sending it on the v1 path
+// is rejected by spec-strict resources with "API version not supported".
+// Preview features on the v1 path opt in via custom headers
+// (e.g. `aoai-evals: preview`) or via path segments containing `alpha`/
+// `beta`, not via api-version.
+//
+// Reference:
+// https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle
 func WithAPIVersion(v string) Option {
 	return func(o *options) {
 		o.apiVersion = v
 	}
 }
 
-// WithDeploymentBasedURLs enables legacy deployment-based URL format:
+// WithDeploymentBasedURLs enables the legacy deployment-based URL format:
 //
 //	{endpoint}/openai/deployments/{model}{path}?api-version={version}
 //
-// instead of the newer format:
+// instead of the v1 GA format:
 //
-//	{endpoint}/openai/v1{path}?api-version={version}
+//	{endpoint}/openai/v1{path}
 //
 // This matches Vercel AI SDK's useDeploymentBasedUrls option.
 // When enabled, ALL requests (including Responses API) use deployment-based URLs.
+//
+// Use this when:
+//   - Your Azure resource doesn't yet expose the v1 GA path.
+//   - You need to pin a specific dated api-version (only honoured on this path).
+//   - You're talking to a spec-strict resource that rejects the v1 GA path
+//     for a particular model deployment (observed for some GPT-5 deployments).
 func WithDeploymentBasedURLs(enabled bool) Option {
 	return func(o *options) {
 		o.useDeploymentBasedURLs = enabled
@@ -479,13 +497,26 @@ func (t *azureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 
 	var azureURL string
 	if t.useDeploymentBasedURLs {
-		// Legacy deployment-based format for ALL endpoints.
+		// Legacy deployment-based format for ALL endpoints. Azure
+		// requires `?api-version=` on this path.
 		azureURL = fmt.Sprintf("%s/openai/deployments/%s%s?api-version=%s",
 			t.endpoint, t.deployID, path, t.apiVersion)
 	} else {
-		// Default: newer v1 format (model in body).
-		azureURL = fmt.Sprintf("%s/openai/v1%s?api-version=%s",
-			t.endpoint, path, t.apiVersion)
+		// v1 GA format (model in body). Per Azure's v1 API spec the
+		// `api-version` query parameter is removed on this path:
+		//   "v1 API simplifies authentication, removes the need for
+		//    dated `api-version` parameters"
+		// Sending it anyway is rejected by spec-strict resources with
+		// "API version not supported" (observed live on gpt-5.5).
+		// Preview features on the v1 path opt-in via custom headers
+		// (e.g. `aoai-evals: preview`) or via path segments containing
+		// `alpha`/`beta`, not via `api-version`. See:
+		//   https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle
+		// Callers that still need a specific dated api-version should
+		// use WithDeploymentBasedURLs(true) to opt back into the
+		// legacy deployment-based path which honours api-version.
+		azureURL = fmt.Sprintf("%s/openai/v1%s",
+			t.endpoint, path)
 	}
 
 	// Clone the request with the new URL.

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -38,8 +38,10 @@ func TestChat_Stream(t *testing.T) {
 		if r.Header.Get("api-key") != "test-key" {
 			t.Errorf("api-key = %s", r.Header.Get("api-key"))
 		}
-		if !strings.Contains(r.URL.RawQuery, "api-version=") {
-			t.Errorf("missing api-version in query")
+		// v1 GA path must NOT carry an api-version query (Azure's
+		// v1 spec rejects it: "API version not supported").
+		if strings.Contains(r.URL.RawQuery, "api-version=") {
+			t.Errorf("v1 GA path must not include api-version query, got: %s", r.URL.RawQuery)
 		}
 		responsesSSE(w, "Hello")
 	}))
@@ -366,8 +368,9 @@ func TestAzureURLRewrite(t *testing.T) {
 	if capturedPath != "/openai/v1/responses" {
 		t.Errorf("path = %s, want /openai/v1/responses", capturedPath)
 	}
-	if !strings.Contains(capturedQuery, "api-version=2025-03-01-preview") {
-		t.Errorf("query = %s", capturedQuery)
+	// v1 GA path must NOT carry api-version (spec removed it).
+	if strings.Contains(capturedQuery, "api-version=") {
+		t.Errorf("v1 GA path must not include api-version query, got: %s", capturedQuery)
 	}
 }
 
@@ -504,6 +507,10 @@ func TestRequestHeaders(t *testing.T) {
 
 // === BF.17 Tests ===
 
+// TestWithAPIVersion verifies that an explicit api-version flows through
+// on the legacy deployment-based path. The v1 GA path no longer accepts
+// api-version (Azure spec removed it), so api-version is only meaningful
+// when the caller opts into the legacy path via WithDeploymentBasedURLs(true).
 func TestWithAPIVersion(t *testing.T) {
 	var capturedQuery string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -513,7 +520,12 @@ func TestWithAPIVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	model := Chat("gpt-4o", WithAPIKey("k"), WithEndpoint(server.URL), WithAPIVersion("2024-12-01-preview"))
+	model := Chat("gpt-4o",
+		WithAPIKey("k"),
+		WithEndpoint(server.URL),
+		WithAPIVersion("2024-12-01-preview"),
+		WithDeploymentBasedURLs(true),
+	)
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
@@ -527,6 +539,9 @@ func TestWithAPIVersion(t *testing.T) {
 	}
 }
 
+// TestWithAPIVersion_Default verifies the default api-version flows through
+// on the legacy deployment-based path. v1 GA path tested separately
+// (TestAzureURLRewrite); it deliberately omits api-version.
 func TestWithAPIVersion_Default(t *testing.T) {
 	var capturedQuery string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -537,7 +552,7 @@ func TestWithAPIVersion_Default(t *testing.T) {
 	defer server.Close()
 
 	// No WithAPIVersion -- should default to "2025-03-01-preview".
-	model := Chat("gpt-4o", WithAPIKey("k"), WithEndpoint(server.URL))
+	model := Chat("gpt-4o", WithAPIKey("k"), WithEndpoint(server.URL), WithDeploymentBasedURLs(true))
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
@@ -548,6 +563,39 @@ func TestWithAPIVersion_Default(t *testing.T) {
 	}
 	if !strings.Contains(capturedQuery, "api-version=2025-03-01-preview") {
 		t.Errorf("query = %s, want api-version=2025-03-01-preview", capturedQuery)
+	}
+}
+
+// TestV1Path_NoAPIVersion pins the contract that the v1 GA path never
+// includes the api-version query parameter, even when WithAPIVersion
+// was supplied. Azure's v1 GA spec rejects api-version with "API
+// version not supported"; preview features on v1 opt-in via custom
+// headers or path segments instead.
+func TestV1Path_NoAPIVersion(t *testing.T) {
+	var capturedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, okResponsesJSON)
+	}))
+	defer server.Close()
+
+	// Even with an explicit api-version, the v1 GA path must drop it.
+	model := Chat("gpt-4o",
+		WithAPIKey("k"),
+		WithEndpoint(server.URL),
+		WithAPIVersion("2024-12-01-preview"),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(capturedQuery, "api-version=") {
+		t.Errorf("v1 GA path must not include api-version query (got %q); opt into the legacy path via WithDeploymentBasedURLs(true) when an explicit api-version is required", capturedQuery)
 	}
 }
 
@@ -605,8 +653,9 @@ func TestImage(t *testing.T) {
 		if !strings.Contains(r.URL.Path, "/images/generations") {
 			t.Errorf("path = %s, want .../images/generations", r.URL.Path)
 		}
-		if !strings.Contains(r.URL.RawQuery, "api-version=") {
-			t.Errorf("missing api-version in query: %s", r.URL.RawQuery)
+		// v1 GA path drops api-version (per Azure spec).
+		if strings.Contains(r.URL.RawQuery, "api-version=") {
+			t.Errorf("v1 GA path must not include api-version query, got: %s", r.URL.RawQuery)
 		}
 		if r.Header.Get("api-key") != "test-key" {
 			t.Errorf("api-key = %q", r.Header.Get("api-key"))


### PR DESCRIPTION
## Summary
- The Azure v1 GA path (`/openai/v1{path}`) no longer accepts the dated `api-version` query parameter. Per Azure's spec, sending it is rejected by spec-strict resources with `"API version not supported"` (observed live on gpt-5.5).
- The legacy deployment-based path (`/openai/deployments/{model}{path}?api-version=...`) still requires it, so `WithAPIVersion` is now only honoured when callers opt into that path via `WithDeploymentBasedURLs(true)`.
- Updated godoc on `WithAPIVersion` / `WithDeploymentBasedURLs` to explain the split, with a link to Azure's [api-version-lifecycle docs](https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle).

## Test plan
- [x] `go test ./provider/azure/` passes
- [x] `TestAzureURLRewrite`, `TestChat_Stream`, `TestImage` updated to assert v1 path has NO api-version
- [x] `TestWithAPIVersion` / `TestWithAPIVersion_Default` switched to opt into legacy path
- [x] New `TestV1Path_NoAPIVersion` pins the contract that v1 GA drops api-version even when one is supplied