### PR TITLE
test(openai,cohere): cover cancel path on streaming tool-call delta

### DIFF
--- a/provider/cohere/cohere_test.go
+++ b/provider/cohere/cohere_test.go
@@ -1854,6 +1854,27 @@ func TestParseChatStream_ContextCancel_AllBranches(t *testing.T) {
 		})
 	}
 
+	// Nested: tool-call-delta ChunkToolCallDelta TrySend cancel.
+	t.Run("tool_call_delta_cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		out := make(chan provider.StreamChunk) // unbuffered
+
+		input := "data: {\"type\":\"tool-call-start\",\"delta\":{\"message\":{\"tool_calls\":{\"id\":\"t1\",\"function\":{\"name\":\"fn\"}}}}}\n" +
+			"data: {\"type\":\"tool-call-delta\",\"delta\":{\"message\":{\"tool_calls\":{\"function\":{\"arguments\":\"{}\"}}}}}\n"
+
+		done := make(chan struct{})
+		go func() {
+			parseChatStream(ctx, strings.NewReader(input), out)
+			close(done)
+		}()
+
+		<-out // tool start
+		cancel()
+		<-done
+		for range out {
+		}
+	})
+
 	// Nested: tool-call-end (line 710) requires tool-call-start TrySend to succeed first.
 	t.Run("tool_call_end_cancel", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -3470,6 +3470,29 @@ func TestStreamResponses_ContextCancel_AllBranches(t *testing.T) {
 		}
 	})
 
+	// Nested: function_call_arguments.delta ChunkToolCall TrySend cancel
+	// (after the new ChunkToolCallDelta TrySend succeeds).
+	t.Run("function_call_args_toolcall_cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		out := make(chan provider.StreamChunk) // unbuffered
+
+		input := line("response.output_item.added", `{"output_index":0,"item":{"type":"function_call","id":"fc1","call_id":"c1","name":"fn"}}`) +
+			line("response.function_call_arguments.delta", `{"output_index":0,"delta":"{}"}`)
+
+		done := make(chan struct{})
+		go func() {
+			streamResponses(ctx, io.NopCloser(strings.NewReader(input)), out)
+			close(done)
+		}()
+
+		<-out // function call start
+		<-out // ChunkToolCallDelta
+		cancel()
+		<-done
+		for range out {
+		}
+	})
+
 	// Nested: function_call_arguments.done flush (line 553)
 	t.Run("function_call_args_done_cancel", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())


### PR DESCRIPTION
## Summary
Address Codecov patch-coverage feedback on #57. The `ChunkToolCallDelta` TrySend cancel branch lacked test coverage in both adapters.

- `provider/openai/openai_test.go` — new nested test `function_call_args_toolcall_cancel` consumes the start + delta chunk, then cancels before the final `ChunkToolCall` TrySend. The pre-existing `function_call_args_cancel` test continues to cover the new delta TrySend cancel branch.
- `provider/cohere/cohere_test.go` — new nested test `tool_call_delta_cancel` consumes the start chunk, cancels, then lets the delta event hit the new `ChunkToolCallDelta` TrySend cancel return.

Coverage: `provider/openai` 98.9% → 99.0%; `provider/cohere` 99.0% → 99.3%.

## Test plan
- [x] `go test ./provider/openai/ ./provider/cohere/`
- [x] coverage profile shows previously-uncovered cancel returns now hit