### PR TITLE
fix(anthropic,openai,core): round-trip server-executed tool calls (#59)

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1480,6 +1480,30 @@ func requestMessages(system string, msgs []provider.Message) []provider.Message 
 	return append(out, msgs...)
 }
 
+// isProviderExecuted reports whether a tool call was executed by the provider
+// (e.g. Anthropic web_search, OpenAI web_search_call). The provider returns
+// the result inline on the assistant turn, so goai must not look it up in
+// the user's tool map or synthesize a tool-result message for it.
+//
+// Providers mark these calls by setting tc.Metadata["providerExecuted"] = true
+// (or by attaching a non-nil "resultBlock" / "rawItem" payload that the
+// request serializer re-emits verbatim).
+func isProviderExecuted(tc provider.ToolCall) bool {
+	if tc.Metadata == nil {
+		return false
+	}
+	if v, ok := tc.Metadata["providerExecuted"].(bool); ok && v {
+		return true
+	}
+	if _, ok := tc.Metadata["resultBlock"]; ok {
+		return true
+	}
+	if _, ok := tc.Metadata["rawItem"]; ok {
+		return true
+	}
+	return false
+}
+
 // buildToolMap creates a name→Tool lookup from the options.
 func buildToolMap(tools []Tool) map[string]Tool {
 	if len(tools) == 0 {
@@ -1530,6 +1554,14 @@ func executeToolsParallel(
 	var wg sync.WaitGroup
 
 	for i, tc := range calls {
+		// Server-executed tool calls (e.g. Anthropic web_search, OpenAI
+		// web_search_call) are run by the provider itself; their results are
+		// already inline on the assistant turn. They have no Execute and must
+		// not be looked up in toolMap or surfaced as unknown-tool errors.
+		if isProviderExecuted(tc) {
+			results[i] = toolOutput{index: i, result: ""}
+			continue
+		}
 		tool, ok := toolMap[tc.Name]
 		if !ok {
 			// Unknown tool: fire OnToolCallStart + OnToolCall with ErrUnknownTool.
@@ -1797,6 +1829,11 @@ func buildToolResults(calls []provider.ToolCall, results []toolOutput) []provide
 func buildToolMessages(calls []provider.ToolCall, results []toolOutput) []provider.Message {
 	msgs := make([]provider.Message, 0, len(calls))
 	for i, tc := range calls {
+		// Server-executed calls have no separate tool message; their result
+		// is delivered inline on the assistant turn.
+		if isProviderExecuted(tc) {
+			continue
+		}
 		r := results[i]
 		if r.err != nil {
 			errStr := r.err.Error()

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -621,14 +621,29 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 				if input == nil {
 					input = map[string]any{}
 				}
+				// Server-executed tools (e.g. web_search) carry the matched
+				// result block via ProviderOptions["resultBlock"]. Emit
+				// "server_tool_use" instead of "tool_use" so the API
+				// recognizes the pairing, then append the raw result block.
+				resultBlock, _ := part.ProviderOptions["resultBlock"].(map[string]any)
+				toolUseType := "tool_use"
+				if resultBlock != nil {
+					toolUseType = "server_tool_use"
+				}
 				p := map[string]any{
-					"type":  "tool_use",
+					"type":  toolUseType,
 					"id":    part.ToolCallID,
 					"name":  part.ToolName,
 					"input": input,
 				}
-				applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+				if resultBlock == nil {
+					applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+				}
 				content = append(content, p)
+				if resultBlock != nil {
+					applyCacheControl(resultBlock, part.CacheControl, msgCacheControl, isLast)
+					content = append(content, resultBlock)
+				}
 
 			case provider.PartToolResult:
 				p := map[string]any{
@@ -769,9 +784,38 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 	var isRFBlock bool                  // true when current tool_use block is the synthetic response format tool
 	var isFirstDelta bool               // true for first input_json_delta of a tool_use block
 	var isServerTool bool               // true when current block is server_tool_use
+	var isResultBlock bool              // true when current block is a server tool result (e.g. web_search_tool_result)
 	var usage provider.Usage
 	var responseMeta provider.ResponseMetadata
 	var finishMeta map[string]any // metadata accumulated for ChunkFinish
+
+	// Pending server_tool_use ChunkToolCall: deferred so we can attach the
+	// matching result block (which arrives in the next content_block) before
+	// emitting. See parseResponse for the non-streaming equivalent.
+	var pendingHasCall bool
+	var pendingCallID, pendingCallName string
+	var pendingCallArgs string
+	var capturedResultBlock map[string]any
+
+	flushPendingCall := func() bool {
+		if !pendingHasCall {
+			return true
+		}
+		args := cmp.Or(pendingCallArgs, "{}")
+		chunk := provider.StreamChunk{
+			Type:       provider.ChunkToolCall,
+			ToolCallID: pendingCallID,
+			ToolName:   pendingCallName,
+			ToolInput:  args,
+		}
+		if capturedResultBlock != nil {
+			chunk.Metadata = map[string]any{"resultBlock": capturedResultBlock}
+		}
+		pendingHasCall = false
+		pendingCallID, pendingCallName, pendingCallArgs = "", "", ""
+		capturedResultBlock = nil
+		return provider.TrySend(ctx, out, chunk)
+	}
 
 	for data, ok := sseScanner.Next(); ok; data, ok = sseScanner.Next() {
 
@@ -807,6 +851,15 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 		case "content_block_start":
 			if cb, ok := event["content_block"].(map[string]any); ok {
 				cbType, _ := cb["type"].(string)
+				isResultBlock = false
+				// If a pending server_tool_use awaits a result block and the
+				// next block is NOT its matching result, flush it without
+				// resultBlock attached.
+				if pendingHasCall && !isServerToolResultBlock(cbType) {
+					if !flushPendingCall() {
+						return
+					}
+				}
 				switch cbType {
 				case "tool_use":
 					currentToolCallID, _ = cb["id"].(string)
@@ -835,6 +888,20 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 						ToolName:   currentToolName,
 					}) {
 						return
+					}
+				default:
+					if isServerToolResultBlock(cbType) {
+						isResultBlock = true
+						if pendingHasCall {
+							// Anthropic emits the full result block in
+							// content_block_start (no input_json_delta for
+							// these). Capture verbatim for round-trip when
+							// tool_use_id matches the pending call.
+							useID, _ := cb["tool_use_id"].(string)
+							if useID == pendingCallID {
+								capturedResultBlock = cb
+							}
+						}
 					}
 				}
 			}
@@ -919,7 +986,23 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 			}
 
 		case "content_block_stop":
-			if currentToolCallID != "" && !isRFBlock {
+			switch {
+			case isResultBlock:
+				// End of a server tool result block. Flush the deferred
+				// server_tool_use ChunkToolCall with resultBlock attached.
+				if !flushPendingCall() {
+					return
+				}
+				isResultBlock = false
+			case isServerTool && currentToolCallID != "":
+				// Defer ChunkToolCall emission so we can attach the matching
+				// result block (next content_block) before flushing.
+				pendingHasCall = true
+				pendingCallID = currentToolCallID
+				pendingCallName = currentToolName
+				pendingCallArgs = currentToolArgs.String()
+				currentToolArgs.Reset()
+			case currentToolCallID != "" && !isRFBlock:
 				// Emit accumulated tool call with complete JSON args.
 				args := cmp.Or(currentToolArgs.String(), "{}")
 				if !provider.TrySend(ctx, out, provider.StreamChunk{
@@ -942,6 +1025,11 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 		case "message_delta":
 			if delta, ok := event["delta"].(map[string]any); ok {
 				if sr, ok := delta["stop_reason"].(string); ok {
+					// Flush any pending server tool call before signalling
+					// step finish so consumers see the ChunkToolCall first.
+					if !flushPendingCall() {
+						return
+					}
 					fr := mapFinishReason(sr)
 					// In RF mode, tool_use finish → stop (we consumed the tool as text).
 					if isRFMode && fr == provider.FinishToolCalls {
@@ -1008,6 +1096,10 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 			}
 
 		case "message_stop":
+			// Flush pending server tool call without resultBlock if none arrived.
+			if !flushPendingCall() {
+				return
+			}
 			usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 			if !provider.TrySend(ctx, out, provider.StreamChunk{
 				Type:     provider.ChunkFinish,
@@ -1039,6 +1131,7 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 		return
 	}
 	// Clean EOF without message_stop: emit finish with accumulated usage and response meta.
+	_ = flushPendingCall()
 	usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 	provider.TrySend(ctx, out, provider.StreamChunk{
 		Type:     provider.ChunkFinish,
@@ -1085,6 +1178,23 @@ func mapFinishReason(reason string) provider.FinishReason {
 
 // --- Non-streaming response parsing ---
 
+// serverToolResultBlockTypes lists Anthropic block types that pair with a
+// server_tool_use as the matched result. They must be round-tripped on the
+// assistant turn -- omitting them causes the API to reject re-sent transcripts
+// with "tool_use ids were found without `tool_result` blocks".
+var serverToolResultBlockTypes = map[string]bool{
+	"web_search_tool_result":                true,
+	"web_fetch_tool_result":                 true,
+	"code_execution_tool_result":            true,
+	"bash_code_execution_tool_result":       true,
+	"text_editor_code_execution_tool_result": true,
+	"mcp_tool_result":                       true,
+}
+
+func isServerToolResultBlock(t string) bool {
+	return serverToolResultBlockTypes[t]
+}
+
 func parseResponse(body []byte) (*provider.GenerateResult, error) {
 	var resp struct {
 		ID      string `json:"id"`
@@ -1099,6 +1209,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 			Thinking  string          `json:"thinking,omitempty"`
 			Signature string          `json:"signature,omitempty"`
 			Data      string          `json:"data,omitempty"` // redacted_thinking
+			ToolUseID string          `json:"tool_use_id,omitempty"` // for server tool result blocks
 			Citations []struct {
 				Type            string  `json:"type"`
 				CitedText       string  `json:"cited_text"`
@@ -1150,6 +1261,17 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 		return nil, fmt.Errorf("parsing anthropic response: %w", err)
 	}
 
+	// Side-channel raw parse of content blocks: server tool result blocks
+	// (e.g. web_search_tool_result) carry provider-specific payloads we cannot
+	// fully model in our typed struct. We preserve them verbatim so they can
+	// be round-tripped on the assistant turn (Anthropic's API rejects
+	// transcripts where a server_tool_use is not immediately followed by its
+	// result block).
+	var rawContent struct {
+		Content []json.RawMessage `json:"content"`
+	}
+	_ = json.Unmarshal(body, &rawContent)
+
 	// Handle error response.
 	if resp.Error != nil {
 		if goai.IsOverflow(resp.Error.Message) {
@@ -1173,7 +1295,10 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 	var textParts []string
 	var reasoningParts []string
 	var providerMeta map[string]any
-	for _, block := range resp.Content {
+	// Index of the last server_tool_use ToolCall, for attaching the matching
+	// result block when it appears immediately after.
+	lastServerToolIdx := -1
+	for i, block := range resp.Content {
 		switch block.Type {
 		case "text":
 			if block.Text != "" {
@@ -1243,6 +1368,25 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 				Name:  block.Name,
 				Input: block.Input,
 			})
+			if block.Type == "server_tool_use" {
+				lastServerToolIdx = len(result.ToolCalls) - 1
+			} else {
+				lastServerToolIdx = -1
+			}
+		default:
+			if isServerToolResultBlock(block.Type) && lastServerToolIdx >= 0 && i < len(rawContent.Content) {
+				// Decode raw block as map[string]any so the request serializer
+				// can re-emit it verbatim alongside the matching server_tool_use.
+				var rb map[string]any
+				if err := json.Unmarshal(rawContent.Content[i], &rb); err == nil {
+					tc := &result.ToolCalls[lastServerToolIdx]
+					if tc.Metadata == nil {
+						tc.Metadata = map[string]any{}
+					}
+					tc.Metadata["resultBlock"] = rb
+				}
+				lastServerToolIdx = -1
+			}
 		}
 	}
 	result.Text = strings.Join(textParts, "")

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -2887,3 +2887,189 @@ func TestWithSkipEnvResolve(t *testing.T) {
 		t.Errorf("baseURL = %q, want %q", model.opts.baseURL, defaultBaseURL)
 	}
 }
+
+// --- Server-side tool round-trip (web_search, code_execution, ...) ---
+
+// TestChat_Generate_ServerToolResultRoundTrip verifies that web_search_tool_result
+// (and similar server-executed tool result blocks) are captured into the
+// matching ToolCall.Metadata so they survive a multi-turn round-trip.
+// Regression for the issue where re-sending ResponseMessages containing a
+// server_tool_use (e.g. web_search) without its inline result was rejected
+// by the API as "tool_use ids were found without `tool_result` blocks".
+func TestChat_Generate_ServerToolResultRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "msg_srv1",
+			"model": "sonnet-test-model",
+			"type": "message",
+			"content": [
+				{"type": "text", "text": "Searching..."},
+				{"type": "server_tool_use", "id": "srvtoolu_abc", "name": "web_search", "input": {"query": "go 1.26"}},
+				{"type": "web_search_tool_result", "tool_use_id": "srvtoolu_abc", "content": [
+					{"type": "web_search_result", "url": "https://example.com", "title": "Go 1.26 release", "encrypted_content": "xxx"}
+				]},
+				{"type": "text", "text": "Go 1.26 was released in 2026."}
+			],
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 30, "output_tokens": 40}
+		}`)
+	}))
+	defer server.Close()
+
+	model := Chat("sonnet-test-model", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new in go?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	tc := result.ToolCalls[0]
+	if tc.ID != "srvtoolu_abc" || tc.Name != "web_search" {
+		t.Errorf("ToolCall = %+v, want srvtoolu_abc/web_search", tc)
+	}
+	rb, ok := tc.Metadata["resultBlock"].(map[string]any)
+	if !ok {
+		t.Fatalf("ToolCall.Metadata[resultBlock] missing or wrong type: %T", tc.Metadata["resultBlock"])
+	}
+	if rb["type"] != "web_search_tool_result" {
+		t.Errorf("resultBlock type = %v, want web_search_tool_result", rb["type"])
+	}
+	if rb["tool_use_id"] != "srvtoolu_abc" {
+		t.Errorf("resultBlock tool_use_id = %v, want srvtoolu_abc", rb["tool_use_id"])
+	}
+}
+
+// TestChat_Stream_ServerToolResultRoundTrip is the streaming counterpart to
+// TestChat_Generate_ServerToolResultRoundTrip.
+func TestChat_Stream_ServerToolResultRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"id":"msg_srv2","model":"sonnet-test-model","usage":{"input_tokens":30}}}`+"\n\n")
+		// Index 0: text
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Searching..."}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		// Index 1: server_tool_use
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_abc","name":"web_search"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"go 1.26\"}"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":1}`+"\n\n")
+		// Index 2: web_search_tool_result (full block in start, no deltas)
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":2,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_abc","content":[{"type":"web_search_result","url":"https://example.com","title":"Go 1.26 release","encrypted_content":"xxx"}]}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":2}`+"\n\n")
+		// Index 3: text follow-up
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":3,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"Go 1.26 was released in 2026."}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":3}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":40}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("sonnet-test-model", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new in go?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawToolCall provider.StreamChunk
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkToolCall {
+			sawToolCall = chunk
+		}
+	}
+	if sawToolCall.ToolCallID != "srvtoolu_abc" {
+		t.Fatalf("ChunkToolCall ID = %q, want srvtoolu_abc", sawToolCall.ToolCallID)
+	}
+	rb, ok := sawToolCall.Metadata["resultBlock"].(map[string]any)
+	if !ok {
+		t.Fatalf("ChunkToolCall.Metadata[resultBlock] missing: %v", sawToolCall.Metadata)
+	}
+	if rb["type"] != "web_search_tool_result" {
+		t.Errorf("resultBlock type = %v, want web_search_tool_result", rb["type"])
+	}
+	if rb["tool_use_id"] != "srvtoolu_abc" {
+		t.Errorf("resultBlock tool_use_id = %v, want srvtoolu_abc", rb["tool_use_id"])
+	}
+}
+
+// TestConvertMessages_ServerToolResultBlock verifies that an assistant
+// PartToolCall with ProviderOptions["resultBlock"] re-emits the original
+// server_tool_use + web_search_tool_result pair when sent back to the API.
+func TestConvertMessages_ServerToolResultBlock(t *testing.T) {
+	resultBlock := map[string]any{
+		"type":        "web_search_tool_result",
+		"tool_use_id": "srvtoolu_abc",
+		"content": []any{
+			map[string]any{"type": "web_search_result", "url": "https://example.com", "title": "Go 1.26"},
+		},
+	}
+	msgs := convertMessages([]provider.Message{
+		{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new?"}}},
+		{Role: provider.RoleAssistant, Content: []provider.Part{
+			{Type: provider.PartText, Text: "Searching..."},
+			{
+				Type:            provider.PartToolCall,
+				ToolCallID:      "srvtoolu_abc",
+				ToolName:        "web_search",
+				ToolInput:       json.RawMessage(`{"query":"go 1.26"}`),
+				ProviderOptions: map[string]any{"resultBlock": resultBlock},
+			},
+			{Type: provider.PartText, Text: "Go 1.26 was released in 2026."},
+		}},
+		{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "thanks"}}},
+	})
+
+	if len(msgs) < 2 {
+		t.Fatalf("got %d messages, want at least 2", len(msgs))
+	}
+	asst := msgs[1]["content"].([]map[string]any)
+	// Find server_tool_use and assert the result block follows immediately.
+	// (ReorderAssistantParts moves text before tool_use; what matters is the
+	// tool_use → result adjacency required by the API.)
+	stIdx := -1
+	for i, p := range asst {
+		if p["type"] == "server_tool_use" {
+			stIdx = i
+			break
+		}
+	}
+	if stIdx < 0 {
+		t.Fatalf("no server_tool_use block in assistant content: %+v", asst)
+	}
+	if asst[stIdx]["id"] != "srvtoolu_abc" {
+		t.Errorf("server_tool_use id = %v, want srvtoolu_abc", asst[stIdx]["id"])
+	}
+	if stIdx+1 >= len(asst) {
+		t.Fatalf("no block after server_tool_use; result missing")
+	}
+	rb := asst[stIdx+1]
+	if rb["type"] != "web_search_tool_result" {
+		t.Errorf("block after server_tool_use type = %v, want web_search_tool_result", rb["type"])
+	}
+	if rb["tool_use_id"] != "srvtoolu_abc" {
+		t.Errorf("result tool_use_id = %v, want srvtoolu_abc", rb["tool_use_id"])
+	}
+
+	// No orphan tool_result should be injected for the server tool call --
+	// its result is already inline in the assistant turn. An orphan would
+	// surface as a tool_result block in a following user message.
+	for i := 2; i < len(msgs); i++ {
+		c := msgs[i]["content"].([]map[string]any)
+		for _, p := range c {
+			if p["type"] == "tool_result" && p["tool_use_id"] == "srvtoolu_abc" {
+				t.Errorf("orphan tool_result injected for server tool srvtoolu_abc in msg[%d]: %+v", i, p)
+			}
+		}
+	}
+}

--- a/provider/normalize.go
+++ b/provider/normalize.go
@@ -14,6 +14,11 @@ func NormalizeToolMessages(msgs []Message) []Message {
 // ensureToolResultPairing ensures every assistant message with tool-call parts
 // has matching tool-result parts in following messages. Injects synthetic
 // "Tool execution aborted" results for orphaned tool-calls.
+//
+// Server-executed tool calls (e.g. Anthropic web_search) are skipped: their
+// result is delivered inline on the same assistant turn via the part's
+// ProviderOptions["resultBlock"], so no following tool-result message is
+// expected.
 func ensureToolResultPairing(msgs []Message) []Message {
 	for i := 0; i < len(msgs); i++ {
 		if msgs[i].Role != RoleAssistant {
@@ -22,6 +27,9 @@ func ensureToolResultPairing(msgs []Message) []Message {
 		var callIDs []string
 		for _, p := range msgs[i].Content {
 			if p.Type == PartToolCall && p.ToolCallID != "" {
+				if _, hasInlineResult := p.ProviderOptions["resultBlock"]; hasInlineResult {
+					continue
+				}
 				callIDs = append(callIDs, p.ToolCallID)
 			}
 		}

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -3790,3 +3790,136 @@ func TestChat_DoGenerate_PromptCachingWarning(t *testing.T) {
 		t.Errorf("Text = %q, want ok", result.Text)
 	}
 }
+
+// --- Responses API server-executed tool round-trip ---
+
+// TestChat_Responses_Generate_ServerToolRoundTrip verifies that Responses API
+// server-executed items (web_search_call, file_search_call, ...) are captured
+// into ToolCall.Metadata so they survive a multi-turn round-trip.
+func TestChat_Responses_Generate_ServerToolRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "resp-srv-1",
+			"model": "test-model",
+			"status": "completed",
+			"output": [
+				{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"go 1.26"}},
+				{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Go 1.26 was released."}]}
+			],
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`)
+	}))
+	defer server.Close()
+
+	model := Chat("test-model", WithAPIKey("k"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new in go?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	tc := result.ToolCalls[0]
+	if tc.ID != "ws_1" || tc.Name != "web_search_call" {
+		t.Errorf("ToolCall = %+v, want id=ws_1 name=web_search_call", tc)
+	}
+	if exec, _ := tc.Metadata["providerExecuted"].(bool); !exec {
+		t.Errorf("Metadata[providerExecuted] = false, want true")
+	}
+	raw, _ := tc.Metadata["rawItem"].(map[string]any)
+	if raw["type"] != "web_search_call" {
+		t.Errorf("rawItem type = %v, want web_search_call", raw["type"])
+	}
+}
+
+// TestChat_Responses_Stream_ServerToolRoundTrip is the streaming counterpart.
+func TestChat_Responses_Stream_ServerToolRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.output_item.added\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0,"item":{"type":"web_search_call","id":"ws_1"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.output_item.done\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0,"item":{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"go 1.26"}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.output_text.delta\n")
+		_, _ = fmt.Fprint(w, `data: {"delta":"Go 1.26 was released."}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.completed\n")
+		_, _ = fmt.Fprint(w, `data: {"response":{"id":"resp_1","model":"test-model","usage":{"input_tokens":10,"output_tokens":5}}}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("test-model", WithAPIKey("k"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawToolCall provider.StreamChunk
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkToolCall {
+			sawToolCall = chunk
+		}
+	}
+	if sawToolCall.ToolCallID != "ws_1" {
+		t.Fatalf("ChunkToolCall ID = %q, want ws_1", sawToolCall.ToolCallID)
+	}
+	if exec, _ := sawToolCall.Metadata["providerExecuted"].(bool); !exec {
+		t.Errorf("Metadata[providerExecuted] = false, want true")
+	}
+	raw, _ := sawToolCall.Metadata["rawItem"].(map[string]any)
+	if raw["type"] != "web_search_call" {
+		t.Errorf("rawItem type = %v, want web_search_call", raw["type"])
+	}
+	if raw["id"] != "ws_1" {
+		t.Errorf("rawItem id = %v, want ws_1", raw["id"])
+	}
+}
+
+// TestConvertToResponsesInput_ServerToolItem verifies that an assistant
+// PartToolCall carrying ProviderOptions["rawItem"] is re-emitted verbatim
+// instead of being shaped as a function_call.
+func TestConvertToResponsesInput_ServerToolItem(t *testing.T) {
+	rawItem := map[string]any{
+		"type":   "web_search_call",
+		"id":     "ws_1",
+		"status": "completed",
+		"action": map[string]any{"type": "search", "query": "go 1.26"},
+	}
+	input := convertToResponsesInput([]provider.Message{
+		{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "search"}}},
+		{Role: provider.RoleAssistant, Content: []provider.Part{
+			{Type: provider.PartText, Text: "Searching..."},
+			{
+				Type:            provider.PartToolCall,
+				ToolCallID:      "ws_1",
+				ToolName:        "web_search_call",
+				ProviderOptions: map[string]any{"providerExecuted": true, "rawItem": rawItem},
+			},
+		}},
+	})
+
+	var sawWebSearch bool
+	for _, item := range input {
+		if item["type"] == "web_search_call" {
+			sawWebSearch = true
+			if item["id"] != "ws_1" {
+				t.Errorf("web_search_call id = %v, want ws_1", item["id"])
+			}
+			if _, hasFunctionCallShape := item["call_id"]; hasFunctionCallShape {
+				t.Error("web_search_call should not be reshaped as function_call")
+			}
+		}
+	}
+	if !sawWebSearch {
+		t.Errorf("expected web_search_call item in serialized input, got: %+v", input)
+	}
+}
+

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -14,6 +14,24 @@ import (
 	"github.com/zendev-sh/goai/provider"
 )
 
+// serverExecutedItemTypes lists Responses API output item types that the
+// provider runs server-side (no client execution). When these items appear in
+// the response output, their full payload must round-trip on the assistant
+// turn so the model retains context across follow-up requests.
+var serverExecutedItemTypes = map[string]bool{
+	"web_search_call":       true,
+	"file_search_call":      true,
+	"code_interpreter_call": true,
+	"image_generation_call": true,
+	"local_shell_call":      true,
+	"mcp_call":              true,
+	"mcp_list_tools":        true,
+	"mcp_approval_request":  true,
+	"computer_call":         true,
+}
+
+func isServerExecutedItem(t string) bool { return serverExecutedItemTypes[t] }
+
 // buildResponsesRequest creates an OpenAI Responses API request body.
 func buildResponsesRequest(params provider.GenerateParams, modelID string, streaming bool) map[string]any {
 	body := map[string]any{
@@ -328,6 +346,13 @@ func convertToResponsesInput(msgs []provider.Message) []map[string]any {
 						textParts = append(textParts, part.Text)
 					}
 				case provider.PartToolCall:
+					// Server-executed tool items (web_search_call,
+					// file_search_call, ...) round-trip verbatim so the model
+					// sees the same context across turns.
+					if raw, ok := part.ProviderOptions["rawItem"].(map[string]any); ok {
+						items = append(items, raw)
+						break
+					}
 					items = append(items, map[string]any{
 						"type":      "function_call",
 						"call_id":   part.ToolCallID,
@@ -597,19 +622,45 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 
 		case "response.output_item.done":
 			var ev struct {
-				OutputIndex int `json:"output_index"`
-				Item        struct {
-					Type string `json:"type"`
-				} `json:"item"`
+				OutputIndex int             `json:"output_index"`
+				Item        json.RawMessage `json:"item"`
 			}
 			if json.Unmarshal([]byte(data), &ev) == nil {
-				switch ev.Item.Type {
+				var itemHead struct {
+					Type string `json:"type"`
+				}
+				_ = json.Unmarshal(ev.Item, &itemHead)
+				switch itemHead.Type {
 				case "reasoning":
 					delete(activeReasoning, ev.OutputIndex)
 					if currentReasoningIdx == ev.OutputIndex {
 						currentReasoningIdx = -1
 					}
 				default:
+					if isServerExecutedItem(itemHead.Type) {
+						// Capture the full server-executed item payload and
+						// emit a ChunkToolCall so it round-trips into the
+						// assistant turn via ToolCall.Metadata.
+						var raw map[string]any
+						if err := json.Unmarshal(ev.Item, &raw); err == nil {
+							id, _ := raw["id"].(string)
+							name, _ := raw["name"].(string)
+							if name == "" {
+								name = itemHead.Type
+							}
+							if !provider.TrySend(ctx, out, provider.StreamChunk{
+								Type:       provider.ChunkToolCall,
+								ToolCallID: id,
+								ToolName:   name,
+								Metadata: map[string]any{
+									"providerExecuted": true,
+									"rawItem":          raw,
+								},
+							}) {
+								return
+							}
+						}
+					}
 					delete(activeTools, ev.OutputIndex)
 				}
 			}
@@ -879,6 +930,14 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 		return nil, &goai.APIError{Message: resp.Error.Message, ResponseBody: string(body)}
 	}
 
+	// Side-channel raw parse so server-executed items (web_search_call etc.)
+	// can be round-tripped verbatim on the assistant turn -- the typed struct
+	// only models the subset of fields we explicitly consume.
+	var rawOutput struct {
+		Output []json.RawMessage `json:"output"`
+	}
+	_ = json.Unmarshal(body, &rawOutput)
+
 	result := &provider.GenerateResult{
 		Response: provider.ResponseMetadata{
 			ID:    resp.ID,
@@ -893,7 +952,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 	providerMeta := map[string]any{}
 	var allLogprobs []any
 
-	for _, item := range resp.Output {
+	for i, item := range resp.Output {
 		switch item.Type {
 		case "message":
 			for _, c := range item.Content {
@@ -935,6 +994,25 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 					providerMeta["reasoning"] = append(reasoning, map[string]any{
 						"type": s.Type,
 						"text": s.Text,
+					})
+				}
+			}
+		default:
+			if isServerExecutedItem(item.Type) && i < len(rawOutput.Output) {
+				var raw map[string]any
+				if err := json.Unmarshal(rawOutput.Output[i], &raw); err == nil {
+					id, _ := raw["id"].(string)
+					name, _ := raw["name"].(string)
+					if name == "" {
+						name = item.Type
+					}
+					result.ToolCalls = append(result.ToolCalls, provider.ToolCall{
+						ID:   id,
+						Name: name,
+						Metadata: map[string]any{
+							"providerExecuted": true,
+							"rawItem":          raw,
+						},
 					})
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes #59. Provider-executed tools (Anthropic `web_search`, `code_execution`, `web_fetch`, `mcp`; OpenAI Responses `web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `local_shell_call`, `mcp_call`, `computer_call`) now round-trip correctly across multi-turn conversations.

- **Hard bug (Anthropic, HTTP 400 on re-send)**: the provider dropped server tool result blocks. Appending `result.ResponseMessages` produced an orphan `tool_use` and the next request was rejected with `tool_use ids were found without tool_result blocks`.
- **Soft bug (OpenAI Responses, lost context)**: server tool items were silently dropped. Re-send lost search/grounding history; not rejected, but model lost context across turns.

## Approach

- Capture server-tool payload in non-streaming (`parseResponse` / `parseResponsesResult`) and streaming (`parseSSE` / `parseResponsesStream`) paths via a side-channel raw parse + deferred `ChunkToolCall` emission.
- Attach to `ToolCall.Metadata` (`resultBlock` for Anthropic, `rawItem` + `providerExecuted` for OpenAI Responses). The metadata flows through `buildFinalAssistantMessages` / `appendToolRoundTrip` into `ResponseMessages` via `Part.ProviderOptions`.
- Re-emit verbatim when the assistant turn is serialized back to the API.
- Shared core (`isProviderExecuted`, `executeToolsParallel`, `buildToolMessages`, `ensureToolResultPairing`) skips unknown-tool synthesis and orphan `tool_result` injection for these calls.

Vertex `AnthropicChat` and MiniMax inherit the fix automatically (they delegate to `anthropic.Chat`). Bedrock Converse does not currently route Anthropic server tools — separate provider gap.

## Test plan

- [x] `go test ./...` (all packages green)
- [x] Anthropic non-streaming + streaming round-trip unit tests
- [x] OpenAI Responses non-streaming + streaming round-trip unit tests
- [x] Convert-message round-trip tests for both providers
- [x] Orphan-injection regression test (`ensureToolResultPairing` skips inline results)
- [x] User's exact reproduction code (StreamText + append ResponseMessages loop) verified against a wire-format mock that asserts `server_tool_use → web_search_tool_result` adjacency on each re-send turn