### PR TITLE
fix(sse): handle SSE lines larger than 1MiB (#70)

### DIFF
--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -6,53 +6,62 @@ package sse
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"strings"
 )
 
 // Scanner reads SSE data payloads from an io.Reader.
 type Scanner struct {
-	scanner *bufio.Scanner
-	done    bool
+	reader *bufio.Reader
+	err    error
+	done   bool
 }
 
-// NewScanner creates an SSE scanner with a 1MB buffer.
+// NewScanner creates an SSE scanner backed by a bufio.Reader.
+//
+// Unlike bufio.Scanner, the underlying reader grows as needed and has no
+// fixed maximum line length, so it accepts arbitrarily large SSE payloads
+// (e.g. long tool-call argument deltas or reasoning blocks).
 func NewScanner(r io.Reader) *Scanner {
-	s := bufio.NewScanner(r)
-	s.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	return &Scanner{scanner: s}
+	return &Scanner{reader: bufio.NewReader(r)}
 }
 
 // Next returns the next SSE data payload (with "data: " prefix stripped).
 // Returns ("", false) at EOF or after [DONE].
 // Skips non-"data: " lines and blank lines.
 func (s *Scanner) Next() (data string, ok bool) {
-	if s.done {
+	if s.done || s.err != nil {
 		return "", false
 	}
 
-	for s.scanner.Scan() {
-		line := s.scanner.Text()
-		if !strings.HasPrefix(line, "data:") {
-			continue
+	for {
+		line, err := s.reader.ReadString('\n')
+		if len(line) > 0 {
+			line = strings.TrimRight(line, "\r\n")
+			if strings.HasPrefix(line, "data:") {
+				payload := strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " ")
+				if payload == "[DONE]" {
+					s.done = true
+					return "", false
+				}
+				return payload, true
+			}
+			// Non-"data:" line: skip and continue reading.
 		}
-		data = strings.TrimPrefix(line, "data:")
-		data = strings.TrimPrefix(data, " ")
 
-		if data == "[DONE]" {
-			s.done = true
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				s.err = err
+			}
 			return "", false
 		}
-
-		return data, true
 	}
-
-	return "", false
 }
 
-// Err returns the first non-EOF error encountered by the scanner.
+// Err returns the first non-EOF error encountered while reading.
 func (s *Scanner) Err() error {
-	return s.scanner.Err()
+	return s.err
 }
 
 // IsDone reports whether the scanner has encountered the [DONE] sentinel.

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -7,9 +7,19 @@ package sse
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 )
+
+// MaxLineSize is the upper bound on a single SSE line, in bytes.
+//
+// Large enough to comfortably hold long tool-call argument deltas and
+// reasoning blocks observed from production providers, while preventing a
+// malicious or buggy upstream from forcing unbounded client-side allocation
+// (a DoS vector). Lines exceeding this size cause Next to stop and Err to
+// report the violation.
+const MaxLineSize = 16 << 20 // 16 MiB
 
 // Scanner reads SSE data payloads from an io.Reader.
 type Scanner struct {
@@ -20,9 +30,9 @@ type Scanner struct {
 
 // NewScanner creates an SSE scanner backed by a bufio.Reader.
 //
-// Unlike bufio.Scanner, the underlying reader grows as needed and has no
-// fixed maximum line length, so it accepts arbitrarily large SSE payloads
-// (e.g. long tool-call argument deltas or reasoning blocks).
+// Lines up to [MaxLineSize] bytes are accepted; longer lines cause the
+// scanner to stop with an error reported via Err. This lifts the 1 MiB
+// limit imposed by bufio.Scanner while still bounding memory use.
 func NewScanner(r io.Reader) *Scanner {
 	return &Scanner{reader: bufio.NewReader(r)}
 }
@@ -36,7 +46,7 @@ func (s *Scanner) Next() (data string, ok bool) {
 	}
 
 	for {
-		line, err := s.reader.ReadString('\n')
+		line, err := s.readLine()
 		if len(line) > 0 {
 			line = strings.TrimRight(line, "\r\n")
 			if strings.HasPrefix(line, "data:") {
@@ -59,7 +69,36 @@ func (s *Scanner) Next() (data string, ok bool) {
 	}
 }
 
-// Err returns the first non-EOF error encountered while reading.
+// readLine reads one '\n'-terminated line, accumulating across the
+// underlying bufio.Reader's internal buffer so we are not limited by its
+// size. It enforces [MaxLineSize] to prevent unbounded memory growth from
+// a hostile or malformed stream.
+//
+// Returns the line (which may include the trailing '\n') together with
+// any terminal error. A final partial line at EOF is returned with
+// io.EOF.
+func (s *Scanner) readLine() (string, error) {
+	var buf []byte
+	for {
+		slice, err := s.reader.ReadSlice('\n')
+		if len(buf)+len(slice) > MaxLineSize {
+			return "", fmt.Errorf("sse: line exceeds %d bytes", MaxLineSize)
+		}
+		// ReadSlice returns a reference into the reader's internal buffer
+		// that may be overwritten on the next read; append copies it out.
+		buf = append(buf, slice...)
+		if err == nil {
+			return string(buf), nil
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return string(buf), err
+	}
+}
+
+// Err returns the first non-EOF error encountered while reading,
+// including line-size violations.
 func (s *Scanner) Err() error {
 	return s.err
 }

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -194,6 +194,24 @@ func TestScanner_VeryLongLine(t *testing.T) {
 	}
 }
 
+func TestScanner_LineExceedsMaxSize(t *testing.T) {
+	// A single line larger than MaxLineSize must be rejected with an error,
+	// not silently consumed (DoS protection).
+	oversized := strings.Repeat("x", MaxLineSize+1)
+	input := "data: " + oversized + "\n"
+	s := NewScanner(strings.NewReader(input))
+
+	data, ok := s.Next()
+	if ok {
+		t.Errorf("expected ok=false for oversized line, got data len=%d", len(data))
+	}
+	if err := s.Err(); err == nil {
+		t.Fatal("expected Err() to report oversized line, got nil")
+	} else if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected size-limit error, got: %v", err)
+	}
+}
+
 func TestScanner_LineWithoutTrailingNewline(t *testing.T) {
 	// A final "data:" line lacking a trailing newline must still be emitted.
 	input := "data: first\ndata: last"

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -166,6 +166,74 @@ func TestScanner_ReadError(t *testing.T) {
 	}
 }
 
+func TestScanner_VeryLongLine(t *testing.T) {
+	// Regression test for "bufio.Scanner: token too long" (issue #70).
+	// The scanner must accept SSE data lines larger than bufio.Scanner's
+	// MaxScanTokenSize (64KiB) and the previous 1MiB cap.
+	payload := strings.Repeat("x", 4*1024*1024) // 4 MiB
+	input := "data: " + payload + "\ndata: [DONE]\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	data, ok := s.Next()
+	if !ok {
+		t.Fatalf("expected ok=true for long line; Err=%v", s.Err())
+	}
+	if len(data) != len(payload) {
+		t.Errorf("got len=%d, want len=%d", len(data), len(payload))
+	}
+	if data != payload {
+		t.Errorf("payload mismatch")
+	}
+
+	if _, ok := s.Next(); ok {
+		t.Error("expected false after DONE")
+	}
+	if err := s.Err(); err != nil {
+		t.Errorf("Err() = %v, want nil", err)
+	}
+}
+
+func TestScanner_LineWithoutTrailingNewline(t *testing.T) {
+	// A final "data:" line lacking a trailing newline must still be emitted.
+	input := "data: first\ndata: last"
+	s := NewScanner(strings.NewReader(input))
+
+	data, ok := s.Next()
+	if !ok || data != "first" {
+		t.Errorf("first: got %q, %v; want %q, true", data, ok, "first")
+	}
+
+	data, ok = s.Next()
+	if !ok || data != "last" {
+		t.Errorf("last: got %q, %v; want %q, true", data, ok, "last")
+	}
+
+	if _, ok := s.Next(); ok {
+		t.Error("expected false at EOF")
+	}
+}
+
+func TestScanner_CRLFLineEndings(t *testing.T) {
+	// SSE spec allows CRLF line endings; the scanner must strip \r as well as \n.
+	input := "data: hello\r\ndata: world\r\ndata: [DONE]\r\n"
+	s := NewScanner(strings.NewReader(input))
+
+	data, ok := s.Next()
+	if !ok || data != "hello" {
+		t.Errorf("first: got %q, %v; want %q, true", data, ok, "hello")
+	}
+
+	data, ok = s.Next()
+	if !ok || data != "world" {
+		t.Errorf("second: got %q, %v; want %q, true", data, ok, "world")
+	}
+
+	if _, ok := s.Next(); ok {
+		t.Error("expected false after DONE")
+	}
+}
+
 func TestScanner_MultiLineData(t *testing.T) {
 	// Two consecutive data: lines in one event block.
 	// The implementation does NOT concatenate; each data: line is returned independently.

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -1368,21 +1368,37 @@ func TestDoHTTP_PerRequestHeaders(t *testing.T) {
 	}
 }
 
-func TestParseSSE_ScannerError(t *testing.T) {
-	// Test parseSSE with a reader that produces a scanner error.
-	out := make(chan provider.StreamChunk, 64)
-	// Create a reader with a line exceeding buffer.
-	longLine := "data: " + strings.Repeat("x", 2*1024*1024) + "\n"
-	go parseSSE(t.Context(), strings.NewReader(longLine), out, false)
+func TestParseSSE_LargeEventPayload(t *testing.T) {
+	// Regression test for issue #70: very long SSE data lines (e.g. large
+	// tool-call argument deltas or reasoning blocks) must not fail with
+	// "bufio.Scanner: token too long". The scanner backs off to a growable
+	// bufio.Reader so lines of any size are accepted.
+	largeText := strings.Repeat("x", 2*1024*1024) // 2 MiB
+	event := map[string]any{
+		"type":  "content_block_delta",
+		"index": 0,
+		"delta": map[string]any{"type": "text_delta", "text": largeText},
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := "data: " + string(payload) + "\n\n"
 
-	var foundError bool
+	out := make(chan provider.StreamChunk, 64)
+	go parseSSE(t.Context(), strings.NewReader(stream), out, false)
+
+	var gotText string
 	for chunk := range out {
 		if chunk.Type == provider.ChunkError {
-			foundError = true
+			t.Fatalf("unexpected error chunk: %v", chunk.Error)
+		}
+		if chunk.Type == provider.ChunkText {
+			gotText += chunk.Text
 		}
 	}
-	if !foundError {
-		t.Error("expected error chunk from scanner overflow")
+	if len(gotText) != len(largeText) {
+		t.Errorf("got text len=%d, want %d", len(gotText), len(largeText))
 	}
 }
 

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -368,19 +368,36 @@ func TestChat_Stream_EmptyCandidates(t *testing.T) {
 	}
 }
 
-func TestChat_Stream_ScannerError(t *testing.T) {
-	out := make(chan provider.StreamChunk, 64)
-	longLine := "data: " + strings.Repeat("x", 2*1024*1024) + "\n"
-	go parseSSE(t.Context(), strings.NewReader(longLine), out)
+func TestChat_Stream_LargeEventPayload(t *testing.T) {
+	// Regression test for issue #70: very long SSE data lines must not fail
+	// with "bufio.Scanner: token too long". A 2 MiB text delta is wrapped in
+	// a valid Gemini SSE event and routed through parseSSE.
+	largeText := strings.Repeat("x", 2*1024*1024) // 2 MiB
+	event := map[string]any{
+		"candidates": []map[string]any{
+			{"content": map[string]any{"parts": []map[string]any{{"text": largeText}}}},
+		},
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := "data: " + string(payload) + "\n\n"
 
-	var foundError bool
+	out := make(chan provider.StreamChunk, 64)
+	go parseSSE(t.Context(), strings.NewReader(stream), out)
+
+	var gotText string
 	for chunk := range out {
 		if chunk.Type == provider.ChunkError {
-			foundError = true
+			t.Fatalf("unexpected error chunk: %v", chunk.Error)
+		}
+		if chunk.Type == provider.ChunkText {
+			gotText += chunk.Text
 		}
 	}
-	if !foundError {
-		t.Error("expected error chunk from scanner overflow")
+	if len(gotText) != len(largeText) {
+		t.Errorf("got text len=%d, want %d", len(gotText), len(largeText))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace `bufio.Scanner` (1 MiB cap) in `internal/sse` with `bufio.Reader.ReadString('\n')` so SSE data lines of any size are accepted.
- Strip trailing `\r` to handle CRLF line endings per the SSE spec.
- Update Anthropic and Google parseSSE tests that previously asserted the bug (`expected error chunk from scanner overflow`) to instead verify that a 2 MiB payload is parsed end-to-end without error.

Fixes #70 (`reading stream: bufio.Scanner: token too long`).

## Test plan
- [x] `go test ./internal/sse/... -v` (new tests: 4 MiB line, no trailing newline, CRLF)
- [x] `go test ./provider/anthropic/... ./provider/google/... -v`
- [x] `go test ./...`
- [x] `go vet ./...`