### PR TITLE
fix(mcp): HTTPTransport tolerates POST-only Streamable HTTP servers (#74)

### DIFF
--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -319,9 +319,15 @@ func (t *HTTPTransport) OnError(fn func(error)) {
 	t.onError = fn
 }
 
-// Start initiates the SSE connection for server-to-client messages.
-// The HTTP request is made synchronously so connection errors are returned
-// directly. The SSE body read loop runs in a background goroutine.
+// Start initiates the optional server-to-client SSE stream.
+//
+// Per the MCP Streamable HTTP spec (2025-03-26), the GET-for-SSE channel is
+// OPTIONAL: a server that does not offer it SHOULD return HTTP 405. When the
+// server returns 405 (or 404), Start completes successfully without an SSE
+// reader goroutine, and the transport stays usable for POST-only client→
+// server messages (server replies still arrive inline on POST responses).
+// Servers that do offer a stream return 200 + text/event-stream, and the
+// SSE body read loop runs in a background goroutine.
 func (t *HTTPTransport) Start(ctx context.Context) error {
 	sseCtx, cancel := context.WithCancel(ctx)
 	t.mu.Lock()
@@ -353,6 +359,17 @@ func (t *HTTPTransport) Start(ctx context.Context) error {
 	if err != nil {
 		cancel()
 		return fmt.Errorf("mcp: SSE connection: %w", err)
+	}
+	// Streamable HTTP servers that do not expose a server-initiated SSE
+	// stream signal this with 405 (spec) or 404 (some implementations).
+	// Treat both as "POST-only" and keep the transport usable.
+	if resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotFound {
+		_ = resp.Body.Close()
+		cancel()
+		t.mu.Lock()
+		t.cancel = nil
+		t.mu.Unlock()
+		return nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		_ = resp.Body.Close()

--- a/mcp/transport_test.go
+++ b/mcp/transport_test.go
@@ -505,6 +505,67 @@ func TestHTTPTransport_Start_SSEConnection(t *testing.T) {
 	_ = ht.Close()
 }
 
+func TestHTTPTransport_Start_NoServerSSE(t *testing.T) {
+	// Regression test for issue #74: Streamable HTTP MCP servers
+	// (Zoho MCP, etc.) reject the optional GET-for-SSE with 405 per spec.
+	// Start must treat 405/404 as "POST-only" and not fail, so Send can
+	// still post JSON-RPC requests and receive inline responses.
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{"405 method not allowed", http.StatusMethodNotAllowed},
+		{"404 not found", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var posts atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					w.WriteHeader(tc.status)
+				case http.MethodPost:
+					posts.Add(1)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = fmt.Fprint(w, `{"jsonrpc":"2.0","id":"1","result":{"ok":true}}`)
+				default:
+					w.WriteHeader(http.StatusBadRequest)
+				}
+			}))
+			defer srv.Close()
+
+			ht := NewHTTPTransport(srv.URL)
+
+			received := make(chan JSONRPCMessage, 1)
+			ht.OnMessage(func(m JSONRPCMessage) { received <- m })
+
+			if err := ht.Start(context.Background()); err != nil {
+				t.Fatalf("Start with %d should not fail: %v", tc.status, err)
+			}
+
+			msg := JSONRPCMessage{JSONRPC: "2.0", Method: "initialize", ID: "1"}
+			if err := ht.Send(context.Background(), msg); err != nil {
+				t.Fatalf("Send: %v", err)
+			}
+			if got := posts.Load(); got != 1 {
+				t.Errorf("posts = %d, want 1", got)
+			}
+			select {
+			case got := <-received:
+				if got.ID != "1" {
+					t.Errorf("dispatched ID = %v, want 1", got.ID)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for inline POST response")
+			}
+
+			if err := ht.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+		})
+	}
+}
+
 func TestHTTPTransport_Close(t *testing.T) {
 	ht := NewHTTPTransport("http://example.com")
 	if err := ht.Close(); err != nil {


### PR DESCRIPTION
## Summary
- Per the MCP Streamable HTTP spec (2025-03-26), the GET-for-SSE channel is **optional**; a server that does not offer it SHOULD return `405 Method Not Allowed`.
- `HTTPTransport.Start` treated any non-200 as fatal, so POST-only Streamable HTTP servers (Zoho MCP and others) failed with `mcp: SSE connection failed: HTTP 405` (issue #74).
- Now treat `405` and `404` as "no server-initiated stream", skip the SSE goroutine, and return success. POST `Send` already handles inline `application/json` and `text/event-stream` responses, so client→server flow keeps working.

## Test plan
- [x] `go vet ./...`
- [x] `go test -race ./mcp/`
- [x] `mcp` coverage 95.3% (`HTTPTransport.Start` 90.4%)
- [x] New regression test `TestHTTPTransport_Start_NoServerSSE` (subtests for 405 and 404): GET returns the status, POST returns inline JSON-RPC, asserts `Send` posts once and `OnMessage` dispatches the response.

Fixes #74.