### PR TITLE
docs(contributing): mention /zenflow-review trigger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ git checkout -b feat/your-feature
 - Keep PRs focused - one feature or fix per PR
 - Include tests for new functionality
 - Update examples if the public API changes
+- Maintainers can post `/zenflow-review` on a PR to run an AI code review (Go idiomatics + security); see `.github/workflows/zenflow-review.yml`
 
 ## Code Style
 


### PR DESCRIPTION
## Summary
- Add one bullet under "Submit a PR" pointing contributors at `/zenflow-review` (AI code review on demand) and the workflow file for details.

## Why
- We just landed the zenflow-review workflow (#64) but CONTRIBUTING didn't surface it; new contributors have no way to discover it without grepping `.github/workflows/`.

## Test
- Doc-only, one-line addition. No code paths touched.
- Smoke test for the new review workflow itself: post `/zenflow-review` on this PR after open.