### PR TITLE
ci(release): tag Go sub-modules at root tag commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,44 @@ jobs:
       - name: Run tests
         run: go test -race ./...
 
+      # Go monorepo requires per-submodule tags following the pattern
+      # `<path>/vX.Y.Z` (e.g. `observability/otel/v0.7.4`). Without this,
+      # consumers importing `observability/otel` (or any sub-module) as
+      # a separate Go module cannot resolve it at the root tag's version.
+      #
+      # We tag every consumer-facing sub-module (anything with its own
+      # go.mod) at the same commit as the root tag, except internal paths
+      # (examples/*, bench/*) which should never be imported externally.
+      - name: Tag sub-modules at root tag commit
+        env:
+          ROOT_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Enumerate every sub-module go.mod, excluding root + internal-only
+          # paths. Add new exclusions here when introducing internal modules.
+          submodules=$(find . -mindepth 2 -name go.mod -not -path "./.git/*" \
+            | sed 's|/go.mod$||' | sed 's|^\./||' \
+            | grep -Ev '^(examples|bench)(/|$)' || true)
+
+          if [ -z "$submodules" ]; then
+            echo "No sub-modules to tag."
+            exit 0
+          fi
+
+          for sub in $submodules; do
+            sub_tag="${sub}/${ROOT_TAG}"
+            if git rev-parse -q --verify "refs/tags/${sub_tag}" >/dev/null; then
+              echo "Tag ${sub_tag} already exists; skipping."
+              continue
+            fi
+            echo "Tagging ${sub_tag} at ${ROOT_TAG}"
+            git tag "${sub_tag}" "${ROOT_TAG}"
+            git push origin "${sub_tag}"
+          done
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- Tag every sub-module with its own `go.mod` (currently `observability/langfuse`, `observability/otel`) at the root tag's commit using the `<path>/vX.Y.Z` pattern.
- Excludes internal-only paths (`examples/*`, `bench/*`) which are not consumer-facing.
- Idempotent: skips tags that already exist.

## Why
Go's monorepo support requires per-submodule tags for `go get github.com/.../observability/otel@vX.Y.Z` to resolve. Tagging only the root meant downstream consumers couldn't pin the observability sub-modules to a release.

## Test plan
- [ ] Cut a test tag (e.g. `v0.7.5-rc1`) and confirm `observability/langfuse/v0.7.5-rc1` and `observability/otel/v0.7.5-rc1` get pushed.
- [ ] Confirm `examples/*` and `bench/*` are not tagged.
- [ ] Re-running on an existing tag is a no-op.