### PR TITLE
docs: add zenflow link to nav Links menu

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
         items: [
           { text: 'GitHub', link: 'https://github.com/zendev-sh/goai' },
           { text: 'GoDoc', link: 'https://pkg.go.dev/github.com/zendev-sh/goai' },
+          { text: 'zenflow', link: 'https://zenflow.sh' },
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Add `zenflow → https://zenflow.sh` to the Links dropdown in the docs nav (shared by homepage and docsite).
- Mirrors the `goai SDK → https://goai.sh` entry that zenflow's docsite already exposes.

## Test plan
- [ ] `cd docs && npm run dev` and confirm the Links dropdown shows GitHub, GoDoc, zenflow.