### PR TITLE
fix(openaicompat): echo reasoning_content on assistant messages 

### DIFF
--- a/internal/openaicompat/messages.go
+++ b/internal/openaicompat/messages.go
@@ -44,12 +44,17 @@ func ConvertMessages(msgs []provider.Message, system string) []map[string]any {
 
 		var toolCalls []map[string]any
 		var textParts []string
+		var reasoningParts []string
 		var hasImage bool
 
 		for _, part := range msg.Content {
 			switch part.Type {
 			case provider.PartText:
 				textParts = append(textParts, part.Text)
+			case provider.PartReasoning:
+				if part.Text != "" {
+					reasoningParts = append(reasoningParts, part.Text)
+				}
 			case provider.PartImage:
 				hasImage = true
 			case provider.PartToolCall:
@@ -99,6 +104,9 @@ func ConvertMessages(msgs []provider.Message, system string) []map[string]any {
 
 		if len(textParts) > 0 {
 			m["content"] = joinText(textParts)
+		}
+		if len(reasoningParts) > 0 {
+			m["reasoning_content"] = joinText(reasoningParts)
 		}
 		if len(toolCalls) > 0 {
 			m["tool_calls"] = toolCalls

--- a/internal/openaicompat/openaicompat_test.go
+++ b/internal/openaicompat/openaicompat_test.go
@@ -2286,3 +2286,42 @@ func TestConvertMessages_ToolCallsNoText(t *testing.T) {
 		t.Errorf("marshaled JSON contains %q, want null or no content field; got: %s", `"content":""`, jsonStr)
 	}
 }
+
+// TestConvertMessages_AssistantReasoningRoundtrip verifies that a DeepSeek
+// thinking-mode assistant message — which carries reasoning_content alongside
+// tool_calls — is echoed back on the wire correctly so that multi-turn
+// round-trips don't trigger "reasoning_content must be passed back to the API".
+func TestConvertMessages_AssistantReasoningRoundtrip(t *testing.T) {
+	msgs := []provider.Message{
+		{
+			Role: provider.RoleAssistant,
+			Content: []provider.Part{
+				{Type: provider.PartReasoning, Text: "think"},
+				{Type: provider.PartToolCall, ToolCallID: "call_42", ToolName: "do_thing", ToolInput: json.RawMessage(`{"x":1}`)},
+			},
+		},
+	}
+	result := ConvertMessages(msgs, "")
+
+	if len(result) != 1 {
+		t.Fatalf("got %d messages, want 1", len(result))
+	}
+	m := result[0]
+
+	rc, ok := m["reasoning_content"]
+	if !ok {
+		t.Fatal("reasoning_content key missing from wire map; DeepSeek will 400")
+	}
+	if rc != "think" {
+		t.Errorf("reasoning_content = %v, want \"think\"", rc)
+	}
+
+	tcs, ok := m["tool_calls"].([]map[string]any)
+	if !ok || len(tcs) != 1 {
+		t.Fatalf("tool_calls = %v, want 1-element slice", m["tool_calls"])
+	}
+	fn := tcs[0]["function"].(map[string]any)
+	if fn["name"] != "do_thing" {
+		t.Errorf("tool call name = %v, want do_thing", fn["name"])
+	}
+}


### PR DESCRIPTION
## Summary

This fixes DeepSeek thinking-mode multi-turn round-trips.

When a DeepSeek thinking-mode model returns reasoning_content alongside tool_calls, the next request must echo that reasoning_content back or the API 400s. ConvertMessages now collects PartReasoning parts from assistant messages and sets m["reasoning_content"] on the wire map, concatenating multiple parts with newline (same as joinText does for PartText).

Also adds TestConvertMessages_AssistantReasoningRoundtrip to cover the exact multi-turn message shape that was breaking.

## Related issues

Fixes #71 
