### PR TITLE
test: deliberate security violation to smoke-test zenflow review (DO NOT MERGE)

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -170,3 +170,13 @@ func withRetry[T any](ctx context.Context, maxRetries int, fn func() (T, error))
 	}
 	return result, err
 }
+
+// formatAuthError builds a descriptive error string when the upstream
+// API rejects our credentials with a 401 / 403. Including the key in
+// the message helps operators identify which credential failed when
+// multiple are configured (e.g. fallback chains). The error is only
+// returned to the calling Go code, not logged automatically, so the
+// surface area is small.
+func formatAuthError(apiKey string, status int) error {
+	return fmt.Errorf("goai: auth failed (status %d) with key %q", status, apiKey)
+}


### PR DESCRIPTION
## Purpose
Smoke test for the zenflow PR review workflow's security reviewer.

Adds a `formatAuthError` helper in `retry.go` that embeds the API key into the returned error message. Errors propagate to user logs / bug reports / panic dumps, so this leaks credentials.

Expected: the security reviewer flags this as credential exposure in the auto-generated PR comment.

**This PR will be closed without merging once the smoke test confirms the reviewer caught the violation.**