### PR TITLE
fix(openai): rename max_tokens by model, not reasoning_effort

### DIFF
--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -206,10 +206,13 @@ func BuildRequest(params provider.GenerateParams, modelID string, streaming bool
 		body["_headers"] = params.Headers
 	}
 
-	// Reasoning models use max_completion_tokens instead of max_tokens.
-	// Follows Vercel AI SDK pattern: always set max_tokens first, then rename
-	// if reasoning_effort is present (indicating a reasoning model).
-	if _, hasReasoning := body["reasoning_effort"]; hasReasoning {
+	// Reasoning models (o-series, gpt-5+, codex) require
+	// max_completion_tokens instead of max_tokens. The rename is keyed
+	// on the model id, not on reasoning_effort being present: a
+	// reasoning model rejects max_tokens outright (Azure gpt-5 returns
+	// `Unsupported parameter: 'max_tokens'`) whether or not the caller
+	// passed a reasoning_effort.
+	if isReasoningModel(modelID) {
 		if v, ok := body["max_tokens"]; ok {
 			body["max_completion_tokens"] = v
 			delete(body, "max_tokens")
@@ -217,6 +220,25 @@ func BuildRequest(params provider.GenerateParams, modelID string, streaming bool
 	}
 
 	return body
+}
+
+// isReasoningModel reports whether modelID is an OpenAI-family reasoning
+// model (o-series, gpt-5+, codex). Reasoning models require
+// max_completion_tokens in place of max_tokens. Mirrors the predicate
+// in provider/openai; duplicated here to avoid an import cycle
+// (provider/openai imports this package).
+func isReasoningModel(modelID string) bool {
+	id := strings.ToLower(modelID)
+	// o-series reasoning models (o1, o3, o4, ...).
+	if len(id) >= 2 && id[0] == 'o' && id[1] >= '0' && id[1] <= '9' {
+		return true
+	}
+	// GPT-5+ models (gpt-5-chat is NOT a reasoning model, per Vercel).
+	if strings.HasPrefix(id, "gpt-5") && !strings.HasPrefix(id, "gpt-5-chat") {
+		return true
+	}
+	// codex- prefix models.
+	return strings.HasPrefix(id, "codex-")
 }
 
 // applyProviderOptions maps known provider options to their wire-format keys,

--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -212,7 +212,7 @@ func BuildRequest(params provider.GenerateParams, modelID string, streaming bool
 	// reasoning model rejects max_tokens outright (Azure gpt-5 returns
 	// `Unsupported parameter: 'max_tokens'`) whether or not the caller
 	// passed a reasoning_effort.
-	if isReasoningModel(modelID) {
+	if IsReasoningModel(modelID) {
 		if v, ok := body["max_tokens"]; ok {
 			body["max_completion_tokens"] = v
 			delete(body, "max_tokens")
@@ -222,12 +222,12 @@ func BuildRequest(params provider.GenerateParams, modelID string, streaming bool
 	return body
 }
 
-// isReasoningModel reports whether modelID is an OpenAI-family reasoning
+// IsReasoningModel reports whether modelID is an OpenAI-family reasoning
 // model (o-series, gpt-5+, codex). Reasoning models require
-// max_completion_tokens in place of max_tokens. Mirrors the predicate
-// in provider/openai; duplicated here to avoid an import cycle
-// (provider/openai imports this package).
-func isReasoningModel(modelID string) bool {
+// max_completion_tokens in place of max_tokens, do not accept a
+// temperature, and support reasoning. provider/openai consumes this
+// predicate for capability detection.
+func IsReasoningModel(modelID string) bool {
 	id := strings.ToLower(modelID)
 	// o-series reasoning models (o1, o3, o4, ...).
 	if len(id) >= 2 && id[0] == 'o' && id[1] >= '0' && id[1] <= '9' {

--- a/internal/openaicompat/openaicompat_test.go
+++ b/internal/openaicompat/openaicompat_test.go
@@ -870,10 +870,47 @@ func TestBuildRequest_MaxCompletionTokensForReasoning(t *testing.T) {
 	body := BuildRequest(params, "o3", false, RequestConfig{})
 
 	if _, ok := body["max_tokens"]; ok {
-		t.Error("max_tokens should be removed when reasoning_effort is set")
+		t.Error("max_tokens should be renamed to max_completion_tokens for a reasoning model")
 	}
 	if body["max_completion_tokens"] != 2000 {
 		t.Errorf("max_completion_tokens = %v, want 2000", body["max_completion_tokens"])
+	}
+}
+
+// TestBuildRequest_MaxCompletionTokens_NoReasoningEffort: the rename
+// is keyed on the model id, not on reasoning_effort. A reasoning model
+// (gpt-5) rejects max_tokens outright, so the rename must fire even
+// when the caller passed no reasoning_effort.
+func TestBuildRequest_MaxCompletionTokens_NoReasoningEffort(t *testing.T) {
+	params := provider.GenerateParams{
+		Messages:        []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		MaxOutputTokens: 1500,
+	}
+	body := BuildRequest(params, "gpt-5", false, RequestConfig{})
+
+	if _, ok := body["max_tokens"]; ok {
+		t.Error("max_tokens must be renamed to max_completion_tokens for gpt-5 even without reasoning_effort")
+	}
+	if body["max_completion_tokens"] != 1500 {
+		t.Errorf("max_completion_tokens = %v, want 1500", body["max_completion_tokens"])
+	}
+}
+
+// TestBuildRequest_MaxTokensKeptForNonReasoning: a non-reasoning model
+// keeps the plain max_tokens parameter.
+func TestBuildRequest_MaxTokensKeptForNonReasoning(t *testing.T) {
+	params := provider.GenerateParams{
+		Messages:        []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		MaxOutputTokens: 1500,
+	}
+	for _, model := range []string{"gpt-4o", "gpt-5-chat"} {
+		body := BuildRequest(params, model, false, RequestConfig{})
+		if body["max_tokens"] != 1500 {
+			t.Errorf("%s: max_tokens = %v, want 1500", model, body["max_tokens"])
+		}
+		if _, ok := body["max_completion_tokens"]; ok {
+			t.Errorf("%s: must not set max_completion_tokens", model)
+		}
 	}
 }
 

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/zendev-sh/goai"
@@ -117,8 +116,8 @@ func (m *chatModel) ModelID() string { return m.id }
 
 func (m *chatModel) Capabilities() provider.ModelCapabilities {
 	return provider.ModelCapabilities{
-		Temperature: !isReasoningModel(m.id),
-		Reasoning:   isReasoningModel(m.id),
+		Temperature: !openaicompat.IsReasoningModel(m.id),
+		Reasoning:   openaicompat.IsReasoningModel(m.id),
 		ToolCall:    true,
 		Attachment:  true,
 		InputModalities: provider.ModalitySet{
@@ -286,25 +285,3 @@ func (m *chatModel) shouldUseResponsesAPI(params provider.GenerateParams) bool {
 	return true
 }
 
-// isReasoningModel returns true if the model is a reasoning model (o-series, gpt-5+, codex-).
-// Used for capability detection (temperature, reasoning support).
-func isReasoningModel(modelID string) bool {
-	id := strings.ToLower(modelID)
-
-	// o-series reasoning models (o1, o3, o4, etc.)
-	if len(id) >= 2 && id[0] == 'o' && id[1] >= '0' && id[1] <= '9' {
-		return true
-	}
-
-	// GPT-5+ models (except gpt-5-chat which is NOT a reasoning model per Vercel)
-	if strings.HasPrefix(id, "gpt-5") && !strings.HasPrefix(id, "gpt-5-chat") {
-		return true
-	}
-
-	// codex- prefix models
-	if strings.HasPrefix(id, "codex-") {
-		return true
-	}
-
-	return false
-}

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/provider"
 )
 
@@ -671,9 +672,9 @@ func TestIsReasoningModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
-			got := isReasoningModel(tt.model)
+			got := openaicompat.IsReasoningModel(tt.model)
 			if got != tt.want {
-				t.Errorf("isReasoningModel(%q) = %v, want %v", tt.model, got, tt.want)
+				t.Errorf("IsReasoningModel(%q) = %v, want %v", tt.model, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

Reasoning models (o-series, gpt-5+, codex) reject the `max_tokens`
request parameter and require `max_completion_tokens`. `BuildRequest`
gated the rename on a `reasoning_effort` provider option being present.

A caller that sets `WithMaxOutputTokens` on a reasoning model without
also passing `reasoning_effort` therefore produced a request the API
rejects, e.g. Azure gpt-5 returns:

```
Unsupported parameter: 'max_tokens'
```

## Fix

Key the rename on the model id (`isReasoningModel`), not on the
presence of `reasoning_effort`. A reasoning model always needs
`max_completion_tokens`.

## Tests

* `TestBuildRequest_MaxCompletionTokens_NoReasoningEffort`: gpt-5
  without `reasoning_effort` still gets `max_completion_tokens`.
* `TestBuildRequest_MaxTokensKeptForNonReasoning`: gpt-4o and
  gpt-5-chat keep plain `max_tokens`.
* Existing `TestBuildRequest_MaxCompletionTokensForReasoning` (o3)
  still passes.