### PR TITLE
fix(openai,cohere): forward ChunkToolCallDelta during tool-call streaming

### DIFF
--- a/provider/cohere/cohere.go
+++ b/provider/cohere/cohere.go
@@ -752,7 +752,18 @@ func parseChatStream(ctx context.Context, body io.Reader, out chan<- provider.St
 
 		case "tool-call-delta":
 			if pending != nil {
-				pending.args.WriteString(event.Delta.Message.ToolCalls.Function.Arguments)
+				frag := event.Delta.Message.ToolCalls.Function.Arguments
+				pending.args.WriteString(frag)
+				if frag != "" {
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type:       provider.ChunkToolCallDelta,
+						ToolCallID: pending.id,
+						ToolName:   pending.name,
+						ToolInput:  frag,
+					}) {
+						return
+					}
+				}
 			}
 
 		case "tool-call-end":

--- a/provider/cohere/cohere_test.go
+++ b/provider/cohere/cohere_test.go
@@ -343,6 +343,7 @@ func TestStream_ToolCallEvents(t *testing.T) {
 	var gotToolStart bool
 	var gotToolCall bool
 	var gotFinish bool
+	var toolDeltas []provider.StreamChunk
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkToolCallStreamStart {
 			gotToolStart = true
@@ -352,6 +353,9 @@ func TestStream_ToolCallEvents(t *testing.T) {
 			if chunk.ToolCallID != "tc1" {
 				t.Errorf("ToolCallID = %q", chunk.ToolCallID)
 			}
+		}
+		if chunk.Type == provider.ChunkToolCallDelta {
+			toolDeltas = append(toolDeltas, chunk)
 		}
 		if chunk.Type == provider.ChunkToolCall {
 			gotToolCall = true
@@ -370,6 +374,22 @@ func TestStream_ToolCallEvents(t *testing.T) {
 			if chunk.FinishReason != provider.FinishToolCalls {
 				t.Errorf("FinishReason = %q", chunk.FinishReason)
 			}
+		}
+	}
+
+	wantDeltas := []string{`{"city"`, `: "Paris"}`}
+	if len(toolDeltas) != len(wantDeltas) {
+		t.Fatalf("expected %d ChunkToolCallDelta, got %d", len(wantDeltas), len(toolDeltas))
+	}
+	for i, want := range wantDeltas {
+		if toolDeltas[i].ToolCallID != "tc1" {
+			t.Errorf("delta[%d].ToolCallID = %q, want %q", i, toolDeltas[i].ToolCallID, "tc1")
+		}
+		if toolDeltas[i].ToolName != "get_weather" {
+			t.Errorf("delta[%d].ToolName = %q, want %q", i, toolDeltas[i].ToolName, "get_weather")
+		}
+		if toolDeltas[i].ToolInput != want {
+			t.Errorf("delta[%d].ToolInput = %q, want %q", i, toolDeltas[i].ToolInput, want)
 		}
 	}
 	if !gotToolStart {

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -425,10 +425,14 @@ func TestChat_Responses_ToolCalls(t *testing.T) {
 	}
 
 	var toolCalls []provider.StreamChunk
+	var toolDeltas []provider.StreamChunk
 	var finishReason provider.FinishReason
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkToolCall {
 			toolCalls = append(toolCalls, chunk)
+		}
+		if chunk.Type == provider.ChunkToolCallDelta {
+			toolDeltas = append(toolDeltas, chunk)
 		}
 		if chunk.Type == provider.ChunkStepFinish {
 			finishReason = chunk.FinishReason
@@ -446,6 +450,22 @@ func TestChat_Responses_ToolCalls(t *testing.T) {
 	}
 	if finishReason != provider.FinishToolCalls {
 		t.Errorf("FinishReason = %q, want %q", finishReason, provider.FinishToolCalls)
+	}
+
+	wantDeltas := []string{`{"path":`, `"a.txt"}`}
+	if len(toolDeltas) != len(wantDeltas) {
+		t.Fatalf("expected %d ChunkToolCallDelta, got %d", len(wantDeltas), len(toolDeltas))
+	}
+	for i, want := range wantDeltas {
+		if toolDeltas[i].ToolCallID != "tc1" {
+			t.Errorf("delta[%d].ToolCallID = %q, want %q", i, toolDeltas[i].ToolCallID, "tc1")
+		}
+		if toolDeltas[i].ToolName != "read" {
+			t.Errorf("delta[%d].ToolName = %q, want %q", i, toolDeltas[i].ToolName, "read")
+		}
+		if toolDeltas[i].ToolInput != want {
+			t.Errorf("delta[%d].ToolInput = %q, want %q", i, toolDeltas[i].ToolInput, want)
+		}
 	}
 }
 

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -553,6 +553,15 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 				}
 				active.args.WriteString(ev.Delta)
 
+				if !provider.TrySend(ctx, out, provider.StreamChunk{
+					Type:       provider.ChunkToolCallDelta,
+					ToolCallID: active.id,
+					ToolName:   active.name,
+					ToolInput:  ev.Delta,
+				}) {
+					return
+				}
+
 				if accumulated := active.args.String(); json.Valid([]byte(accumulated)) {
 					if !provider.TrySend(ctx, out, provider.StreamChunk{
 						Type:       provider.ChunkToolCall,


### PR DESCRIPTION
## Summary
- `provider/openai/responses.go` (Responses API) and `provider/cohere/cohere.go` previously buffered tool-call argument fragments and only emitted `ChunkToolCall` once the accumulated buffer became valid JSON (or at done/end). This made progressive rendering of large tool inputs (e.g. `write.content`, `edit.edits[].newText`) impossible — consumers saw a long silence between `ChunkToolCallStreamStart` and the final `ChunkToolCall`.
- Each upstream argument fragment is now forwarded as `ChunkToolCallDelta{ToolCallID, ToolName, ToolInput: <fragment>}`. The existing buffer + final `ChunkToolCall` emission is preserved, so existing consumers are unaffected.
- Aligns these two adapters with anthropic, bedrock-converse, and the shared `internal/openaicompat` codec, which already forward deltas. Audited all 25 providers — only these two (and Azure routed through openai-responses) had the gap. Google Gemini native REST is upstream-limited (no delta events) and not addressable at adapter level.

Closes #56.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full repo, all packages pass)
- [x] `go test -cover ./provider/openai/ ./provider/cohere/` — coverage 98.9% / 99.0% (well above 90% target)
- [x] Extended `TestChat_Responses_ToolCalls` and `TestStream_ToolCallEvents` to assert `ChunkToolCallDelta` fragments are emitted in correct order with correct `ToolCallID` / `ToolName`
- [x] `go vet ./provider/openai/... ./provider/cohere/...`