### PR TITLE
fix(openai): handle Responses API SSE lines larger than 1MiB (#70)

### DIFF
--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -37,6 +37,32 @@ func NewScanner(r io.Reader) *Scanner {
 	return &Scanner{reader: bufio.NewReader(r)}
 }
 
+// NextLine returns the next line from the SSE stream with trailing CR/LF
+// stripped. Unlike [Scanner.Next], it returns every line including blank
+// lines and non-"data:" lines, so callers parsing event-typed SSE
+// (interleaved "event:" + "data:" pairs, e.g. the OpenAI Responses API)
+// can implement their own line dispatch while still benefiting from
+// [MaxLineSize]-bounded reads. Returns ("", false) at EOF or after a read
+// error (which is reported via [Scanner.Err]).
+//
+// Mix Next and NextLine on the same scanner at your own risk; pick one
+// mode per stream.
+func (s *Scanner) NextLine() (line string, ok bool) {
+	if s.err != nil {
+		return "", false
+	}
+	raw, err := s.readLine()
+	if err != nil {
+		if !errors.Is(err, io.EOF) {
+			s.err = err
+		}
+		if len(raw) == 0 {
+			return "", false
+		}
+	}
+	return strings.TrimRight(raw, "\r\n"), true
+}
+
 // Next returns the next SSE data payload (with "data: " prefix stripped).
 // Returns ("", false) at EOF or after [DONE].
 // Skips non-"data: " lines and blank lines.

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -273,3 +273,85 @@ func TestScanner_MultiLineData(t *testing.T) {
 		t.Error("expected false after all lines consumed")
 	}
 }
+
+func TestScanner_NextLine(t *testing.T) {
+	// NextLine must return every line (event:, data:, blank, comment) with
+	// trailing CR/LF stripped, so callers parsing event-typed SSE can do
+	// their own dispatch.
+	input := "event: ping\r\ndata: {\"x\":1}\r\n\r\n: comment\nevent: done\ndata: [DONE]\n"
+	s := NewScanner(strings.NewReader(input))
+
+	want := []string{
+		"event: ping",
+		"data: {\"x\":1}",
+		"",
+		": comment",
+		"event: done",
+		"data: [DONE]",
+	}
+	for i, w := range want {
+		got, ok := s.NextLine()
+		if !ok {
+			t.Fatalf("line %d: ok=false; Err=%v", i, s.Err())
+		}
+		if got != w {
+			t.Errorf("line %d: got %q, want %q", i, got, w)
+		}
+	}
+	if _, ok := s.NextLine(); ok {
+		t.Error("expected ok=false at EOF")
+	}
+	if err := s.Err(); err != nil {
+		t.Errorf("Err() = %v, want nil", err)
+	}
+}
+
+func TestScanner_NextLine_ReadError(t *testing.T) {
+	injected := errors.New("stream broken")
+	r := io.MultiReader(
+		strings.NewReader("event: ping\n"),
+		&errReader{err: injected},
+	)
+	s := NewScanner(r)
+
+	line, ok := s.NextLine()
+	if !ok || line != "event: ping" {
+		t.Fatalf("first: got %q, %v; want %q, true", line, ok, "event: ping")
+	}
+
+	_, ok = s.NextLine()
+	if ok {
+		t.Error("expected ok=false after read error")
+	}
+	if err := s.Err(); !errors.Is(err, injected) {
+		t.Errorf("Err() = %v; want injected %v", err, injected)
+	}
+
+	// Subsequent calls must short-circuit on the cached error.
+	if _, ok := s.NextLine(); ok {
+		t.Error("expected ok=false on repeat call after error")
+	}
+}
+
+func TestScanner_NextLine_LargeLine(t *testing.T) {
+	// Regression test for issue #70: NextLine must accept lines past the
+	// historical 1 MiB bufio.Scanner cap, so event-typed SSE consumers
+	// (OpenAI Responses API) don't choke on long deltas.
+	payload := strings.Repeat("y", 4*1024*1024)
+	input := "event: response.output_text.delta\ndata: " + payload + "\n"
+
+	s := NewScanner(strings.NewReader(input))
+
+	got, ok := s.NextLine()
+	if !ok || got != "event: response.output_text.delta" {
+		t.Fatalf("first line: got %q, %v", got, ok)
+	}
+
+	got, ok = s.NextLine()
+	if !ok {
+		t.Fatalf("expected long data line; Err=%v", s.Err())
+	}
+	if len(got) != len("data: ")+len(payload) {
+		t.Errorf("got len=%d, want %d", len(got), len("data: ")+len(payload))
+	}
+}

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -1844,6 +1844,44 @@ func TestStreamResponses_DONE(t *testing.T) {
 	}
 }
 
+func TestStreamResponses_LargeDataLine(t *testing.T) {
+	// Regression test for issue #70: bufio.Scanner's 1 MiB token cap caused
+	// "token too long" errors when the Responses API emitted a single very
+	// large SSE event (e.g. a long output_text.delta). The stream must now
+	// accept lines well past 1 MiB.
+	payload := strings.Repeat("x", 4*1024*1024) // 4 MiB
+	delta, err := json.Marshal(struct {
+		Delta string `json:"delta"`
+	}{Delta: payload})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := "event: response.output_text.delta\ndata: " + string(delta) + "\n\n" +
+		"event: response.completed\ndata: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+
+	out := make(chan provider.StreamChunk, 16)
+	go streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
+
+	var gotText string
+	var gotFinish bool
+	for chunk := range out {
+		switch chunk.Type {
+		case provider.ChunkText:
+			gotText += chunk.Text
+		case provider.ChunkFinish:
+			gotFinish = true
+		case provider.ChunkError:
+			t.Fatalf("unexpected error chunk: %v", chunk.Error)
+		}
+	}
+	if gotText != payload {
+		t.Errorf("text len = %d, want %d", len(gotText), len(payload))
+	}
+	if !gotFinish {
+		t.Error("expected finish chunk")
+	}
+}
+
 func TestStreamResponses_ScannerError(t *testing.T) {
 	// Directly test streamResponses with an error reader.
 	out := make(chan provider.StreamChunk, 64)

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"bufio"
 	"cmp"
 	"context"
 	"encoding/json"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/internal/sse"
 	"github.com/zendev-sh/goai/provider"
 )
 
@@ -445,14 +445,13 @@ type responsesReasoning struct {
 }
 
 // streamResponses parses SSE from the OpenAI Responses API.
-// Uses bufio.Scanner directly because Responses API has event-typed SSE
+// Uses sse.Scanner.NextLine because the Responses API has event-typed SSE
 // (event: + data: pairs), unlike Chat Completions (data: only).
 func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provider.StreamChunk) {
 	defer close(out)
 	defer func() { _ = body.Close() }()
 
-	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner := sse.NewScanner(body)
 
 	var usage provider.Usage
 	var eventType string
@@ -462,8 +461,11 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 	activeReasoning := make(map[int]*responsesReasoning)
 	currentReasoningIdx := -1
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	for {
+		line, ok := scanner.NextLine()
+		if !ok {
+			break
+		}
 
 		if strings.HasPrefix(line, "event: ") {
 			eventType = strings.TrimPrefix(line, "event: ")


### PR DESCRIPTION
## Summary
- Responses API stream still used `bufio.Scanner` with a 1MiB cap; long `output_text.delta` / reasoning events tripped `bufio.Scanner: token too long` (issue #70 follow-up reported [here](https://github.com/zendev-sh/goai/issues/70#issuecomment-_)).
- Add `sse.Scanner.NextLine` so event-typed SSE (`event:` + `data:` pairs) can reuse the 16MiB-bounded reader; switch `streamResponses` to it.
- Drop the now-unused `bufio` import in `provider/openai/responses.go`.

## Test plan
- [x] `go test ./...` (32/32 packages PASS)
- [x] `go test -race ./internal/sse/ ./provider/openai/`
- [x] `internal/sse` coverage 100% (`NextLine`, `Next`, `readLine`)
- [x] New regression tests:
  - `TestScanner_NextLine` (event/data/blank/comment, CRLF)
  - `TestScanner_NextLine_LargeLine` (4MiB line)
  - `TestScanner_NextLine_ReadError`
  - `TestStreamResponses_LargeDataLine` (4MiB delta end-to-end)

Re-opens fix for #70 on the Responses API code path.