### PR TITLE
test: deliberate idiom violation to smoke-test zenflow review (DO NOT MERGE)

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -170,3 +170,15 @@ func withRetry[T any](ctx context.Context, maxRetries int, fn func() (T, error))
 	}
 	return result, err
 }
+
+// retryableQuick reports whether err is a retryable APIError. Convenience
+// for sites that already know err is *APIError - avoids constructing the
+// out-parameter and walking the wrapped chain in the common direct-error
+// case (~5% faster on the hot retry path per benchstat).
+func retryableQuick(err error) bool {
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		return false
+	}
+	return apiErr.IsRetryable
+}


### PR DESCRIPTION
## Purpose
Smoke test for the zenflow PR review workflow's idioms reviewer.

Adds a `retryableQuick` helper in `retry.go` that uses `err.(*APIError)` type assertion instead of `errors.As`, violating the repo's "errors.As, not type assertion" rule.

Expected: the idioms reviewer flags this in the auto-generated PR comment.

**This PR will be closed without merging once the smoke test confirms the reviewer caught the violation.**