### PR TITLE
ci(zenflow-review): add comment-triggered AI PR review workflow

### DIFF
--- a/.github/workflows/zenflow-review.yml
+++ b/.github/workflows/zenflow-review.yml
@@ -1,0 +1,103 @@
+name: zenflow PR review
+
+# Comment-triggered AI code review using zenflow + FPT Smart Cloud
+# (Qwen3.6-27B). Repo maintainers post `/zenflow-review` on a PR to
+# trigger a two-reviewer pass (Go idiomatics + security) that
+# synthesises into a single PR comment. See .zenflow/pr-review.yaml for
+# the workflow spec.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    # Run only on PR comments (issue_comment fires for both issues and
+    # PRs - the `pull_request` field on the issue payload disambiguates),
+    # gated to writers (OWNER / MEMBER / COLLABORATOR) so randos cannot
+    # burn org credits.
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/zenflow-review') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      PR_NUMBER: ${{ github.event.issue.number }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Acknowledge trigger
+        # Eyes reaction tells the requester the job started without
+        # waiting on the model. Failure here is non-fatal so a missing
+        # token scope doesn't tank the whole run.
+        continue-on-error: true
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes
+
+      - name: Checkout PR head
+        # issue_comment fires in the base-repo context; explicit ref
+        # checkout pulls the PR's head commit so the workflow YAML at
+        # .zenflow/pr-review.yaml matches what the PR author proposes.
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Install zenflow
+        run: go install github.com/zendev-sh/zenflow/cmd/zenflow@v0.1.5
+
+      - name: Fetch PR diff
+        run: |
+          mkdir -p .zenflow
+          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > .zenflow/diff.patch
+          wc -l .zenflow/diff.patch
+
+      - name: Run zenflow review
+        env:
+          ZENFLOW_MODEL: fptcloud/Qwen3.6-27B
+          FPT_API_KEY: ${{ secrets.FPT_API_KEY }}
+          FPT_REGION: jp
+        run: |
+          zenflow flow .zenflow/pr-review.yaml \
+            --json \
+            --timeout 20m \
+            > .zenflow/events.ndjson
+
+      - name: Post review comment
+        run: |
+          if [ ! -s .zenflow/review.md ]; then
+            echo "lead agent did not produce .zenflow/review.md" >&2
+            exit 1
+          fi
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file .zenflow/review.md
+
+      - name: Upload event stream
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zenflow-events-pr-${{ env.PR_NUMBER }}
+          path: |
+            .zenflow/events.ndjson
+            .zenflow/review.md
+            .zenflow/diff.patch
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Report failure
+        if: failure()
+        continue-on-error: true
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "zenflow review failed - see [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ credentials*
 bedrock.test
 .zencode/
 testdata/
+
+# zenflow PR review run artifacts (the workflow YAML at
+# .zenflow/pr-review.yaml is tracked; everything else is per-run state).
+.zenflow/diff.patch
+.zenflow/events.ndjson
+.zenflow/review.md

--- a/.zenflow/pr-review.yaml
+++ b/.zenflow/pr-review.yaml
@@ -1,0 +1,134 @@
+# PR review workflow for goai. Two reviewers (Go idiomatics + security)
+# run in parallel against the diff at .zenflow/diff.patch, then a lead
+# agent synthesises both reviews into a single PR comment written to
+# .zenflow/review.md via the write tool.
+#
+# Triggered by the zenflow-review GitHub Action on `/zenflow-review`
+# comments. The Action fetches the diff (gh pr diff > .zenflow/diff.patch),
+# runs `zenflow flow .zenflow/pr-review.yaml`, then posts review.md back
+# to the PR.
+
+name: goai-pr-review
+version: 1
+description: Two-reviewer (Go idiomatics + security) PR review for goai, synthesised into a single PR comment.
+
+agents:
+  idioms:
+    description: "Senior Go reviewer auditing diffs against goai's coding standards and standard Go idioms."
+    tools:
+      - read
+  security:
+    description: "Security reviewer focused on AI-SDK risks: secret handling, prompt injection, HTTP safety."
+    tools:
+      - read
+  lead:
+    description: "Tech lead who merges two reviews into a single prioritised PR comment."
+    tools:
+      - read
+      - write
+
+steps:
+  - id: review-idioms
+    agent: idioms
+    instructions: |
+      Review the diff at `.zenflow/diff.patch` against goai's coding standards and standard Go idioms.
+
+      Repo-specific rules to enforce:
+      - Vercel AI SDK is the reference for provider behaviour - flag deviations.
+      - errors.As, never type assertion on errors.
+      - No input mutation - functions must copy slices/maps before modifying.
+      - Lock-free network calls - never hold a mutex during HTTP I/O.
+      - Shared utilities live in internal/, not duplicated per provider.
+      - Provider options: WithAPIKey, WithTokenSource, WithBaseURL, WithHTTPClient, WithHeaders.
+      - Compile-time interface check (`var _ provider.LanguageModel = (*chatModel)(nil)`).
+      - Dependencies: keep core minimal (no new third-party deps without strong justification).
+      - 90% test coverage per package, mock HTTP not internals.
+
+      Go idioms beyond the repo rules:
+      - context.Context as first arg, propagated to all I/O calls.
+      - Goroutine lifecycle: leaks, missing waitgroup or cancellation.
+      - defer for cleanup, especially response body close.
+      - Error wrapping with %w not %s, sentinel vs typed errors used correctly.
+      - Naming: short locals, exported godoc starts with identifier.
+      - No premature interfaces, no struct embedding for concrete reuse.
+
+      For each finding output one line:
+      `[severity] file:line - what is wrong and why (link to rule if applicable)`
+
+      Severity is one of: critical, high, medium, nit.
+      Skip nits entirely if you find anything critical or high.
+      If the diff is clean, output exactly: `NO ISSUES`.
+      Output nothing else - no preamble, no headers, no JSON.
+    contextFiles:
+      - ".zenflow/diff.patch"
+
+  - id: review-security
+    agent: security
+    instructions: |
+      Review the diff at `.zenflow/diff.patch` for security issues specific to a multi-provider AI SDK.
+
+      What to look for:
+      - API keys / tokens: never logged, never in error messages, never in panic recover dumps.
+      - HTTP request/response logging redacts Authorization and similar headers.
+      - TLS: production endpoints use https, not http; no InsecureSkipVerify in non-test code.
+      - URL handling: user-supplied baseURL / endpoint values cannot reach internal-only hosts (SSRF).
+      - HTTP client timeouts present, context cancellation respected on all paths.
+      - Input validation at API boundaries (size limits on user content, type checks on JSON).
+      - Prompt injection: tool definitions and user content cannot escape and gain extra tool access.
+      - JSON parsing: no unbounded decoders, no panics on malformed input.
+      - Concurrency: race conditions, goroutine leaks, double-close of channels.
+      - Token sources: lock-free fetch enforced, no mutex held during network calls.
+
+      For each finding output one line:
+      `[severity] file:line - issue, risk/exploit, recommended fix`
+
+      Severity is one of: critical, high, medium, nit.
+      Skip nits entirely if you find anything critical or high.
+      If the diff is clean, output exactly: `NO ISSUES`.
+      Output nothing else - no preamble, no headers, no JSON.
+    contextFiles:
+      - ".zenflow/diff.patch"
+
+  - id: synthesise
+    agent: lead
+    dependsOn:
+      - review-idioms
+      - review-security
+    instructions: |
+      You have two independent reviews of the same diff: one focused on Go idiomatics and repo standards, one on security.
+
+      Merge them into a single markdown PR comment and write it to `.zenflow/review.md` using the write tool.
+
+      Output format inside review.md:
+
+      ```
+      ## zenflow review
+
+      <one-sentence verdict>
+
+      ### Critical & High
+      - file:line - description (reviewer)
+
+      ### Medium
+      - file:line - description (reviewer)
+
+      ### Nits
+      - file:line - description (reviewer)
+
+      <one-line recommendation: approve / comment / request-changes>
+      ```
+
+      Rules:
+      - Drop sections that are empty.
+      - Drop duplicate findings - if both reviewers flagged the same thing keep one entry and cite both reviewers.
+      - If BOTH reviewers said `NO ISSUES`, write exactly:
+        ```
+        ## zenflow review
+
+        LGTM - no issues found by either reviewer.
+        ```
+      - Tag each finding with `(idioms)` or `(security)` so authors know which lens caught it.
+      - Do NOT invent findings beyond what the two reviewers reported.
+      - The comment body is the ENTIRE content of review.md - no preamble, no metadata, no markdown code fence around the comment itself.
+
+      After writing the file, output a one-line confirmation like `wrote N bytes to .zenflow/review.md` so the run is auditable.


### PR DESCRIPTION
## Summary
- New comment-triggered workflow that runs two AI reviewers (Go idiomatics, security) and posts a single synthesised summary comment back to the PR.
- Powered by [zenflow](https://github.com/zendev-sh/zenflow) v0.1.5 + FPT Smart Cloud Qwen3.6-27B (262K context).
- Files: `.zenflow/pr-review.yaml` (workflow spec), `.github/workflows/zenflow-review.yml` (GH Action), `.gitignore` (per-run artifacts).

## How to use
A repo OWNER / MEMBER / COLLABORATOR posts a comment containing `/zenflow-review` on the PR. The action acknowledges with an eyes reaction, runs the review, posts the result comment, and uploads the event stream as an artifact.

## What it checks
1. **Go idiomatics + repo standards**: errors.As vs type assertion, no input mutation, lock-free I/O, provider option conventions, compile-time interface checks, dependency minimality, ctx propagation, goroutine lifecycle.
2. **Security**: secret handling, log/error leak of API keys, TLS, SSRF on user-supplied URLs, HTTP timeouts, prompt injection in tool defs, race conditions.

Lead agent merges both into a markdown comment with severity-bucketed findings, drops duplicates, and tags each finding with the originating reviewer.

## Required org secret
- `FPT_API_KEY`: FPT Smart Cloud marketplace API key (JP region).

`GITHUB_TOKEN` is auto-provided by Actions and is sufficient for diff fetch + PR comment posting on same-repo PRs.

## Test plan
- [ ] Merge this PR.
- [ ] Open a follow-up trivial PR and post `/zenflow-review`. Expect: eyes reaction, then a summary comment within ~3-5 min.
- [ ] Open a PR with a deliberate violation (e.g. type assertion instead of errors.As) and verify it gets flagged.
- [ ] Verify a non-collaborator posting `/zenflow-review` does NOT trigger the run.