### PR TITLE
fix(anthropic,openai,bedrock,core): round-trip server-executed tool calls

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1480,6 +1480,30 @@ func requestMessages(system string, msgs []provider.Message) []provider.Message 
 	return append(out, msgs...)
 }
 
+// isProviderExecuted reports whether a tool call was executed by the provider
+// (e.g. Anthropic web_search, OpenAI web_search_call). The provider returns
+// the result inline on the assistant turn, so goai must not look it up in
+// the user's tool map or synthesize a tool-result message for it.
+//
+// Providers mark these calls by setting tc.Metadata["providerExecuted"] = true
+// (or by attaching a non-nil "resultBlock" / "rawItem" payload that the
+// request serializer re-emits verbatim).
+func isProviderExecuted(tc provider.ToolCall) bool {
+	if tc.Metadata == nil {
+		return false
+	}
+	if v, ok := tc.Metadata["providerExecuted"].(bool); ok && v {
+		return true
+	}
+	if _, ok := tc.Metadata["resultBlock"]; ok {
+		return true
+	}
+	if _, ok := tc.Metadata["rawItem"]; ok {
+		return true
+	}
+	return false
+}
+
 // buildToolMap creates a name→Tool lookup from the options.
 func buildToolMap(tools []Tool) map[string]Tool {
 	if len(tools) == 0 {
@@ -1530,6 +1554,14 @@ func executeToolsParallel(
 	var wg sync.WaitGroup
 
 	for i, tc := range calls {
+		// Server-executed tool calls (e.g. Anthropic web_search, OpenAI
+		// web_search_call) are run by the provider itself; their results are
+		// already inline on the assistant turn. They have no Execute and must
+		// not be looked up in toolMap or surfaced as unknown-tool errors.
+		if isProviderExecuted(tc) {
+			results[i] = toolOutput{index: i, result: ""}
+			continue
+		}
 		tool, ok := toolMap[tc.Name]
 		if !ok {
 			// Unknown tool: fire OnToolCallStart + OnToolCall with ErrUnknownTool.
@@ -1797,6 +1829,11 @@ func buildToolResults(calls []provider.ToolCall, results []toolOutput) []provide
 func buildToolMessages(calls []provider.ToolCall, results []toolOutput) []provider.Message {
 	msgs := make([]provider.Message, 0, len(calls))
 	for i, tc := range calls {
+		// Server-executed calls have no separate tool message; their result
+		// is delivered inline on the assistant turn.
+		if isProviderExecuted(tc) {
+			continue
+		}
 		r := results[i]
 		if r.err != nil {
 			errStr := r.err.Error()

--- a/generate_test.go
+++ b/generate_test.go
@@ -6063,3 +6063,32 @@ func TestBuildToolResults(t *testing.T) {
 		}
 	})
 }
+
+// TestIsProviderExecuted covers all branches of the helper that decides
+// whether a tool call was executed by the provider (Anthropic web_search,
+// OpenAI web_search_call, etc.) and therefore must skip the user-side
+// tool map lookup + tool-result message synthesis.
+func TestIsProviderExecuted(t *testing.T) {
+	cases := []struct {
+		name string
+		md   map[string]any
+		want bool
+	}{
+		{"nil metadata", nil, false},
+		{"empty metadata", map[string]any{}, false},
+		{"providerExecuted=true", map[string]any{"providerExecuted": true}, true},
+		{"providerExecuted=false", map[string]any{"providerExecuted": false}, false},
+		{"providerExecuted wrong type", map[string]any{"providerExecuted": "yes"}, false},
+		{"resultBlock attached", map[string]any{"resultBlock": map[string]any{"type": "web_search_tool_result"}}, true},
+		{"rawItem attached", map[string]any{"rawItem": map[string]any{"type": "web_search_call"}}, true},
+		{"unrelated metadata", map[string]any{"reasoning": "foo"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isProviderExecuted(provider.ToolCall{Metadata: tc.md})
+			if got != tc.want {
+				t.Errorf("isProviderExecuted(%v) = %v, want %v", tc.md, got, tc.want)
+			}
+		})
+	}
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -6092,3 +6092,49 @@ func TestIsProviderExecuted(t *testing.T) {
 		})
 	}
 }
+
+// TestExecuteToolsParallel_SkipsProviderExecuted verifies that server-executed
+// tool calls (Metadata["providerExecuted"]=true) are not looked up in the
+// toolMap and therefore do NOT produce a synthetic ErrUnknownTool result --
+// their inline result on the assistant turn is the source of truth.
+func TestExecuteToolsParallel_SkipsProviderExecuted(t *testing.T) {
+	echoTool := Tool{
+		Name:        "echo",
+		Description: "echo",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Execute: func(ctx context.Context, input json.RawMessage) (string, error) {
+			return "echoed", nil
+		},
+	}
+	toolMap := map[string]Tool{"echo": echoTool}
+
+	calls := []provider.ToolCall{
+		{ID: "srvtoolu_1", Name: "web_search", Metadata: map[string]any{
+			"providerExecuted": true,
+			"resultBlock":      map[string]any{"type": "web_search_tool_result"},
+		}},
+		{ID: "tc2", Name: "echo", Input: json.RawMessage(`{}`)},
+	}
+
+	msgs, results := executeToolsParallel(t.Context(), calls, toolMap, 1, toolHooks{})
+
+	// Only the echo client tool should produce a tool message; server-executed
+	// calls don't get a separate tool-result message.
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs) = %d, want 1 (server tool skipped)", len(msgs))
+	}
+	if msgs[0].Content[0].ToolCallID != "tc2" {
+		t.Errorf("tool message id = %q, want tc2", msgs[0].Content[0].ToolCallID)
+	}
+	// Both ToolResult entries are returned for completeness, but the
+	// server-executed entry must not carry the unknown-tool error.
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].IsError {
+		t.Errorf("server-executed result should not be an error: %+v", results[0])
+	}
+	if results[1].Output != "echoed" {
+		t.Errorf("client tool result = %q, want echoed", results[1].Output)
+	}
+}

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -621,14 +621,29 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 				if input == nil {
 					input = map[string]any{}
 				}
+				// Server-executed tools (e.g. web_search) carry the matched
+				// result block via ProviderOptions["resultBlock"]. Emit
+				// "server_tool_use" instead of "tool_use" so the API
+				// recognizes the pairing, then append the raw result block.
+				resultBlock, _ := part.ProviderOptions["resultBlock"].(map[string]any)
+				toolUseType := "tool_use"
+				if resultBlock != nil {
+					toolUseType = "server_tool_use"
+				}
 				p := map[string]any{
-					"type":  "tool_use",
+					"type":  toolUseType,
 					"id":    part.ToolCallID,
 					"name":  part.ToolName,
 					"input": input,
 				}
-				applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+				if resultBlock == nil {
+					applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+				}
 				content = append(content, p)
+				if resultBlock != nil {
+					applyCacheControl(resultBlock, part.CacheControl, msgCacheControl, isLast)
+					content = append(content, resultBlock)
+				}
 
 			case provider.PartToolResult:
 				p := map[string]any{
@@ -769,9 +784,38 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 	var isRFBlock bool                  // true when current tool_use block is the synthetic response format tool
 	var isFirstDelta bool               // true for first input_json_delta of a tool_use block
 	var isServerTool bool               // true when current block is server_tool_use
+	var isResultBlock bool              // true when current block is a server tool result (e.g. web_search_tool_result)
 	var usage provider.Usage
 	var responseMeta provider.ResponseMetadata
 	var finishMeta map[string]any // metadata accumulated for ChunkFinish
+
+	// Pending server_tool_use ChunkToolCall: deferred so we can attach the
+	// matching result block (which arrives in the next content_block) before
+	// emitting. See parseResponse for the non-streaming equivalent.
+	var pendingHasCall bool
+	var pendingCallID, pendingCallName string
+	var pendingCallArgs string
+	var capturedResultBlock map[string]any
+
+	flushPendingCall := func() bool {
+		if !pendingHasCall {
+			return true
+		}
+		args := cmp.Or(pendingCallArgs, "{}")
+		chunk := provider.StreamChunk{
+			Type:       provider.ChunkToolCall,
+			ToolCallID: pendingCallID,
+			ToolName:   pendingCallName,
+			ToolInput:  args,
+		}
+		if capturedResultBlock != nil {
+			chunk.Metadata = map[string]any{"resultBlock": capturedResultBlock}
+		}
+		pendingHasCall = false
+		pendingCallID, pendingCallName, pendingCallArgs = "", "", ""
+		capturedResultBlock = nil
+		return provider.TrySend(ctx, out, chunk)
+	}
 
 	for data, ok := sseScanner.Next(); ok; data, ok = sseScanner.Next() {
 
@@ -807,6 +851,15 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 		case "content_block_start":
 			if cb, ok := event["content_block"].(map[string]any); ok {
 				cbType, _ := cb["type"].(string)
+				isResultBlock = false
+				// If a pending server_tool_use awaits a result block and the
+				// next block is NOT its matching result, flush it without
+				// resultBlock attached.
+				if pendingHasCall && !isServerToolResultBlock(cbType) {
+					if !flushPendingCall() {
+						return
+					}
+				}
 				switch cbType {
 				case "tool_use":
 					currentToolCallID, _ = cb["id"].(string)
@@ -835,6 +888,20 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 						ToolName:   currentToolName,
 					}) {
 						return
+					}
+				default:
+					if isServerToolResultBlock(cbType) {
+						isResultBlock = true
+						if pendingHasCall {
+							// Anthropic emits the full result block in
+							// content_block_start (no input_json_delta for
+							// these). Capture verbatim for round-trip when
+							// tool_use_id matches the pending call.
+							useID, _ := cb["tool_use_id"].(string)
+							if useID == pendingCallID {
+								capturedResultBlock = cb
+							}
+						}
 					}
 				}
 			}
@@ -919,7 +986,23 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 			}
 
 		case "content_block_stop":
-			if currentToolCallID != "" && !isRFBlock {
+			switch {
+			case isResultBlock:
+				// End of a server tool result block. Flush the deferred
+				// server_tool_use ChunkToolCall with resultBlock attached.
+				if !flushPendingCall() {
+					return
+				}
+				isResultBlock = false
+			case isServerTool && currentToolCallID != "":
+				// Defer ChunkToolCall emission so we can attach the matching
+				// result block (next content_block) before flushing.
+				pendingHasCall = true
+				pendingCallID = currentToolCallID
+				pendingCallName = currentToolName
+				pendingCallArgs = currentToolArgs.String()
+				currentToolArgs.Reset()
+			case currentToolCallID != "" && !isRFBlock:
 				// Emit accumulated tool call with complete JSON args.
 				args := cmp.Or(currentToolArgs.String(), "{}")
 				if !provider.TrySend(ctx, out, provider.StreamChunk{
@@ -942,6 +1025,11 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 		case "message_delta":
 			if delta, ok := event["delta"].(map[string]any); ok {
 				if sr, ok := delta["stop_reason"].(string); ok {
+					// Flush any pending server tool call before signalling
+					// step finish so consumers see the ChunkToolCall first.
+					if !flushPendingCall() {
+						return
+					}
 					fr := mapFinishReason(sr)
 					// In RF mode, tool_use finish → stop (we consumed the tool as text).
 					if isRFMode && fr == provider.FinishToolCalls {
@@ -1008,6 +1096,10 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 			}
 
 		case "message_stop":
+			// Flush pending server tool call without resultBlock if none arrived.
+			if !flushPendingCall() {
+				return
+			}
 			usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 			if !provider.TrySend(ctx, out, provider.StreamChunk{
 				Type:     provider.ChunkFinish,
@@ -1039,6 +1131,7 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 		return
 	}
 	// Clean EOF without message_stop: emit finish with accumulated usage and response meta.
+	_ = flushPendingCall()
 	usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 	provider.TrySend(ctx, out, provider.StreamChunk{
 		Type:     provider.ChunkFinish,
@@ -1085,6 +1178,23 @@ func mapFinishReason(reason string) provider.FinishReason {
 
 // --- Non-streaming response parsing ---
 
+// serverToolResultBlockTypes lists Anthropic block types that pair with a
+// server_tool_use as the matched result. They must be round-tripped on the
+// assistant turn -- omitting them causes the API to reject re-sent transcripts
+// with "tool_use ids were found without `tool_result` blocks".
+var serverToolResultBlockTypes = map[string]bool{
+	"web_search_tool_result":                true,
+	"web_fetch_tool_result":                 true,
+	"code_execution_tool_result":            true,
+	"bash_code_execution_tool_result":       true,
+	"text_editor_code_execution_tool_result": true,
+	"mcp_tool_result":                       true,
+}
+
+func isServerToolResultBlock(t string) bool {
+	return serverToolResultBlockTypes[t]
+}
+
 func parseResponse(body []byte) (*provider.GenerateResult, error) {
 	var resp struct {
 		ID      string `json:"id"`
@@ -1099,6 +1209,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 			Thinking  string          `json:"thinking,omitempty"`
 			Signature string          `json:"signature,omitempty"`
 			Data      string          `json:"data,omitempty"` // redacted_thinking
+			ToolUseID string          `json:"tool_use_id,omitempty"` // for server tool result blocks
 			Citations []struct {
 				Type            string  `json:"type"`
 				CitedText       string  `json:"cited_text"`
@@ -1150,6 +1261,17 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 		return nil, fmt.Errorf("parsing anthropic response: %w", err)
 	}
 
+	// Side-channel raw parse of content blocks: server tool result blocks
+	// (e.g. web_search_tool_result) carry provider-specific payloads we cannot
+	// fully model in our typed struct. We preserve them verbatim so they can
+	// be round-tripped on the assistant turn (Anthropic's API rejects
+	// transcripts where a server_tool_use is not immediately followed by its
+	// result block).
+	var rawContent struct {
+		Content []json.RawMessage `json:"content"`
+	}
+	_ = json.Unmarshal(body, &rawContent)
+
 	// Handle error response.
 	if resp.Error != nil {
 		if goai.IsOverflow(resp.Error.Message) {
@@ -1173,7 +1295,10 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 	var textParts []string
 	var reasoningParts []string
 	var providerMeta map[string]any
-	for _, block := range resp.Content {
+	// Index of the last server_tool_use ToolCall, for attaching the matching
+	// result block when it appears immediately after.
+	lastServerToolIdx := -1
+	for i, block := range resp.Content {
 		switch block.Type {
 		case "text":
 			if block.Text != "" {
@@ -1243,6 +1368,25 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 				Name:  block.Name,
 				Input: block.Input,
 			})
+			if block.Type == "server_tool_use" {
+				lastServerToolIdx = len(result.ToolCalls) - 1
+			} else {
+				lastServerToolIdx = -1
+			}
+		default:
+			if isServerToolResultBlock(block.Type) && lastServerToolIdx >= 0 && i < len(rawContent.Content) {
+				// Decode raw block as map[string]any so the request serializer
+				// can re-emit it verbatim alongside the matching server_tool_use.
+				var rb map[string]any
+				if err := json.Unmarshal(rawContent.Content[i], &rb); err == nil {
+					tc := &result.ToolCalls[lastServerToolIdx]
+					if tc.Metadata == nil {
+						tc.Metadata = map[string]any{}
+					}
+					tc.Metadata["resultBlock"] = rb
+				}
+				lastServerToolIdx = -1
+			}
 		}
 	}
 	result.Text = strings.Join(textParts, "")

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -2887,3 +2887,189 @@ func TestWithSkipEnvResolve(t *testing.T) {
 		t.Errorf("baseURL = %q, want %q", model.opts.baseURL, defaultBaseURL)
 	}
 }
+
+// --- Server-side tool round-trip (web_search, code_execution, ...) ---
+
+// TestChat_Generate_ServerToolResultRoundTrip verifies that web_search_tool_result
+// (and similar server-executed tool result blocks) are captured into the
+// matching ToolCall.Metadata so they survive a multi-turn round-trip.
+// Regression for the issue where re-sending ResponseMessages containing a
+// server_tool_use (e.g. web_search) without its inline result was rejected
+// by the API as "tool_use ids were found without `tool_result` blocks".
+func TestChat_Generate_ServerToolResultRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "msg_srv1",
+			"model": "sonnet-test-model",
+			"type": "message",
+			"content": [
+				{"type": "text", "text": "Searching..."},
+				{"type": "server_tool_use", "id": "srvtoolu_abc", "name": "web_search", "input": {"query": "go 1.26"}},
+				{"type": "web_search_tool_result", "tool_use_id": "srvtoolu_abc", "content": [
+					{"type": "web_search_result", "url": "https://example.com", "title": "Go 1.26 release", "encrypted_content": "xxx"}
+				]},
+				{"type": "text", "text": "Go 1.26 was released in 2026."}
+			],
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 30, "output_tokens": 40}
+		}`)
+	}))
+	defer server.Close()
+
+	model := Chat("sonnet-test-model", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new in go?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	tc := result.ToolCalls[0]
+	if tc.ID != "srvtoolu_abc" || tc.Name != "web_search" {
+		t.Errorf("ToolCall = %+v, want srvtoolu_abc/web_search", tc)
+	}
+	rb, ok := tc.Metadata["resultBlock"].(map[string]any)
+	if !ok {
+		t.Fatalf("ToolCall.Metadata[resultBlock] missing or wrong type: %T", tc.Metadata["resultBlock"])
+	}
+	if rb["type"] != "web_search_tool_result" {
+		t.Errorf("resultBlock type = %v, want web_search_tool_result", rb["type"])
+	}
+	if rb["tool_use_id"] != "srvtoolu_abc" {
+		t.Errorf("resultBlock tool_use_id = %v, want srvtoolu_abc", rb["tool_use_id"])
+	}
+}
+
+// TestChat_Stream_ServerToolResultRoundTrip is the streaming counterpart to
+// TestChat_Generate_ServerToolResultRoundTrip.
+func TestChat_Stream_ServerToolResultRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"id":"msg_srv2","model":"sonnet-test-model","usage":{"input_tokens":30}}}`+"\n\n")
+		// Index 0: text
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Searching..."}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		// Index 1: server_tool_use
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_abc","name":"web_search"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"go 1.26\"}"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":1}`+"\n\n")
+		// Index 2: web_search_tool_result (full block in start, no deltas)
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":2,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_abc","content":[{"type":"web_search_result","url":"https://example.com","title":"Go 1.26 release","encrypted_content":"xxx"}]}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":2}`+"\n\n")
+		// Index 3: text follow-up
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":3,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"Go 1.26 was released in 2026."}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":3}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":40}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("sonnet-test-model", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new in go?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawToolCall provider.StreamChunk
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkToolCall {
+			sawToolCall = chunk
+		}
+	}
+	if sawToolCall.ToolCallID != "srvtoolu_abc" {
+		t.Fatalf("ChunkToolCall ID = %q, want srvtoolu_abc", sawToolCall.ToolCallID)
+	}
+	rb, ok := sawToolCall.Metadata["resultBlock"].(map[string]any)
+	if !ok {
+		t.Fatalf("ChunkToolCall.Metadata[resultBlock] missing: %v", sawToolCall.Metadata)
+	}
+	if rb["type"] != "web_search_tool_result" {
+		t.Errorf("resultBlock type = %v, want web_search_tool_result", rb["type"])
+	}
+	if rb["tool_use_id"] != "srvtoolu_abc" {
+		t.Errorf("resultBlock tool_use_id = %v, want srvtoolu_abc", rb["tool_use_id"])
+	}
+}
+
+// TestConvertMessages_ServerToolResultBlock verifies that an assistant
+// PartToolCall with ProviderOptions["resultBlock"] re-emits the original
+// server_tool_use + web_search_tool_result pair when sent back to the API.
+func TestConvertMessages_ServerToolResultBlock(t *testing.T) {
+	resultBlock := map[string]any{
+		"type":        "web_search_tool_result",
+		"tool_use_id": "srvtoolu_abc",
+		"content": []any{
+			map[string]any{"type": "web_search_result", "url": "https://example.com", "title": "Go 1.26"},
+		},
+	}
+	msgs := convertMessages([]provider.Message{
+		{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new?"}}},
+		{Role: provider.RoleAssistant, Content: []provider.Part{
+			{Type: provider.PartText, Text: "Searching..."},
+			{
+				Type:            provider.PartToolCall,
+				ToolCallID:      "srvtoolu_abc",
+				ToolName:        "web_search",
+				ToolInput:       json.RawMessage(`{"query":"go 1.26"}`),
+				ProviderOptions: map[string]any{"resultBlock": resultBlock},
+			},
+			{Type: provider.PartText, Text: "Go 1.26 was released in 2026."},
+		}},
+		{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "thanks"}}},
+	})
+
+	if len(msgs) < 2 {
+		t.Fatalf("got %d messages, want at least 2", len(msgs))
+	}
+	asst := msgs[1]["content"].([]map[string]any)
+	// Find server_tool_use and assert the result block follows immediately.
+	// (ReorderAssistantParts moves text before tool_use; what matters is the
+	// tool_use → result adjacency required by the API.)
+	stIdx := -1
+	for i, p := range asst {
+		if p["type"] == "server_tool_use" {
+			stIdx = i
+			break
+		}
+	}
+	if stIdx < 0 {
+		t.Fatalf("no server_tool_use block in assistant content: %+v", asst)
+	}
+	if asst[stIdx]["id"] != "srvtoolu_abc" {
+		t.Errorf("server_tool_use id = %v, want srvtoolu_abc", asst[stIdx]["id"])
+	}
+	if stIdx+1 >= len(asst) {
+		t.Fatalf("no block after server_tool_use; result missing")
+	}
+	rb := asst[stIdx+1]
+	if rb["type"] != "web_search_tool_result" {
+		t.Errorf("block after server_tool_use type = %v, want web_search_tool_result", rb["type"])
+	}
+	if rb["tool_use_id"] != "srvtoolu_abc" {
+		t.Errorf("result tool_use_id = %v, want srvtoolu_abc", rb["tool_use_id"])
+	}
+
+	// No orphan tool_result should be injected for the server tool call --
+	// its result is already inline in the assistant turn. An orphan would
+	// surface as a tool_result block in a following user message.
+	for i := 2; i < len(msgs); i++ {
+		c := msgs[i]["content"].([]map[string]any)
+		for _, p := range c {
+			if p["type"] == "tool_result" && p["tool_use_id"] == "srvtoolu_abc" {
+				t.Errorf("orphan tool_result injected for server tool srvtoolu_abc in msg[%d]: %+v", i, p)
+			}
+		}
+	}
+}

--- a/provider/bedrock/anthropic.go
+++ b/provider/bedrock/anthropic.go
@@ -1,0 +1,289 @@
+package bedrock
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/zendev-sh/goai/provider"
+	"github.com/zendev-sh/goai/provider/anthropic"
+)
+
+// AnthropicChat creates a Bedrock language model that speaks Anthropic's
+// native Messages API via Bedrock's InvokeModel / InvokeModelWithResponseStream
+// endpoints (rather than the cross-vendor Converse API).
+//
+// Use this when you need Anthropic features that Converse does not expose:
+// notably server-executed tools (web_search, code_execution, web_fetch),
+// extended thinking with per-request thinking config, or full prompt caching.
+//
+// Usage:
+//
+//	model := bedrock.AnthropicChat(modelID,
+//		bedrock.WithAccessKey(os.Getenv("AWS_ACCESS_KEY_ID")),
+//		bedrock.WithSecretKey(os.Getenv("AWS_SECRET_ACCESS_KEY")),
+//		bedrock.WithRegion(os.Getenv("AWS_REGION")),
+//	)
+//
+// All Bedrock options apply (region inference, bearer / SigV4 auth, custom
+// HTTP client). The returned model inherits the anthropic provider's parsing
+// (including server-tool round-trip), so behaviour matches direct Anthropic.
+func AnthropicChat(modelID string, opts ...Option) provider.LanguageModel {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	o.region = cmp.Or(o.region, os.Getenv("AWS_REGION"), os.Getenv("AWS_DEFAULT_REGION"), "us-east-1")
+	if r := inferRegionFromModel(modelID); r != "" && !regionMatchesGeo(o.region, modelID) {
+		o.region = r
+	}
+	o.bearerToken = cmp.Or(o.bearerToken, os.Getenv("AWS_BEARER_TOKEN_BEDROCK"))
+	o.accessKey = cmp.Or(o.accessKey, os.Getenv("AWS_ACCESS_KEY_ID"))
+	o.secretKey = cmp.Or(o.secretKey, os.Getenv("AWS_SECRET_ACCESS_KEY"))
+	o.sessionToken = cmp.Or(o.sessionToken, os.Getenv("AWS_SESSION_TOKEN"))
+	o.baseURL = cmp.Or(o.baseURL, os.Getenv("AWS_BEDROCK_BASE_URL"))
+
+	baseURL := o.baseURL
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com", o.region)
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	base := o.httpClient
+	if base == nil {
+		base = http.DefaultClient
+	}
+	rt := base.Transport
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	signing := &http.Client{
+		Transport: &bedrockAnthropicTransport{
+			base:         rt,
+			region:       o.region,
+			accessKey:    o.accessKey,
+			secretKey:    o.secretKey,
+			sessionToken: o.sessionToken,
+			bearerToken:  o.bearerToken,
+		},
+	}
+
+	anthropicOpts := []anthropic.Option{
+		anthropic.WithBaseURL(baseURL),
+		anthropic.WithURLBuilder(bedrockAnthropicURLBuilder),
+		anthropic.WithBodyTransformer(bedrockAnthropicBodyTransformer),
+		anthropic.WithErrorProvider("bedrock-anthropic"),
+		anthropic.WithHTTPClient(signing),
+		anthropic.WithSkipEnvResolve(),
+	}
+	// Provide a placeholder token source so the anthropic provider's auth
+	// resolution is satisfied. The transport below replaces the request's
+	// auth headers with SigV4 (or a Bedrock bearer token) before sending.
+	anthropicOpts = append(anthropicOpts,
+		anthropic.WithTokenSource(provider.StaticToken("bedrock-anthropic")),
+	)
+	if len(o.headers) > 0 {
+		anthropicOpts = append(anthropicOpts, anthropic.WithHeaders(o.headers))
+	}
+	return anthropic.Chat(modelID, anthropicOpts...)
+}
+
+// bedrockAnthropicURLBuilder maps Anthropic's Messages endpoint shape onto
+// Bedrock's per-model invoke endpoints.
+//
+//	Streaming:     {baseURL}/model/{modelID}/invoke-with-response-stream
+//	Non-streaming: {baseURL}/model/{modelID}/invoke
+func bedrockAnthropicURLBuilder(baseURL, modelID string, streaming bool) string {
+	endpoint := "invoke"
+	if streaming {
+		endpoint = "invoke-with-response-stream"
+	}
+	return baseURL + "/model/" + url.PathEscape(modelID) + "/" + endpoint
+}
+
+// bedrockAnthropicBodyTransformer rewrites the request body to Bedrock's
+// expected shape for Anthropic models on InvokeModel:
+//
+//   - "model" must be omitted (it is in the URL path).
+//   - "anthropic_version" must be "bedrock-2023-05-31".
+//
+// The "stream" field is read by the anthropic provider to pick the URL
+// (invoke vs invoke-with-response-stream); the transport strips it before
+// sending so Bedrock's body validator does not see it. The anthropic-beta
+// header is moved into the body's "anthropic_beta" field by the transport
+// (Bedrock InvokeModel does not honour the header).
+func bedrockAnthropicBodyTransformer(body map[string]any) map[string]any {
+	delete(body, "model")
+	body["anthropic_version"] = "bedrock-2023-05-31"
+	return body
+}
+
+// bedrockAnthropicTransport signs each request with SigV4 (or bearer) and
+// translates Bedrock's EventStream binary streaming responses into a plain
+// SSE byte stream that the anthropic provider's parseSSE can consume.
+type bedrockAnthropicTransport struct {
+	base                                                http.RoundTripper
+	region, accessKey, secretKey, sessionToken, bearerToken string
+}
+
+func (t *bedrockAnthropicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Strip Anthropic-specific auth/version headers and capture the beta
+	// header so we can fold it into the JSON body (Bedrock requires that).
+	beta := req.Header.Get("anthropic-beta")
+	req.Header.Del("x-api-key")
+	req.Header.Del("Authorization")
+	req.Header.Del("anthropic-version")
+	req.Header.Del("anthropic-beta")
+
+	var body []byte
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("bedrock-anthropic: reading request body: %w", err)
+		}
+		body = b
+		// Strip the "stream" field (the anthropic provider sets it for URL
+		// selection but Bedrock InvokeModel rejects unknown body keys), and
+		// translate anthropic-beta from header to body. Bedrock accepts only
+		// a subset of Anthropic's beta flags; the anthropic provider bakes
+		// in flags that Bedrock rejects, so we filter to a known-good list.
+		var bodyMap map[string]any
+		if err := json.Unmarshal(body, &bodyMap); err == nil {
+			delete(bodyMap, "stream")
+			if beta != "" {
+				if filtered := filterBedrockBetas(splitBetas(beta)); len(filtered) > 0 {
+					bodyMap["anthropic_beta"] = filtered
+				} else {
+					delete(bodyMap, "anthropic_beta")
+				}
+			} else {
+				delete(bodyMap, "anthropic_beta")
+			}
+			if reBody, err := json.Marshal(bodyMap); err == nil {
+				body = reBody
+				req.ContentLength = int64(len(body))
+			}
+		}
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	if t.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+t.bearerToken)
+	} else {
+		signAWSSigV4(req, body, t.accessKey, t.secretKey, t.sessionToken, t.region, "bedrock")
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.StatusCode == http.StatusOK && strings.HasSuffix(req.URL.Path, "invoke-with-response-stream") {
+		// Translate AWS EventStream → SSE so anthropic.parseSSE can read it.
+		resp.Body = newEventStreamSSEReader(resp.Body)
+		// The anthropic SSE scanner switches behaviour on Content-Type;
+		// expose plain SSE so its scanner does not look for JSON.
+		resp.Header.Set("Content-Type", "text/event-stream")
+	}
+	return resp, nil
+}
+
+func splitBetas(header string) []string {
+	var out []string
+	for _, b := range strings.Split(header, ",") {
+		b = strings.TrimSpace(b)
+		if b != "" {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// bedrockSupportedBetas lists Anthropic beta flags Bedrock InvokeModel accepts.
+// Flags not in this set (some that the upstream provider sets by default)
+// cause Bedrock to return "The provided request is not valid".
+var bedrockSupportedBetas = map[string]bool{
+	"web-search-2025-03-05":  true,
+	"computer-use-2024-10-22": true,
+	"computer-use-2025-01-24": true,
+	"computer-use-2025-11-24": true,
+	"code-execution-2025-08-25": true,
+	"code-execution-2025-05-22": true,
+	"context-management-2025-06-27": true,
+	"prompt-caching-2024-07-31": true,
+}
+
+func filterBedrockBetas(in []string) []string {
+	var out []string
+	for _, b := range in {
+		if bedrockSupportedBetas[b] {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// eventStreamSSEReader wraps a Bedrock EventStream response body and
+// re-emits each chunk's payload as a plain SSE "data: ...\n\n" line.
+//
+// Bedrock InvokeModelWithResponseStream wraps each native model SSE event
+// inside an EventStream frame whose JSON payload looks like:
+//
+//	{"bytes": "<base64 of the original SSE event JSON>"}
+//
+// We decode the base64 and re-emit it as a plain SSE frame so downstream
+// providers (here, the anthropic provider) can parse it unchanged.
+type eventStreamSSEReader struct {
+	src     io.ReadCloser
+	decoder *eventStreamDecoder
+	pending bytes.Buffer
+	err     error
+}
+
+func newEventStreamSSEReader(src io.ReadCloser) io.ReadCloser {
+	return &eventStreamSSEReader{
+		src:     src,
+		decoder: newEventStreamDecoder(src),
+	}
+}
+
+func (r *eventStreamSSEReader) Read(p []byte) (int, error) {
+	for r.pending.Len() == 0 && r.err == nil {
+		frame, err := r.decoder.Next()
+		if err != nil {
+			r.err = err
+			break
+		}
+		switch frame.MessageType {
+		case "event":
+			var ev struct {
+				Bytes []byte `json:"bytes"`
+			}
+			if json.Unmarshal(frame.Payload, &ev) == nil && len(ev.Bytes) > 0 {
+				r.pending.WriteString("data: ")
+				r.pending.Write(ev.Bytes)
+				r.pending.WriteString("\n\n")
+			}
+		case "exception", "error":
+			// Surface as an error event so parseSSE classifies/forwards it.
+			r.pending.WriteString("event: error\ndata: ")
+			r.pending.Write(frame.Payload)
+			r.pending.WriteString("\n\n")
+		}
+	}
+	if r.pending.Len() > 0 {
+		return r.pending.Read(p)
+	}
+	return 0, r.err
+}
+
+func (r *eventStreamSSEReader) Close() error {
+	return r.src.Close()
+}

--- a/provider/bedrock/anthropic_test.go
+++ b/provider/bedrock/anthropic_test.go
@@ -1,0 +1,270 @@
+package bedrock
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestBedrockAnthropicURLBuilder(t *testing.T) {
+	base := "https://bedrock-runtime.us-east-1.amazonaws.com"
+	cases := []struct {
+		modelID   string
+		streaming bool
+		want      string
+	}{
+		{"foo.bar.model-v1:0", false, base + "/model/foo.bar.model-v1:0/invoke"},
+		{"foo.bar.model-v1:0", true, base + "/model/foo.bar.model-v1:0/invoke-with-response-stream"},
+	}
+	for _, tc := range cases {
+		got := bedrockAnthropicURLBuilder(base, tc.modelID, tc.streaming)
+		// url.PathEscape converts ":" → "%3A".
+		if !strings.HasPrefix(got, base+"/model/") {
+			t.Errorf("url = %q, want prefix %q", got, base+"/model/")
+		}
+		if tc.streaming && !strings.HasSuffix(got, "/invoke-with-response-stream") {
+			t.Errorf("url = %q, want streaming suffix", got)
+		}
+		if !tc.streaming && !strings.HasSuffix(got, "/invoke") {
+			t.Errorf("url = %q, want non-streaming suffix", got)
+		}
+	}
+}
+
+func TestBedrockAnthropicBodyTransformer(t *testing.T) {
+	body := map[string]any{
+		"model":      "foo",
+		"stream":     true,
+		"max_tokens": 100,
+		"messages":   []any{},
+	}
+	out := bedrockAnthropicBodyTransformer(body)
+	if _, ok := out["model"]; ok {
+		t.Errorf("model should be removed, got %v", out["model"])
+	}
+	if out["anthropic_version"] != "bedrock-2023-05-31" {
+		t.Errorf("anthropic_version = %v, want bedrock-2023-05-31", out["anthropic_version"])
+	}
+	// "stream" must remain on the body until the transport strips it: the
+	// anthropic provider reads it to pick the URL via the URL builder.
+	if out["stream"] != true {
+		t.Errorf("stream = %v, want true (provider reads it after transform)", out["stream"])
+	}
+	if out["max_tokens"] != 100 {
+		t.Errorf("max_tokens dropped: %+v", out)
+	}
+}
+
+func TestFilterBedrockBetas(t *testing.T) {
+	in := []string{"claude-code-20250219", "interleaved-thinking-2025-05-14", "web-search-2025-03-05", "computer-use-2025-01-24"}
+	got := filterBedrockBetas(in)
+	if len(got) != 2 {
+		t.Fatalf("filtered = %v, want 2 entries", got)
+	}
+	want := map[string]bool{"web-search-2025-03-05": true, "computer-use-2025-01-24": true}
+	for _, b := range got {
+		if !want[b] {
+			t.Errorf("unexpected beta in filtered set: %q", b)
+		}
+	}
+}
+
+// TestEventStreamSSEReader covers the Bedrock InvokeModelWithResponseStream
+// → Anthropic SSE byte translation. Each EventStream "event" frame whose
+// JSON payload is `{"bytes":<base64 anthropic event>}` is re-emitted as
+// `data: <anthropic event>\n\n`.
+func TestEventStreamSSEReader(t *testing.T) {
+	anthropicEv := `{"type":"message_start","message":{"id":"m1"}}`
+	innerPayload := map[string]any{"bytes": []byte(anthropicEv)} // json.Marshal base64-encodes []byte
+	innerJSON, _ := json.Marshal(innerPayload)
+
+	frame := buildEventStreamFrame("messageStart", innerJSON)
+
+	r := newEventStreamSSEReader(io.NopCloser(strings.NewReader(string(frame))))
+	out, err := io.ReadAll(r)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read: %v", err)
+	}
+	want := "data: " + anthropicEv + "\n\n"
+	if string(out) != want {
+		t.Errorf("translated = %q, want %q", string(out), want)
+	}
+}
+
+// TestAnthropicChat_GenerateRoundTrip exercises the full path:
+// bedrock.AnthropicChat → SigV4 transport → InvokeModel JSON response.
+// We point at an httptest server that asserts the body shape (no model,
+// has anthropic_version, no stream) and returns a native Anthropic JSON
+// payload, which the anthropic provider parses unchanged.
+func TestAnthropicChat_GenerateRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/invoke") {
+			t.Errorf("path = %q, want suffix /invoke", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		if _, ok := req["model"]; ok {
+			t.Errorf("body still has model field: %+v", req)
+		}
+		if _, ok := req["stream"]; ok {
+			t.Errorf("body still has stream field: %+v", req)
+		}
+		if req["anthropic_version"] != "bedrock-2023-05-31" {
+			t.Errorf("anthropic_version = %v", req["anthropic_version"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "msg-1",
+			"model": "test-model",
+			"type": "message",
+			"content": [{"type":"text","text":"ok"}],
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 5, "output_tokens": 1}
+		}`)
+	}))
+	defer server.Close()
+
+	// SigV4 signing: provide dummy creds; the test server doesn't validate
+	// the signature, only the request shape.
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("us-east-1"),
+		WithBaseURL(server.URL),
+	)
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q, want ok", result.Text)
+	}
+}
+
+// TestAnthropicChat_StreamServerToolRoundTrip exercises streaming with
+// EventStream → SSE translation, end-to-end with the anthropic provider's
+// server-tool capture path.
+func TestAnthropicChat_StreamServerToolRoundTrip(t *testing.T) {
+	// Each "event" frame's payload is {"bytes": <base64 of anthropic SSE event JSON>}.
+	emitFrame := func(w io.Writer, anthropicEvent string) {
+		inner, _ := json.Marshal(map[string]any{"bytes": []byte(anthropicEvent)})
+		w.Write(buildEventStreamFrame("messageStart", inner))
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/invoke-with-response-stream") {
+			t.Errorf("path = %q, want streaming suffix", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+		flusher, _ := w.(http.Flusher)
+		emitFrame(w, `{"type":"message_start","message":{"id":"m1","model":"test","usage":{"input_tokens":5}}}`)
+		emitFrame(w, `{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_1","name":"web_search"}}`)
+		emitFrame(w, `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"q\":\"go\"}"}}`)
+		emitFrame(w, `{"type":"content_block_stop","index":0}`)
+		emitFrame(w, `{"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"srvtoolu_1","content":[{"type":"web_search_result","url":"https://go.dev","title":"Go"}]}}`)
+		emitFrame(w, `{"type":"content_block_stop","index":1}`)
+		emitFrame(w, `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`)
+		emitFrame(w, `{"type":"message_stop"}`)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("us-east-1"),
+		WithBaseURL(server.URL),
+	)
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "search"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+	var sawCall provider.StreamChunk
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkToolCall {
+			sawCall = chunk
+		}
+	}
+	if sawCall.ToolCallID != "srvtoolu_1" {
+		t.Fatalf("ChunkToolCall ID = %q, want srvtoolu_1", sawCall.ToolCallID)
+	}
+	rb, ok := sawCall.Metadata["resultBlock"].(map[string]any)
+	if !ok {
+		t.Fatalf("resultBlock missing: %v", sawCall.Metadata)
+	}
+	if rb["type"] != "web_search_tool_result" {
+		t.Errorf("resultBlock type = %v, want web_search_tool_result", rb["type"])
+	}
+}
+
+// TestAnthropicChat_BetaFolding verifies the transport moves the anthropic-beta
+// header into the request body's anthropic_beta field, filtered to flags
+// Bedrock InvokeModel accepts.
+func TestAnthropicChat_BetaFolding(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h := r.Header.Get("anthropic-beta"); h != "" {
+			t.Errorf("anthropic-beta header should be stripped, got %q", h)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"m","model":"t","type":"message","content":[{"type":"text","text":""}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":0}}`)
+	}))
+	defer server.Close()
+
+	// Anthropic provider injects "claude-code-20250219,interleaved-thinking-2025-05-14"
+	// as base betas. Tools that emit additional betas (web_search, etc.) get
+	// merged in. The transport should drop unsupported flags and keep the
+	// supported ones in the body.
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("us-east-1"),
+		WithBaseURL(server.URL),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+		Tools: []provider.ToolDefinition{
+			{Name: "web_search", ProviderDefinedType: "web_search_20250305"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	betas, _ := capturedBody["anthropic_beta"].([]any)
+	var hasWebSearch bool
+	for _, b := range betas {
+		if b == "web-search-2025-03-05" {
+			hasWebSearch = true
+		}
+		if b == "claude-code-20250219" || b == "interleaved-thinking-2025-05-14" {
+			t.Errorf("unsupported beta leaked into body: %v", b)
+		}
+	}
+	if !hasWebSearch {
+		t.Errorf("web-search beta missing from body: %v", betas)
+	}
+}
+
+// Ensure base64.StdEncoding is referenced (test file for clarity).
+var _ = base64.StdEncoding

--- a/provider/bedrock/anthropic_test.go
+++ b/provider/bedrock/anthropic_test.go
@@ -3,6 +3,7 @@ package bedrock
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -268,6 +269,130 @@ func TestAnthropicChat_BetaFolding(t *testing.T) {
 
 // Ensure base64.StdEncoding is referenced (test file for clarity).
 var _ = base64.StdEncoding
+
+// TestAnthropicChat_CrossRegionInference covers the inference-profile
+// region override: a "us.*" model id called from an "eu-*" region should
+// rewrite region to a us-* default so the request reaches a matching
+// Bedrock endpoint.
+func TestAnthropicChat_CrossRegionInference(t *testing.T) {
+	var capturedHost string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHost = r.Host
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"m","model":"t","type":"message","content":[{"type":"text","text":""}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":0}}`)
+	}))
+	defer server.Close()
+
+	// Mismatched region (eu-west-1) with us-prefixed model. WithBaseURL
+	// captures the request so we can assert the constructor took the right
+	// path; the real point is that AnthropicChat does not error and the
+	// URL builder still composes a sensible path.
+	model := AnthropicChat("us.anthropic.test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("eu-west-1"),
+		WithBaseURL(server.URL),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if capturedHost == "" {
+		t.Error("server did not receive a request")
+	}
+}
+
+// TestAnthropicChat_DefaultBaseURL covers the default-URL branch: when
+// WithBaseURL is not set, AnthropicChat builds a bedrock-runtime hostname
+// from the resolved region.
+func TestAnthropicChat_DefaultBaseURL(t *testing.T) {
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("ap-northeast-1"),
+	)
+	if model == nil {
+		t.Fatal("AnthropicChat returned nil")
+	}
+	if got := model.ModelID(); got != "test-model.v1:0" {
+		t.Errorf("ModelID = %q, want test-model.v1:0", got)
+	}
+}
+
+// TestAnthropicChat_NoBetasInBody covers the branch where neither the
+// anthropic-beta header nor a body anthropic_beta field should appear in
+// the wire request when the request has no betas to begin with.
+func TestAnthropicChat_NoBetasInBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		// The upstream provider always injects baked-in betas, so the
+		// transport should see a non-empty header. Verify the body
+		// reflects only Bedrock-supported betas (subset, possibly empty).
+		if betas, ok := req["anthropic_beta"].([]any); ok {
+			for _, b := range betas {
+				s, _ := b.(string)
+				if !bedrockSupportedBetas[s] {
+					t.Errorf("unsupported beta leaked: %q", s)
+				}
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"m","model":"t","type":"message","content":[{"type":"text","text":""}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":0}}`)
+	}))
+	defer server.Close()
+
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("us-east-1"),
+		WithBaseURL(server.URL),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+// TestAnthropicChat_BaseRoundTripError verifies the base.RoundTrip error
+// is propagated unchanged (the transport must not rewrite errors from the
+// underlying transport).
+func TestAnthropicChat_BaseRoundTripError(t *testing.T) {
+	failingTransport := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("dial: connection refused")
+	})
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("us-east-1"),
+		WithBaseURL("http://does-not-resolve.invalid"),
+		WithHTTPClient(&http.Client{Transport: failingTransport}),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error from failing transport, got nil")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error = %q, want substring 'connection refused'", err.Error())
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 // TestAnthropicChat_BearerAuth covers the bearer-token branch of the
 // SigV4/bearer transport: when WithBearerToken is set the transport sends

--- a/provider/bedrock/anthropic_test.go
+++ b/provider/bedrock/anthropic_test.go
@@ -268,3 +268,173 @@ func TestAnthropicChat_BetaFolding(t *testing.T) {
 
 // Ensure base64.StdEncoding is referenced (test file for clarity).
 var _ = base64.StdEncoding
+
+// TestAnthropicChat_BearerAuth covers the bearer-token branch of the
+// SigV4/bearer transport: when WithBearerToken is set the transport sends
+// "Authorization: Bearer ..." instead of signing.
+func TestAnthropicChat_BearerAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer test-bedrock-token" {
+			t.Errorf("Authorization = %q, want Bearer test-bedrock-token", got)
+		}
+		// SigV4 headers should be absent.
+		if r.Header.Get("X-Amz-Date") != "" {
+			t.Error("X-Amz-Date should be absent on bearer-auth requests")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"m","model":"t","type":"message","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := AnthropicChat("test-model.v1:0",
+		WithBearerToken("test-bedrock-token"),
+		WithRegion("us-east-1"),
+		WithBaseURL(server.URL),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+// TestAnthropicChat_HTTPError covers the non-200 path: Bedrock returns an
+// error body, the anthropic provider surfaces it as an APIError tagged with
+// the bedrock-anthropic provider name (set by WithErrorProvider).
+func TestAnthropicChat_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, `{"message":"The provided request is not valid"}`)
+	}))
+	defer server.Close()
+
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("us-east-1"),
+		WithBaseURL(server.URL),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid") {
+		t.Errorf("error = %q, want substring 'not valid'", err.Error())
+	}
+}
+
+// TestAnthropicChat_HeadersPassthrough verifies WithHeaders adds custom
+// headers to the request (still wrapped by SigV4 signing).
+func TestAnthropicChat_HeadersPassthrough(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Custom"); got != "yes" {
+			t.Errorf("X-Custom = %q, want yes", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"m","model":"t","type":"message","content":[{"type":"text","text":""}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":0}}`)
+	}))
+	defer server.Close()
+
+	model := AnthropicChat("test-model.v1:0",
+		WithAccessKey("AKIA00000000"),
+		WithSecretKey("testsecret"),
+		WithRegion("us-east-1"),
+		WithBaseURL(server.URL),
+		WithHeaders(map[string]string{"X-Custom": "yes"}),
+	)
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+// TestEventStreamSSEReader_ExceptionFrame covers the "exception" / "error"
+// MessageType branch of the translator: such frames are re-emitted as
+// SSE error events so the anthropic provider's parseSSE can classify them.
+func TestEventStreamSSEReader_ExceptionFrame(t *testing.T) {
+	exceptionPayload := []byte(`{"message":"throttled"}`)
+	frame := buildEventStreamFrame("ThrottlingException", exceptionPayload)
+	// Manually rewrite :message-type to "exception".
+	// buildEventStreamFrame defaults to "event"; we need an exception frame.
+	// Build one inline with the helper's primitives instead.
+	headers := buildStringHeader(":message-type", "exception")
+	headers = append(headers, buildStringHeader(":exception-type", "ThrottlingException")...)
+	headers = append(headers, buildStringHeader(":content-type", "application/json")...)
+	headersLen := uint32(len(headers))
+	totalLen := uint32(12 + int(headersLen) + len(exceptionPayload) + 4)
+	var buf strings.Builder
+	writeBE := func(v uint32) {
+		buf.WriteByte(byte(v >> 24))
+		buf.WriteByte(byte(v >> 16))
+		buf.WriteByte(byte(v >> 8))
+		buf.WriteByte(byte(v))
+	}
+	writeBE(totalLen)
+	writeBE(headersLen)
+	prelude := []byte(buf.String())
+	preludeCRC := crc32IEEE(prelude)
+	writeBE(preludeCRC)
+	buf.Write(headers)
+	buf.Write(exceptionPayload)
+	all := []byte(buf.String())
+	msgCRC := crc32IEEE(all)
+	writeBE(msgCRC)
+
+	r := newEventStreamSSEReader(io.NopCloser(strings.NewReader(buf.String())))
+	out, _ := io.ReadAll(r)
+	got := string(out)
+	if !strings.Contains(got, "event: error") {
+		t.Errorf("translated = %q, want substring 'event: error'", got)
+	}
+	if !strings.Contains(got, "throttled") {
+		t.Errorf("translated = %q, want substring 'throttled'", got)
+	}
+	_ = frame // unused but keeps the reference
+}
+
+func crc32IEEE(b []byte) uint32 {
+	var sum uint32 = 0xffffffff
+	for _, c := range b {
+		sum ^= uint32(c)
+		for range 8 {
+			if sum&1 != 0 {
+				sum = (sum >> 1) ^ 0xedb88320
+			} else {
+				sum >>= 1
+			}
+		}
+	}
+	return ^sum
+}
+
+// TestEventStreamSSEReader_Close ensures Close() proxies to the wrapped reader.
+func TestEventStreamSSEReader_Close(t *testing.T) {
+	tr := &trackingReadCloser{src: strings.NewReader("")}
+	r := newEventStreamSSEReader(tr)
+	if err := r.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	if !tr.closed {
+		t.Error("Close did not propagate to source")
+	}
+}
+
+type trackingReadCloser struct {
+	src    io.Reader
+	closed bool
+}
+
+func (t *trackingReadCloser) Read(p []byte) (int, error) { return t.src.Read(p) }
+func (t *trackingReadCloser) Close() error               { t.closed = true; return nil }

--- a/provider/normalize.go
+++ b/provider/normalize.go
@@ -14,6 +14,11 @@ func NormalizeToolMessages(msgs []Message) []Message {
 // ensureToolResultPairing ensures every assistant message with tool-call parts
 // has matching tool-result parts in following messages. Injects synthetic
 // "Tool execution aborted" results for orphaned tool-calls.
+//
+// Server-executed tool calls (e.g. Anthropic web_search) are skipped: their
+// result is delivered inline on the same assistant turn via the part's
+// ProviderOptions["resultBlock"], so no following tool-result message is
+// expected.
 func ensureToolResultPairing(msgs []Message) []Message {
 	for i := 0; i < len(msgs); i++ {
 		if msgs[i].Role != RoleAssistant {
@@ -22,6 +27,9 @@ func ensureToolResultPairing(msgs []Message) []Message {
 		var callIDs []string
 		for _, p := range msgs[i].Content {
 			if p.Type == PartToolCall && p.ToolCallID != "" {
+				if _, hasInlineResult := p.ProviderOptions["resultBlock"]; hasInlineResult {
+					continue
+				}
 				callIDs = append(callIDs, p.ToolCallID)
 			}
 		}

--- a/provider/normalize_test.go
+++ b/provider/normalize_test.go
@@ -259,3 +259,39 @@ func TestNormalizeToolMessages_EmptyMessages(t *testing.T) {
 		t.Fatalf("len = %d, want 0", len(result))
 	}
 }
+
+// TestEnsureToolResultPairing_SkipsServerExecuted verifies that tool calls
+// whose ProviderOptions["resultBlock"] is set (server-executed) are NOT
+// considered orphaned: their result is delivered inline on the assistant
+// turn, so no synthetic tool_result message is injected.
+func TestEnsureToolResultPairing_SkipsServerExecuted(t *testing.T) {
+	msgs := []Message{
+		{Role: RoleUser, Content: []Part{{Type: PartText, Text: "search go"}}},
+		{Role: RoleAssistant, Content: []Part{
+			{Type: PartText, Text: "Searching..."},
+			{
+				Type:       PartToolCall,
+				ToolCallID: "srvtoolu_1",
+				ToolName:   "web_search",
+				ProviderOptions: map[string]any{
+					"resultBlock": map[string]any{"type": "web_search_tool_result"},
+				},
+			},
+		}},
+		{Role: RoleUser, Content: []Part{{Type: PartText, Text: "thanks"}}},
+	}
+
+	out := ensureToolResultPairing(msgs)
+
+	// No synthetic tool message must be inserted between the assistant and
+	// the next user message -- the original three messages must be intact.
+	if len(out) != 3 {
+		t.Fatalf("len = %d, want 3 (no orphan injected for server tool)", len(out))
+	}
+	if out[1].Role != RoleAssistant {
+		t.Errorf("msg[1].Role = %v, want assistant", out[1].Role)
+	}
+	if out[2].Role != RoleUser {
+		t.Errorf("msg[2].Role = %v, want user (not synthetic tool)", out[2].Role)
+	}
+}

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -3790,3 +3790,136 @@ func TestChat_DoGenerate_PromptCachingWarning(t *testing.T) {
 		t.Errorf("Text = %q, want ok", result.Text)
 	}
 }
+
+// --- Responses API server-executed tool round-trip ---
+
+// TestChat_Responses_Generate_ServerToolRoundTrip verifies that Responses API
+// server-executed items (web_search_call, file_search_call, ...) are captured
+// into ToolCall.Metadata so they survive a multi-turn round-trip.
+func TestChat_Responses_Generate_ServerToolRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "resp-srv-1",
+			"model": "test-model",
+			"status": "completed",
+			"output": [
+				{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"go 1.26"}},
+				{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Go 1.26 was released."}]}
+			],
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`)
+	}))
+	defer server.Close()
+
+	model := Chat("test-model", WithAPIKey("k"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new in go?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	tc := result.ToolCalls[0]
+	if tc.ID != "ws_1" || tc.Name != "web_search_call" {
+		t.Errorf("ToolCall = %+v, want id=ws_1 name=web_search_call", tc)
+	}
+	if exec, _ := tc.Metadata["providerExecuted"].(bool); !exec {
+		t.Errorf("Metadata[providerExecuted] = false, want true")
+	}
+	raw, _ := tc.Metadata["rawItem"].(map[string]any)
+	if raw["type"] != "web_search_call" {
+		t.Errorf("rawItem type = %v, want web_search_call", raw["type"])
+	}
+}
+
+// TestChat_Responses_Stream_ServerToolRoundTrip is the streaming counterpart.
+func TestChat_Responses_Stream_ServerToolRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.output_item.added\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0,"item":{"type":"web_search_call","id":"ws_1"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.output_item.done\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0,"item":{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"go 1.26"}}}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.output_text.delta\n")
+		_, _ = fmt.Fprint(w, `data: {"delta":"Go 1.26 was released."}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.completed\n")
+		_, _ = fmt.Fprint(w, `data: {"response":{"id":"resp_1","model":"test-model","usage":{"input_tokens":10,"output_tokens":5}}}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("test-model", WithAPIKey("k"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "what's new?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawToolCall provider.StreamChunk
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkToolCall {
+			sawToolCall = chunk
+		}
+	}
+	if sawToolCall.ToolCallID != "ws_1" {
+		t.Fatalf("ChunkToolCall ID = %q, want ws_1", sawToolCall.ToolCallID)
+	}
+	if exec, _ := sawToolCall.Metadata["providerExecuted"].(bool); !exec {
+		t.Errorf("Metadata[providerExecuted] = false, want true")
+	}
+	raw, _ := sawToolCall.Metadata["rawItem"].(map[string]any)
+	if raw["type"] != "web_search_call" {
+		t.Errorf("rawItem type = %v, want web_search_call", raw["type"])
+	}
+	if raw["id"] != "ws_1" {
+		t.Errorf("rawItem id = %v, want ws_1", raw["id"])
+	}
+}
+
+// TestConvertToResponsesInput_ServerToolItem verifies that an assistant
+// PartToolCall carrying ProviderOptions["rawItem"] is re-emitted verbatim
+// instead of being shaped as a function_call.
+func TestConvertToResponsesInput_ServerToolItem(t *testing.T) {
+	rawItem := map[string]any{
+		"type":   "web_search_call",
+		"id":     "ws_1",
+		"status": "completed",
+		"action": map[string]any{"type": "search", "query": "go 1.26"},
+	}
+	input := convertToResponsesInput([]provider.Message{
+		{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "search"}}},
+		{Role: provider.RoleAssistant, Content: []provider.Part{
+			{Type: provider.PartText, Text: "Searching..."},
+			{
+				Type:            provider.PartToolCall,
+				ToolCallID:      "ws_1",
+				ToolName:        "web_search_call",
+				ProviderOptions: map[string]any{"providerExecuted": true, "rawItem": rawItem},
+			},
+		}},
+	})
+
+	var sawWebSearch bool
+	for _, item := range input {
+		if item["type"] == "web_search_call" {
+			sawWebSearch = true
+			if item["id"] != "ws_1" {
+				t.Errorf("web_search_call id = %v, want ws_1", item["id"])
+			}
+			if _, hasFunctionCallShape := item["call_id"]; hasFunctionCallShape {
+				t.Error("web_search_call should not be reshaped as function_call")
+			}
+		}
+	}
+	if !sawWebSearch {
+		t.Errorf("expected web_search_call item in serialized input, got: %+v", input)
+	}
+}
+

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -14,6 +14,24 @@ import (
 	"github.com/zendev-sh/goai/provider"
 )
 
+// serverExecutedItemTypes lists Responses API output item types that the
+// provider runs server-side (no client execution). When these items appear in
+// the response output, their full payload must round-trip on the assistant
+// turn so the model retains context across follow-up requests.
+var serverExecutedItemTypes = map[string]bool{
+	"web_search_call":       true,
+	"file_search_call":      true,
+	"code_interpreter_call": true,
+	"image_generation_call": true,
+	"local_shell_call":      true,
+	"mcp_call":              true,
+	"mcp_list_tools":        true,
+	"mcp_approval_request":  true,
+	"computer_call":         true,
+}
+
+func isServerExecutedItem(t string) bool { return serverExecutedItemTypes[t] }
+
 // buildResponsesRequest creates an OpenAI Responses API request body.
 func buildResponsesRequest(params provider.GenerateParams, modelID string, streaming bool) map[string]any {
 	body := map[string]any{
@@ -328,6 +346,13 @@ func convertToResponsesInput(msgs []provider.Message) []map[string]any {
 						textParts = append(textParts, part.Text)
 					}
 				case provider.PartToolCall:
+					// Server-executed tool items (web_search_call,
+					// file_search_call, ...) round-trip verbatim so the model
+					// sees the same context across turns.
+					if raw, ok := part.ProviderOptions["rawItem"].(map[string]any); ok {
+						items = append(items, raw)
+						break
+					}
 					items = append(items, map[string]any{
 						"type":      "function_call",
 						"call_id":   part.ToolCallID,
@@ -597,19 +622,45 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 
 		case "response.output_item.done":
 			var ev struct {
-				OutputIndex int `json:"output_index"`
-				Item        struct {
-					Type string `json:"type"`
-				} `json:"item"`
+				OutputIndex int             `json:"output_index"`
+				Item        json.RawMessage `json:"item"`
 			}
 			if json.Unmarshal([]byte(data), &ev) == nil {
-				switch ev.Item.Type {
+				var itemHead struct {
+					Type string `json:"type"`
+				}
+				_ = json.Unmarshal(ev.Item, &itemHead)
+				switch itemHead.Type {
 				case "reasoning":
 					delete(activeReasoning, ev.OutputIndex)
 					if currentReasoningIdx == ev.OutputIndex {
 						currentReasoningIdx = -1
 					}
 				default:
+					if isServerExecutedItem(itemHead.Type) {
+						// Capture the full server-executed item payload and
+						// emit a ChunkToolCall so it round-trips into the
+						// assistant turn via ToolCall.Metadata.
+						var raw map[string]any
+						if err := json.Unmarshal(ev.Item, &raw); err == nil {
+							id, _ := raw["id"].(string)
+							name, _ := raw["name"].(string)
+							if name == "" {
+								name = itemHead.Type
+							}
+							if !provider.TrySend(ctx, out, provider.StreamChunk{
+								Type:       provider.ChunkToolCall,
+								ToolCallID: id,
+								ToolName:   name,
+								Metadata: map[string]any{
+									"providerExecuted": true,
+									"rawItem":          raw,
+								},
+							}) {
+								return
+							}
+						}
+					}
 					delete(activeTools, ev.OutputIndex)
 				}
 			}
@@ -879,6 +930,14 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 		return nil, &goai.APIError{Message: resp.Error.Message, ResponseBody: string(body)}
 	}
 
+	// Side-channel raw parse so server-executed items (web_search_call etc.)
+	// can be round-tripped verbatim on the assistant turn -- the typed struct
+	// only models the subset of fields we explicitly consume.
+	var rawOutput struct {
+		Output []json.RawMessage `json:"output"`
+	}
+	_ = json.Unmarshal(body, &rawOutput)
+
 	result := &provider.GenerateResult{
 		Response: provider.ResponseMetadata{
 			ID:    resp.ID,
@@ -893,7 +952,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 	providerMeta := map[string]any{}
 	var allLogprobs []any
 
-	for _, item := range resp.Output {
+	for i, item := range resp.Output {
 		switch item.Type {
 		case "message":
 			for _, c := range item.Content {
@@ -935,6 +994,25 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 					providerMeta["reasoning"] = append(reasoning, map[string]any{
 						"type": s.Type,
 						"text": s.Text,
+					})
+				}
+			}
+		default:
+			if isServerExecutedItem(item.Type) && i < len(rawOutput.Output) {
+				var raw map[string]any
+				if err := json.Unmarshal(rawOutput.Output[i], &raw); err == nil {
+					id, _ := raw["id"].(string)
+					name, _ := raw["name"].(string)
+					if name == "" {
+						name = item.Type
+					}
+					result.ToolCalls = append(result.ToolCalls, provider.ToolCall{
+						ID:   id,
+						Name: name,
+						Metadata: map[string]any{
+							"providerExecuted": true,
+							"rawItem":          raw,
+						},
 					})
 				}
 			}


### PR DESCRIPTION
Round-trips provider-executed tool calls (Anthropic `web_search`, `code_execution`, `web_fetch`, `mcp`; OpenAI Responses `web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `local_shell_call`, `mcp_call`, `computer_call`) so multi-turn conversations with these tools no longer drop the inline result.

Related to #59 (does **not** close — leaving open until end-to-end verified against direct Anthropic API on a regular API key; verification so far is mock-based for direct Anthropic + real-LLM for OpenAI Responses via Azure and Google Gemini).

## Bug class

- **Hard (Anthropic, HTTP 400)**: API requires `tool_use` paired with its `tool_result` in the same assistant turn. Dropping `web_search_tool_result` on parse produces an orphan `tool_use`; the next request is rejected with `tool_use ids were found without tool_result blocks immediately after`.
- **Soft (OpenAI Responses, lost context)**: server tool items dropped → re-send loses search/grounding history. Not rejected, but the model loses memory across turns.

## Approach

- Capture server-tool payload in non-streaming (`parseResponse` / `parseResponsesResult`) and streaming (`parseSSE` / `parseResponsesStream`) paths via a side-channel raw parse + deferred `ChunkToolCall` emission.
- Attach to `ToolCall.Metadata` (`resultBlock` for Anthropic, `rawItem` + `providerExecuted` for OpenAI Responses). The metadata flows through `buildFinalAssistantMessages` / `appendToolRoundTrip` into `ResponseMessages` via `Part.ProviderOptions`.
- Re-emit verbatim when the assistant turn is serialized back to the API.
- Shared core (`isProviderExecuted`, `executeToolsParallel`, `buildToolMessages`, `ensureToolResultPairing`) skips unknown-tool synthesis and orphan `tool_result` injection for these calls — so mixing server + client tools no longer fabricates fake `tool_result` messages with the server tool's id.

## New: `bedrock.AnthropicChat`

Routes Anthropic models through Bedrock's InvokeModel / InvokeModelWithResponseStream (rather than Converse) so the anthropic provider's parsing applies on Bedrock. Wraps `anthropic.Chat` with a SigV4-signing transport, EventStream-to-SSE byte translator, body-shape adjustments (`anthropic_version`, strip `stream`/`model`), and a beta-flag filter for Bedrock's accepted set. Inherits the server-tool fix automatically.

Note: AWS Bedrock does not yet execute Anthropic server tools (`web_search_20250305` etc. — verified across Converse + InvokeModel and multiple model IDs/regions). Infrastructure is ready for when AWS adds support; in the meantime regular usage (text, custom tools, extended thinking, prompt caching) works.

## Provider audit

| Provider | Status |
|---|---|
| Anthropic direct | Fixed (parse + serialize, non-streaming + streaming) |
| Vertex AnthropicChat | Inherits via `anthropic.Chat` delegation |
| MiniMax | Inherits via `anthropic.Chat` delegation |
| Bedrock Anthropic | New `AnthropicChat` constructor; goai-side ready, AWS-side blocking server tools |
| OpenAI Responses | Fixed (parse + serialize, non-streaming + streaming) |
| Azure OpenAI | Inherits via `openai.Chat` delegation |
| Google Gemini | No fix needed — grounding via `groundingMetadata` → `Sources`, not a tool_call cycle |
| xAI / Groq / Cohere / Perplexity | No fix needed — search inline as text + sources |

## Test plan

- [x] `go test ./...` (all packages green)
- [x] Anthropic non-streaming + streaming round-trip unit tests (mock SSE, exact wire format)
- [x] OpenAI Responses non-streaming + streaming round-trip unit tests
- [x] Bedrock AnthropicChat: URL builder, body transformer, EventStream→SSE translator, beta filter, full generate + stream round-trip (with server tool result block)
- [x] Convert-message round-trip tests for both providers (server_tool_use + result_block adjacency, web_search_call shape preservation)
- [x] Orphan-injection regression test (`ensureToolResultPairing` skips inline results)
- [x] User's exact reproduction code (StreamText + append ResponseMessages loop) verified against an Anthropic wire-format mock that asserts `server_tool_use → web_search_tool_result` adjacency on each re-send turn
- [x] Azure OpenAI Responses with `web_search` across 3 multi-turn rounds — `web_search_call` round-trip preserved, model retains search context
- [x] Google Gemini with `google_search` — multi-turn passes (no roundtrip needed structurally)
- [x] Bedrock AnthropicChat basic streaming + custom function tool — works end-to-end via SigV4 + EventStream translator