### PR TITLE
fix(zenflow-review): pass --sandbox to grant tool permissions

### DIFF
--- a/.github/workflows/zenflow-review.yml
+++ b/.github/workflows/zenflow-review.yml
@@ -70,7 +70,13 @@ jobs:
           FPT_API_KEY: ${{ secrets.FPT_API_KEY }}
           FPT_REGION: jp
         run: |
+          # --sandbox grants the safe tool set (read, write, grep, glob)
+          # without bash. Without an explicit permission flag zenflow
+          # denies every tool call on a non-interactive terminal, so the
+          # lead agent could never write .zenflow/review.md and the
+          # reviewer agents could not even call read on the diff.
           zenflow flow .zenflow/pr-review.yaml \
+            --sandbox \
             --json \
             --timeout 20m \
             > .zenflow/events.ndjson


### PR DESCRIPTION
## Summary
- Add `--sandbox` to the `zenflow flow` invocation so the reviewer and lead agents can actually use `read` / `write`.

## Why
First smoke test (#65) failed because zenflow defaults to deny-every-tool on a non-interactive terminal. Reviewer agents could not call `read`, and the lead could not call `write`, so `.zenflow/review.md` was never produced and the "Post review comment" step exited 1.

`--sandbox` pre-allows the safe tool set (`read, write, grep, glob`) and explicitly blocks `bash`, which is the minimum set the three agents in `.zenflow/pr-review.yaml` declare.

## Test plan
- [ ] Merge this PR.
- [ ] Re-post `/zenflow-review` on PR #65 (or any open PR). Expect a summary comment within 3-5 minutes instead of a failed run.