### PR TITLE
chore: release v0.7.6

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,11 +99,17 @@
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Azure v1 GA path fix**      | Drop the `api-version` query parameter on the v1 GA path (`/openai/v1{path}`) per Azure spec. Spec-strict resources rejected it with `"API version not supported"` (observed on gpt-5.5). Legacy deployment-based path still uses `api-version`; opt in via `WithDeploymentBasedURLs(true)` when an explicit dated version is required. |
 
-## v0.7.5 - Current release
+## v0.7.5
 
 | Feature                                | Description                                                                                                                                                                                                                                                                                                                            |
 | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Streaming tool-call delta forward**  | `provider/openai` (Responses API) and `provider/cohere` now emit `ChunkToolCallDelta` for each upstream argument fragment instead of buffering until the accumulated args parse as JSON. Enables progressive rendering of large tool inputs (e.g. `write.content`, `edit.edits[].newText`). Final `ChunkToolCall` semantics unchanged. (#56) |
+
+## v0.7.6 - Current release
+
+| Feature                                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Server-executed tool calls round-trip** | Anthropic (`web_search`, `code_execution`, `web_fetch`, `mcp`) and OpenAI Responses (`web_search_call`, `file_search_call`, `code_interpreter_call`, `image_generation_call`, `local_shell_call`, `mcp_call`, `computer_call`) provider-executed tool results are now captured into `ToolCall.Metadata` and re-emitted verbatim when the assistant turn is serialized back, so multi-turn conversations no longer drop server search context or trip Anthropic's orphan-`tool_use` 400. New `bedrock.AnthropicChat` constructor routes Anthropic models through Bedrock InvokeModel / InvokeModelWithResponseStream so the anthropic provider's parsing applies. (#61) |
 
 ### Planned
 

--- a/docs/public/versions.json
+++ b/docs/public/versions.json
@@ -1,10 +1,15 @@
 {
-  "latest": "v0.7.5",
+  "latest": "v0.7.6",
   "versions": [
+    {
+      "tag": "v0.7.6",
+      "date": "2026-05-08",
+      "label": "v0.7.6 (latest)"
+    },
     {
       "tag": "v0.7.5",
       "date": "2026-05-07",
-      "label": "v0.7.5 (latest)"
+      "label": "v0.7.5"
     },
     {
       "tag": "v0.7.4",


### PR DESCRIPTION
## Summary
- Roadmap entry for v0.7.6 (marks v0.7.5 as shipped, adds v0.7.6 "Current release" with the server-executed tool-call round-trip + new `bedrock.AnthropicChat` constructor).
- Bumps `docs/public/versions.json` to `v0.7.6` (2026-05-08).

Pushing the `v0.7.6` tag after merge will trigger the sub-module tagging workflow (#55).

## Test plan
- [ ] CI green on `release/v0.7.6`
- [ ] Docs site renders the new version in the picker after deploy