### PR TITLE
feat(mcp): native OAuth 2.1 + PKCE for remote MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,19 @@ result, _ := goai.GenerateText(ctx, model,
 )
 ```
 
-See [examples/mcp-tools](examples/mcp-tools/) and the [MCP documentation](https://goai.sh/concepts/mcp) for more.
+For OAuth-protected remote servers, GoAI handles authorization-server discovery, dynamic client registration, PKCE, token refresh, and retry-on-401 natively — no external wrapper needed:
+
+```go
+ts, _ := mcp.NewOAuthTokenSource(ctx, mcp.OAuthConfig{
+    ServerURL:   serverURL,
+    RedirectURI: "http://127.0.0.1:8765/callback",
+    Authorize:   openBrowserAndAwaitRedirect, // returns the OAuth redirect URL
+})
+transport := mcp.NewHTTPTransport(serverURL, mcp.WithHTTPClient(mcp.NewOAuthHTTPClient(ts, nil)))
+client := mcp.NewClient("my-app", "1.0", mcp.WithTransport(transport))
+```
+
+See [examples/mcp-tools](examples/mcp-tools/), [examples/mcp-oauth](examples/mcp-oauth/), and the [MCP documentation](https://goai.sh/concepts/mcp) for more.
 
 ## Companion Projects
 

--- a/examples/mcp-oauth/main.go
+++ b/examples/mcp-oauth/main.go
@@ -1,0 +1,164 @@
+//go:build ignore
+
+// Example: OAuth 2.1 + PKCE authentication for a remote MCP server.
+//
+// Connects to an OAuth-protected Streamable HTTP MCP server using the native
+// OAuth support in the mcp package: authorization-server discovery (RFC 9728 →
+// RFC 8414), dynamic client registration (RFC 7591), PKCE (RFC 7636), and
+// automatic token refresh + retry-on-401.
+//
+// The example runs a temporary loopback HTTP server to capture the OAuth
+// redirect, opens the authorization URL in your browser, and once authorized
+// lists the server's tools. If GEMINI_API_KEY is set, it also runs a one-shot
+// GenerateText call that lets Gemini use the MCP tools.
+//
+// Zero-config OAuth MCP servers (work without pre-registering a client):
+//
+//	https://mcp.linear.app/mcp       (Linear)
+//	https://mcp.sentry.dev/mcp       (Sentry)
+//	https://mcp.notion.com/mcp       (Notion)
+//
+// Usage:
+//
+//	go run ./examples/mcp-oauth/main.go https://mcp.linear.app/mcp
+//	GEMINI_API_KEY=... go run ./examples/mcp-oauth/main.go https://mcp.sentry.dev/mcp
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/mcp"
+	"github.com/zendev-sh/goai/provider/google"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("usage: go run ./examples/mcp-oauth/main.go <mcp-server-url>")
+	}
+	serverURL := os.Args[1]
+
+	ctx := context.Background()
+
+	// --- Start a loopback server to capture the OAuth redirect ---
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer listener.Close()
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", listener.Addr().(*net.TCPAddr).Port)
+
+	redirectCh := make(chan string, 1)
+	go http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { //nolint:errcheck
+		if r.URL.Path != "/callback" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintln(w, "Authorization complete. You can close this tab and return to the terminal.")
+		redirectCh <- "http://127.0.0.1" + r.URL.RequestURI()
+	}))
+
+	// --- Build the OAuth token source ---
+	// NewOAuthTokenSource discovers the authorization server, dynamically
+	// registers a public client, and runs the PKCE authorization-code flow via
+	// the Authorize callback below.
+	ts, err := mcp.NewOAuthTokenSource(ctx, mcp.OAuthConfig{
+		ServerURL:   serverURL,
+		ClientName:  "goai-mcp-oauth-example",
+		RedirectURI: redirectURI,
+		Authorize: func(ctx context.Context, authURL string) (string, error) {
+			fmt.Printf("\nOpen this URL to authorize (it should open automatically):\n\n  %s\n\n", authURL)
+			openBrowser(authURL)
+			select {
+			case redirect := <-redirectCh:
+				return redirect, nil
+			case <-time.After(3 * time.Minute):
+				return "", fmt.Errorf("timed out waiting for authorization")
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		},
+	})
+	if err != nil {
+		log.Fatalf("oauth setup: %v", err)
+	}
+
+	// --- Connect over Streamable HTTP with OAuth-authenticated requests ---
+	// NewOAuthHTTPClient injects the bearer token and retries once on HTTP 401
+	// after refreshing the token.
+	httpClient := mcp.NewOAuthHTTPClient(ts, nil)
+	transport := mcp.NewHTTPTransport(serverURL, mcp.WithHTTPClient(httpClient))
+	client := mcp.NewClient("goai-mcp-oauth", "1.0.0", mcp.WithTransport(transport))
+
+	fmt.Println("Connecting (a browser window will open for authorization)...")
+	if err := client.Connect(ctx); err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	info := client.ServerInfo()
+	fmt.Printf("\nConnected to %s v%s\n\n", info.Name, info.Version)
+
+	// --- List tools ---
+	fmt.Println("=== Available Tools ===")
+	toolsResult, err := client.ListTools(ctx, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, tool := range toolsResult.Tools {
+		fmt.Printf("  %-40s %s\n", tool.Name, truncate(tool.Description, 60))
+	}
+	fmt.Printf("\nTotal: %d tools\n", len(toolsResult.Tools))
+
+	// --- Optional: let Gemini use the MCP tools ---
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		fmt.Println("\n(Set GEMINI_API_KEY to run a model call using these tools.)")
+		return
+	}
+
+	fmt.Println("\n=== Gemini using MCP tools ===")
+	model := google.Chat("gemini-2.5-flash", google.WithAPIKey(apiKey))
+	goaiTools := mcp.ConvertTools(client, toolsResult.Tools)
+
+	res, err := goai.GenerateText(ctx, model,
+		goai.WithTools(goaiTools...),
+		goai.WithPrompt("Briefly, what can you help me with using the tools available?"),
+		goai.WithMaxSteps(5),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(res.Text)
+}
+
+// openBrowser tries to open url in the default browser; failures are ignored
+// since the URL is also printed for manual opening.
+func openBrowser(url string) {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	case "windows":
+		cmd, args = "rundll32", []string{"url.dll,FileProtocolHandler"}
+	default:
+		cmd = "xdg-open"
+	}
+	_ = exec.Command(cmd, append(args, url)...).Start()
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}

--- a/internal/gemini/schema.go
+++ b/internal/gemini/schema.go
@@ -33,7 +33,10 @@ func SanitizeSchema(schema map[string]any) map[string]any {
 // inlineRefsAndStripDrafts walks an arbitrary schema value and:
 //   - Replaces every {"$ref": "#/$defs/X"} with a deep copy of $defs.X
 //     (recursively, so nested refs are also resolved).
-//   - Strips "$defs", "if", "then", "else" keys anywhere they appear.
+//   - Strips "$defs", "if", "then", "else" subschema keywords and the
+//     "$schema", "$id", "$comment" meta keywords anywhere they appear
+//     (Gemini's OpenAPI-subset schema rejects them; MCP tool inputSchemas
+//     commonly carry a top-level "$schema").
 //   - Bails out at maxRefInlineDepth to prevent cyclic-ref infinite loops;
 //     at the depth cap, unresolved refs become {type: "object"}.
 //
@@ -58,7 +61,9 @@ func inlineRefsAndStripDrafts(obj any, defs map[string]any, depth int) any {
 		// Recurse into every key except the blocklisted ones.
 		result := make(map[string]any, len(v))
 		for k, val := range v {
-			if k == "$defs" || k == "if" || k == "then" || k == "else" {
+			switch k {
+			case "$defs", "if", "then", "else", // unsupported subschema keywords
+				"$schema", "$id", "$comment": // meta keywords Gemini rejects
 				continue
 			}
 			result[k] = inlineRefsAndStripDrafts(val, defs, depth)

--- a/internal/gemini/schema_test.go
+++ b/internal/gemini/schema_test.go
@@ -42,6 +42,37 @@ func TestSanitizeSchema_RemovesAdditionalProperties(t *testing.T) {
 	}
 }
 
+func TestSanitizeSchema_RemovesMetaKeywords(t *testing.T) {
+	// MCP tool inputSchemas commonly carry a top-level "$schema"; Gemini rejects
+	// it along with "$id" and "$comment", including when nested.
+	schema := map[string]any{
+		"$schema":  "https://json-schema.org/draft/2020-12/schema",
+		"$id":      "https://example.com/tool",
+		"$comment": "internal note",
+		"type":     "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":     "string",
+				"$comment": "the name",
+			},
+		},
+	}
+	result := SanitizeSchema(schema)
+	for _, k := range []string{"$schema", "$id", "$comment"} {
+		if _, ok := result[k]; ok {
+			t.Errorf("%s should be removed at top level", k)
+		}
+	}
+	props := result["properties"].(map[string]any)
+	name := props["name"].(map[string]any)
+	if _, ok := name["$comment"]; ok {
+		t.Error("$comment should be removed from nested properties")
+	}
+	if name["type"] != "string" {
+		t.Errorf("nested type = %v, want string", name["type"])
+	}
+}
+
 func TestSanitizeSchema_EnumIntegerToString(t *testing.T) {
 	schema := map[string]any{
 		"type": "integer",

--- a/mcp/oauth.go
+++ b/mcp/oauth.go
@@ -1,0 +1,600 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+// ErrAuthorizationRequired is returned by an OAuth [provider.TokenSource] when
+// no usable token is stored and no [OAuthConfig.Authorize] callback was
+// provided to run the interactive authorization-code flow.
+var ErrAuthorizationRequired = errors.New("mcp: oauth authorization required but no Authorize callback configured")
+
+// AuthServerMetadata holds the OAuth 2.0 Authorization Server endpoints
+// discovered for an MCP server, per RFC 8414 (Authorization Server Metadata).
+type AuthServerMetadata struct {
+	// Issuer is the authorization server's issuer identifier.
+	Issuer string `json:"issuer,omitempty"`
+
+	// AuthorizationEndpoint is the URL the user-agent is sent to in order to
+	// obtain an authorization grant (RFC 6749 §3.1).
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+
+	// TokenEndpoint is the URL used to exchange a grant for tokens and to
+	// refresh access tokens (RFC 6749 §3.2).
+	TokenEndpoint string `json:"token_endpoint"`
+
+	// RegistrationEndpoint is the optional Dynamic Client Registration endpoint
+	// (RFC 7591). Empty if the server does not advertise one.
+	RegistrationEndpoint string `json:"registration_endpoint,omitempty"`
+}
+
+// DiscoverAuth resolves the OAuth Authorization Server for an MCP server URL by
+// following the MCP authorization discovery chain:
+//
+//	RFC 9728 (Protected Resource Metadata):
+//	  GET {origin}/.well-known/oauth-protected-resource
+//	  → authorization_servers[0] is the Authorization Server base URL
+//
+//	RFC 8414 (Authorization Server Metadata):
+//	  GET {asURL}/.well-known/oauth-authorization-server
+//	  → authorization_endpoint, token_endpoint, registration_endpoint
+//
+// If RFC 9728 yields no authorization server, RFC 8414 is tried directly on the
+// MCP server's origin as a legacy fallback (some servers skip the indirection).
+//
+// hc may be nil, in which case http.DefaultClient is used.
+func DiscoverAuth(ctx context.Context, serverURL string, hc *http.Client) (*AuthServerMetadata, error) {
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	origin, err := originOf(serverURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// RFC 9728 — find the Authorization Server URL (best-effort).
+	asURL := ""
+	if md, err := getJSON(ctx, hc, origin+"/.well-known/oauth-protected-resource"); err == nil {
+		if servers, ok := md["authorization_servers"].([]any); ok && len(servers) > 0 {
+			asURL, _ = servers[0].(string)
+		}
+	}
+
+	// RFC 8414 — fetch AS metadata: discovered AS first, origin as fallback.
+	candidates := make([]string, 0, 2)
+	if asURL != "" {
+		candidates = append(candidates, asURL)
+	}
+	candidates = append(candidates, origin)
+
+	for _, candidate := range candidates {
+		base := strings.TrimRight(candidate, "/")
+		md, err := getJSON(ctx, hc, base+"/.well-known/oauth-authorization-server")
+		if err != nil {
+			continue
+		}
+		authEndpoint, _ := md["authorization_endpoint"].(string)
+		if authEndpoint == "" {
+			continue
+		}
+		return &AuthServerMetadata{
+			Issuer:                strFromJSON(md["issuer"]),
+			AuthorizationEndpoint: authEndpoint,
+			TokenEndpoint:         strFromJSON(md["token_endpoint"]),
+			RegistrationEndpoint:  strFromJSON(md["registration_endpoint"]),
+		}, nil
+	}
+
+	return nil, fmt.Errorf("mcp: no OAuth authorization server metadata found for %s", serverURL)
+}
+
+// ClientRegistration describes a public OAuth client to register dynamically.
+type ClientRegistration struct {
+	// ClientName is a human-readable name for the client.
+	ClientName string
+
+	// RedirectURIs are the allowed redirect URIs for the authorization-code flow.
+	RedirectURIs []string
+
+	// Scopes is the optional set of scopes the client will request.
+	Scopes []string
+}
+
+// RegisterClient performs OAuth 2.0 Dynamic Client Registration (RFC 7591)
+// against registrationEndpoint and returns the server-assigned client_id.
+//
+// The client is registered as a public client (token_endpoint_auth_method
+// "none") supporting the authorization_code and refresh_token grants.
+//
+// hc may be nil, in which case http.DefaultClient is used.
+func RegisterClient(ctx context.Context, registrationEndpoint string, reg ClientRegistration, hc *http.Client) (clientID string, err error) {
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	body := map[string]any{
+		"client_name":                reg.ClientName,
+		"redirect_uris":              reg.RedirectURIs,
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+	}
+	if len(reg.Scopes) > 0 {
+		body["scope"] = strings.Join(reg.Scopes, " ")
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("mcp: marshal registration request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationEndpoint, strings.NewReader(string(payload)))
+	if err != nil {
+		return "", fmt.Errorf("mcp: create registration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("mcp: dynamic client registration: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("mcp: dynamic client registration: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	var parsed struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", fmt.Errorf("mcp: parse registration response: %w", err)
+	}
+	if parsed.ClientID == "" {
+		return "", errors.New("mcp: registration response missing client_id")
+	}
+	return parsed.ClientID, nil
+}
+
+// GeneratePKCE returns a PKCE code_verifier and its S256 code_challenge per
+// RFC 7636, where challenge = BASE64URL(SHA-256(verifier)).
+//
+// The token sources in this package generate PKCE values internally; this
+// helper is exposed for callers that drive the authorization flow themselves.
+func GeneratePKCE() (verifier, challenge string) {
+	verifier = oauth2.GenerateVerifier()
+	return verifier, oauth2.S256ChallengeFromVerifier(verifier)
+}
+
+// TokenStore persists OAuth tokens keyed by MCP server URL. Implementations
+// must be safe for concurrent use. The in-memory default ([NewMemoryTokenStore])
+// is suitable for a single process; persist tokens (e.g. encrypted on disk) by
+// supplying a custom implementation via [OAuthConfig.Store].
+type TokenStore interface {
+	// Get returns the stored token for key and whether one was found.
+	Get(key string) (*oauth2.Token, bool)
+
+	// Set stores tok for key, replacing any existing token.
+	Set(key string, tok *oauth2.Token) error
+
+	// Delete removes any stored token for key.
+	Delete(key string) error
+}
+
+// NewMemoryTokenStore returns an in-memory [TokenStore].
+func NewMemoryTokenStore() TokenStore {
+	return &memoryTokenStore{tokens: make(map[string]*oauth2.Token)}
+}
+
+type memoryTokenStore struct {
+	mu     sync.RWMutex
+	tokens map[string]*oauth2.Token
+}
+
+func (s *memoryTokenStore) Get(key string) (*oauth2.Token, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	tok, ok := s.tokens[key]
+	return tok, ok
+}
+
+func (s *memoryTokenStore) Set(key string, tok *oauth2.Token) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokens[key] = tok
+	return nil
+}
+
+func (s *memoryTokenStore) Delete(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.tokens, key)
+	return nil
+}
+
+// AuthorizeFunc runs the interactive OAuth authorization-code step. It receives
+// the authorization URL to present to the user and must return the redirect URL
+// the authorization server sent back (which carries the "code" and "state"
+// query parameters). Returning the full redirect URL lets this package validate
+// the state parameter; returning the bare authorization code is also accepted,
+// in which case state validation is skipped.
+type AuthorizeFunc func(ctx context.Context, authURL string) (redirectURL string, err error)
+
+// OAuthConfig configures an OAuth [provider.TokenSource] for an MCP server.
+type OAuthConfig struct {
+	// ServerURL is the MCP server URL. It is used both as the discovery target
+	// and as the key under which tokens are stored.
+	ServerURL string
+
+	// Metadata, when set, supplies the authorization server endpoints directly
+	// and skips discovery. When nil, [DiscoverAuth] is called for ServerURL.
+	Metadata *AuthServerMetadata
+
+	// ClientID is the OAuth client_id. When empty, dynamic client registration
+	// (RFC 7591) is attempted using the server's registration_endpoint.
+	ClientID string
+
+	// ClientName is the human-readable client name used for dynamic registration.
+	ClientName string
+
+	// RedirectURI is the redirect URI used in the authorization-code flow. It
+	// must match a URI the client is registered with.
+	RedirectURI string
+
+	// Scopes are the OAuth scopes to request.
+	Scopes []string
+
+	// Store persists tokens across calls. When nil, an in-memory store is used.
+	Store TokenStore
+
+	// HTTPClient is used for discovery, registration, and token requests. When
+	// nil, http.DefaultClient is used.
+	HTTPClient *http.Client
+
+	// Authorize runs the interactive authorization step when no usable token is
+	// available. When nil, the token source returns [ErrAuthorizationRequired]
+	// instead of starting a flow (useful when only a stored token is expected).
+	Authorize AuthorizeFunc
+}
+
+// NewOAuthTokenSource builds a [provider.TokenSource] that authenticates to an
+// MCP server using OAuth 2.0 with PKCE. It discovers the authorization server
+// (unless Metadata is supplied), performs dynamic client registration (unless
+// ClientID is supplied), and returns a token source that:
+//
+//   - returns the stored access token while it is valid;
+//   - refreshes it using the refresh token when expired;
+//   - runs the interactive authorization-code flow via [OAuthConfig.Authorize]
+//     when no usable token exists.
+//
+// The returned token source implements [provider.InvalidatingTokenSource]; its
+// Invalidate method forces a refresh on the next call, which [NewOAuthHTTPClient]
+// uses to recover from HTTP 401 responses.
+func NewOAuthTokenSource(ctx context.Context, cfg OAuthConfig) (provider.TokenSource, error) {
+	if cfg.ServerURL == "" {
+		return nil, errors.New("mcp: OAuthConfig.ServerURL is required")
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+
+	md := cfg.Metadata
+	if md == nil {
+		var err error
+		md, err = DiscoverAuth(ctx, cfg.ServerURL, hc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	clientID := cfg.ClientID
+	if clientID == "" {
+		if md.RegistrationEndpoint == "" {
+			return nil, errors.New("mcp: no ClientID provided and server has no registration_endpoint")
+		}
+		var err error
+		clientID, err = RegisterClient(ctx, md.RegistrationEndpoint, ClientRegistration{
+			ClientName:   cfg.ClientName,
+			RedirectURIs: []string{cfg.RedirectURI},
+			Scopes:       cfg.Scopes,
+		}, hc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	store := cfg.Store
+	if store == nil {
+		store = NewMemoryTokenStore()
+	}
+
+	return &oauthTokenSource{
+		cfg: &oauth2.Config{
+			ClientID:    clientID,
+			RedirectURL: cfg.RedirectURI,
+			Scopes:      cfg.Scopes,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  md.AuthorizationEndpoint,
+				TokenURL: md.TokenEndpoint,
+			},
+		},
+		store:     store,
+		key:       cfg.ServerURL,
+		authorize: cfg.Authorize,
+		hc:        hc,
+	}, nil
+}
+
+var _ provider.InvalidatingTokenSource = (*oauthTokenSource)(nil)
+
+type oauthTokenSource struct {
+	cfg       *oauth2.Config
+	store     TokenStore
+	key       string
+	authorize AuthorizeFunc
+	hc        *http.Client
+
+	mu    sync.Mutex
+	force bool // forces a refresh on the next Token call, even if not yet expired
+}
+
+func (s *oauthTokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	force := s.force
+	s.force = false
+	s.mu.Unlock()
+
+	// Route oauth2's internal HTTP calls through the configured client.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, s.hc)
+
+	if tok, ok := s.store.Get(s.key); ok && tok.AccessToken != "" {
+		if !force && tok.Valid() {
+			return tok.AccessToken, nil
+		}
+		if tok.RefreshToken != "" {
+			refreshFrom := tok
+			if force {
+				refreshFrom = expired(tok)
+			}
+			// oauth2's TokenSource refreshes lock-free and only when needed.
+			newTok, err := s.cfg.TokenSource(ctx, refreshFrom).Token()
+			if err == nil {
+				_ = s.store.Set(s.key, newTok)
+				return newTok.AccessToken, nil
+			}
+			// Refresh failed (e.g. refresh token revoked) — fall through to
+			// a fresh authorization flow.
+		}
+	}
+
+	return s.authorizeAndStore(ctx)
+}
+
+func (s *oauthTokenSource) Invalidate() {
+	s.mu.Lock()
+	s.force = true
+	s.mu.Unlock()
+}
+
+func (s *oauthTokenSource) authorizeAndStore(ctx context.Context) (string, error) {
+	if s.authorize == nil {
+		return "", ErrAuthorizationRequired
+	}
+
+	verifier := oauth2.GenerateVerifier()
+	state, err := randomState()
+	if err != nil {
+		return "", err
+	}
+	authURL := s.cfg.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
+
+	redirect, err := s.authorize(ctx, authURL)
+	if err != nil {
+		return "", fmt.Errorf("mcp: authorization: %w", err)
+	}
+	code, err := codeFromRedirect(redirect, state)
+	if err != nil {
+		return "", err
+	}
+
+	tok, err := s.cfg.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return "", fmt.Errorf("mcp: token exchange: %w", err)
+	}
+	if err := s.store.Set(s.key, tok); err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}
+
+// NewOAuthHTTPClient returns an *http.Client that attaches the token from ts as
+// a Bearer Authorization header to every request. When a request receives an
+// HTTP 401 response and ts implements [provider.InvalidatingTokenSource], the
+// token is invalidated and the request is retried once with a fresh token.
+//
+// Pass the result to [WithHTTPClient] or [WithSSEHTTPClient] to authenticate a
+// remote MCP transport:
+//
+//	ts, _ := mcp.NewOAuthTokenSource(ctx, cfg)
+//	hc := mcp.NewOAuthHTTPClient(ts, nil)
+//	transport := mcp.NewHTTPTransport(serverURL, mcp.WithHTTPClient(hc))
+//
+// base may be nil, in which case http.DefaultClient is used as the underlying
+// client.
+func NewOAuthHTTPClient(ts provider.TokenSource, base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	baseTransport := base.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	c := *base
+	c.Transport = &oauthRoundTripper{base: baseTransport, ts: ts}
+	return &c
+}
+
+type oauthRoundTripper struct {
+	base http.RoundTripper
+	ts   provider.TokenSource
+}
+
+func (rt *oauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := rt.ts.Token(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	resp, err := rt.base.RoundTrip(withBearer(req, token))
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	inv, ok := rt.ts.(provider.InvalidatingTokenSource)
+	if !ok {
+		return resp, nil
+	}
+
+	// Drop the unauthorized response and retry once with a refreshed token.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	inv.Invalidate()
+
+	token, err = rt.ts.Token(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	retryReq, err := cloneWithBody(req)
+	if err != nil {
+		return nil, err
+	}
+	return rt.base.RoundTrip(withBearer(retryReq, token))
+}
+
+// withBearer clones req and sets the Authorization header, leaving the original
+// request (and its headers) untouched.
+func withBearer(req *http.Request, token string) *http.Request {
+	r := req.Clone(req.Context())
+	r.Header.Set("Authorization", "Bearer "+token)
+	return r
+}
+
+// cloneWithBody clones req with a fresh body for a retry. Requests built with
+// net/http carry a GetBody for in-memory bodies (bytes/strings readers), which
+// the MCP transports use, so the retry can re-send the payload.
+func cloneWithBody(req *http.Request) (*http.Request, error) {
+	r := req.Clone(req.Context())
+	if req.Body != nil && req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("mcp: rewind request body for retry: %w", err)
+		}
+		r.Body = body
+	}
+	return r, nil
+}
+
+// codeFromRedirect extracts the authorization code from the value returned by an
+// [AuthorizeFunc]. If the value parses as a URL carrying query parameters, the
+// "error" parameter is surfaced and "state" is validated against want. If it
+// carries no recognizable query parameters, it is treated as the bare code.
+func codeFromRedirect(redirect, want string) (string, error) {
+	if redirect == "" {
+		return "", errors.New("mcp: authorization returned empty redirect")
+	}
+	// Treat the value as a redirect URL only when it clearly is one (scheme and
+	// host present); otherwise it is the bare authorization code.
+	u, err := url.Parse(redirect)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return redirect, nil
+	}
+	q := u.Query()
+	if e := q.Get("error"); e != "" {
+		if desc := q.Get("error_description"); desc != "" {
+			return "", fmt.Errorf("mcp: authorization error %q: %s", e, desc)
+		}
+		return "", fmt.Errorf("mcp: authorization error %q", e)
+	}
+	if got := q.Get("state"); got != want {
+		return "", errors.New("mcp: authorization state mismatch")
+	}
+	code := q.Get("code")
+	if code == "" {
+		return "", errors.New("mcp: authorization redirect missing code")
+	}
+	return code, nil
+}
+
+// expired returns a shallow copy of tok with its expiry set in the past, so
+// oauth2's TokenSource treats it as invalid and performs a refresh.
+func expired(tok *oauth2.Token) *oauth2.Token {
+	clone := *tok
+	clone.Expiry = time.Now().Add(-time.Hour)
+	return &clone
+}
+
+// randomState returns a cryptographically random, URL-safe CSRF state token.
+func randomState() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("mcp: generate state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// originOf returns the scheme://host[:port] origin of a URL.
+func originOf(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("mcp: parse server URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("mcp: invalid server URL %q", raw)
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+// getJSON performs a GET and decodes a JSON object body. Non-200 responses and
+// non-object bodies return an error.
+func getJSON(ctx context.Context, hc *http.Client, url string) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("mcp: GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// strFromJSON returns v as a string when it is one, else "".
+func strFromJSON(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/mcp/oauth_test.go
+++ b/mcp/oauth_test.go
@@ -1,0 +1,648 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+// oauthServer is a configurable mock that serves the discovery, registration,
+// and token endpoints needed by the OAuth token source.
+type oauthServer struct {
+	mu sync.Mutex
+
+	srv *httptest.Server
+
+	// toggles
+	protectedResource bool // serve RFC 9728 pointing at this server
+	asMetadata        bool // serve RFC 8414
+	registration      bool // serve registration endpoint
+
+	// captured / canned values
+	issuedClientID   string
+	lastTokenForm    url.Values
+	refreshCount     int32
+	accessToken      string
+	refreshToken     string
+	tokenExpiresIn   int
+	registrationCode int  // optional override status for registration
+	failRefresh      bool // reject refresh_token grants with HTTP 400
+}
+
+func newOAuthServer() *oauthServer {
+	o := &oauthServer{
+		protectedResource: true,
+		asMetadata:        true,
+		registration:      true,
+		issuedClientID:    "dyn-client-123",
+		accessToken:       "access-1",
+		refreshToken:      "refresh-1",
+		tokenExpiresIn:    3600,
+	}
+	o.srv = httptest.NewServer(http.HandlerFunc(o.handle))
+	return o
+}
+
+func (o *oauthServer) URL() string { return o.srv.URL + "/mcp" }
+func (o *oauthServer) Close()      { o.srv.Close() }
+
+func (o *oauthServer) handle(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/.well-known/oauth-protected-resource":
+		if !o.protectedResource {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"authorization_servers": []string{o.srv.URL},
+		})
+	case "/.well-known/oauth-authorization-server":
+		if !o.asMetadata {
+			http.NotFound(w, r)
+			return
+		}
+		md := map[string]any{
+			"issuer":                 o.srv.URL,
+			"authorization_endpoint": o.srv.URL + "/authorize",
+			"token_endpoint":         o.srv.URL + "/token",
+		}
+		if o.registration {
+			md["registration_endpoint"] = o.srv.URL + "/register"
+		}
+		writeJSON(w, md)
+	case "/register":
+		if o.registrationCode != 0 {
+			w.WriteHeader(o.registrationCode)
+			return
+		}
+		writeJSON(w, map[string]any{"client_id": o.issuedClientID})
+	case "/token":
+		_ = r.ParseForm()
+		o.mu.Lock()
+		o.lastTokenForm = r.PostForm
+		isRefresh := r.PostForm.Get("grant_type") == "refresh_token"
+		if isRefresh {
+			atomic.AddInt32(&o.refreshCount, 1)
+		}
+		failRefresh := o.failRefresh
+		access := o.accessToken
+		refresh := o.refreshToken
+		expiresIn := o.tokenExpiresIn
+		o.mu.Unlock()
+		if isRefresh && failRefresh {
+			http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{
+			"access_token":  access,
+			"token_type":    "Bearer",
+			"refresh_token": refresh,
+		}
+		if expiresIn > 0 {
+			resp["expires_in"] = expiresIn
+		}
+		writeJSON(w, resp)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// ── DiscoverAuth ────────────────────────────────────────────────────────────
+
+func TestDiscoverAuth_Chain(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+
+	md, err := DiscoverAuth(context.Background(), o.URL(), nil)
+	if err != nil {
+		t.Fatalf("DiscoverAuth: %v", err)
+	}
+	if md.AuthorizationEndpoint != o.srv.URL+"/authorize" {
+		t.Errorf("AuthorizationEndpoint = %q", md.AuthorizationEndpoint)
+	}
+	if md.TokenEndpoint != o.srv.URL+"/token" {
+		t.Errorf("TokenEndpoint = %q", md.TokenEndpoint)
+	}
+	if md.RegistrationEndpoint != o.srv.URL+"/register" {
+		t.Errorf("RegistrationEndpoint = %q", md.RegistrationEndpoint)
+	}
+	if md.Issuer != o.srv.URL {
+		t.Errorf("Issuer = %q", md.Issuer)
+	}
+}
+
+func TestDiscoverAuth_FallbackToOrigin(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+	o.protectedResource = false // no RFC 9728; must fall back to origin RFC 8414
+
+	md, err := DiscoverAuth(context.Background(), o.URL(), o.srv.Client())
+	if err != nil {
+		t.Fatalf("DiscoverAuth: %v", err)
+	}
+	if md.AuthorizationEndpoint == "" {
+		t.Error("expected authorization endpoint via origin fallback")
+	}
+}
+
+func TestDiscoverAuth_NotFound(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+	o.protectedResource = false
+	o.asMetadata = false
+
+	if _, err := DiscoverAuth(context.Background(), o.URL(), nil); err == nil {
+		t.Fatal("expected error when no metadata is served")
+	}
+}
+
+func TestDiscoverAuth_InvalidURL(t *testing.T) {
+	if _, err := DiscoverAuth(context.Background(), "not-a-url", nil); err == nil {
+		t.Fatal("expected error for URL without scheme/host")
+	}
+}
+
+// ── RegisterClient ──────────────────────────────────────────────────────────
+
+func TestRegisterClient(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+
+	id, err := RegisterClient(context.Background(), o.srv.URL+"/register", ClientRegistration{
+		ClientName:   "goai-test",
+		RedirectURIs: []string{"http://localhost/cb"},
+		Scopes:       []string{"a", "b"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+	if id != o.issuedClientID {
+		t.Errorf("client_id = %q, want %q", id, o.issuedClientID)
+	}
+}
+
+func TestRegisterClient_HTTPError(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+	o.registrationCode = http.StatusBadRequest
+
+	if _, err := RegisterClient(context.Background(), o.srv.URL+"/register", ClientRegistration{}, nil); err == nil {
+		t.Fatal("expected error on 400 registration response")
+	}
+}
+
+func TestRegisterClient_MissingClientID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{})
+	}))
+	defer srv.Close()
+
+	if _, err := RegisterClient(context.Background(), srv.URL, ClientRegistration{}, nil); err == nil {
+		t.Fatal("expected error when response omits client_id")
+	}
+}
+
+// ── PKCE ────────────────────────────────────────────────────────────────────
+
+func TestGeneratePKCE(t *testing.T) {
+	verifier, challenge := GeneratePKCE()
+	if verifier == "" || challenge == "" {
+		t.Fatal("empty PKCE values")
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if challenge != want {
+		t.Errorf("challenge = %q, want %q", challenge, want)
+	}
+	if v2, _ := GeneratePKCE(); v2 == verifier {
+		t.Error("expected distinct verifiers across calls")
+	}
+}
+
+// ── MemoryTokenStore ────────────────────────────────────────────────────────
+
+func TestMemoryTokenStore(t *testing.T) {
+	s := NewMemoryTokenStore()
+	if _, ok := s.Get("k"); ok {
+		t.Fatal("expected miss on empty store")
+	}
+	tok := &oauth2.Token{AccessToken: "x"}
+	if err := s.Set("k", tok); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := s.Get("k")
+	if !ok || got.AccessToken != "x" {
+		t.Fatalf("Get = %v, %v", got, ok)
+	}
+	if err := s.Delete("k"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.Get("k"); ok {
+		t.Fatal("expected miss after Delete")
+	}
+}
+
+// ── NewOAuthTokenSource: full authorization flow ────────────────────────────
+
+func TestOAuthTokenSource_AuthorizeFlow(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+
+	var seenAuthURL string
+	cfg := OAuthConfig{
+		ServerURL:   o.URL(),
+		ClientName:  "goai-test",
+		RedirectURI: "http://localhost:0/cb",
+		Scopes:      []string{"read"},
+		HTTPClient:  o.srv.Client(),
+		Authorize: func(_ context.Context, authURL string) (string, error) {
+			seenAuthURL = authURL
+			// Echo back a redirect carrying the state the SDK generated.
+			u, _ := url.Parse(authURL)
+			state := u.Query().Get("state")
+			return "http://localhost:0/cb?code=the-code&state=" + url.QueryEscape(state), nil
+		},
+	}
+
+	ts, err := NewOAuthTokenSource(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	tok, err := ts.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != o.accessToken {
+		t.Errorf("token = %q, want %q", tok, o.accessToken)
+	}
+
+	// Authorization URL must carry PKCE S256 + client_id from dynamic registration.
+	au, _ := url.Parse(seenAuthURL)
+	q := au.Query()
+	if q.Get("code_challenge_method") != "S256" || q.Get("code_challenge") == "" {
+		t.Error("authorization URL missing PKCE challenge")
+	}
+	if q.Get("client_id") != o.issuedClientID {
+		t.Errorf("client_id = %q, want %q", q.Get("client_id"), o.issuedClientID)
+	}
+	// Token endpoint must have received the code_verifier.
+	if o.lastTokenForm.Get("code_verifier") == "" {
+		t.Error("token exchange missing code_verifier")
+	}
+
+	// Second call returns the cached token without re-authorizing.
+	o.mu.Lock()
+	o.accessToken = "should-not-be-used"
+	o.mu.Unlock()
+	tok2, err := ts.Token(context.Background())
+	if err != nil || tok2 != "access-1" {
+		t.Fatalf("cached Token = %q, %v", tok2, err)
+	}
+}
+
+func TestOAuthTokenSource_NoAuthorizeCallback(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static",
+		HTTPClient: o.srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	if _, err := ts.Token(context.Background()); !errors.Is(err, ErrAuthorizationRequired) {
+		t.Fatalf("err = %v, want ErrAuthorizationRequired", err)
+	}
+}
+
+func TestOAuthTokenSource_RefreshOnExpiry(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+
+	store := NewMemoryTokenStore()
+	_ = store.Set(o.URL(), &oauth2.Token{
+		AccessToken:  "old",
+		RefreshToken: "refresh-1",
+		Expiry:       time.Now().Add(-time.Minute), // already expired
+	})
+
+	o.mu.Lock()
+	o.accessToken = "refreshed"
+	o.mu.Unlock()
+
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static",
+		Metadata:   &AuthServerMetadata{AuthorizationEndpoint: o.srv.URL + "/authorize", TokenEndpoint: o.srv.URL + "/token"},
+		Store:      store,
+		HTTPClient: o.srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	tok, err := ts.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "refreshed" {
+		t.Errorf("token = %q, want refreshed", tok)
+	}
+	if atomic.LoadInt32(&o.refreshCount) != 1 {
+		t.Errorf("refresh count = %d, want 1", o.refreshCount)
+	}
+}
+
+func TestOAuthTokenSource_InvalidateForcesRefresh(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+
+	store := NewMemoryTokenStore()
+	_ = store.Set(o.URL(), &oauth2.Token{
+		AccessToken:  "valid-but-rejected",
+		RefreshToken: "refresh-1",
+		Expiry:       time.Now().Add(time.Hour), // still valid by clock
+	})
+
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static",
+		Metadata:   &AuthServerMetadata{AuthorizationEndpoint: o.srv.URL + "/authorize", TokenEndpoint: o.srv.URL + "/token"},
+		Store:      store,
+		HTTPClient: o.srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+
+	inv, ok := ts.(provider.InvalidatingTokenSource)
+	if !ok {
+		t.Fatal("token source must implement InvalidatingTokenSource")
+	}
+	inv.Invalidate()
+
+	if _, err := ts.Token(context.Background()); err != nil {
+		t.Fatalf("Token after Invalidate: %v", err)
+	}
+	if atomic.LoadInt32(&o.refreshCount) != 1 {
+		t.Errorf("refresh count = %d, want 1 (Invalidate should force refresh)", o.refreshCount)
+	}
+}
+
+// ── NewOAuthHTTPClient round tripper ────────────────────────────────────────
+
+func TestNewOAuthHTTPClient_InjectsBearerAndRetriesOn401(t *testing.T) {
+	var calls int32
+	var seenTokens []string
+	resource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenTokens = append(seenTokens, r.Header.Get("Authorization"))
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Echo body to verify it was re-sent on retry.
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer resource.Close()
+
+	ts := &fakeInvalidatingTS{tokens: []string{"first", "second"}}
+	hc := NewOAuthHTTPClient(ts, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, resource.URL, strings.NewReader(`{"jsonrpc":"2.0"}`))
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (one 401 + one retry)", calls)
+	}
+	if seenTokens[0] != "Bearer first" || seenTokens[1] != "Bearer second" {
+		t.Errorf("tokens = %v, want [Bearer first, Bearer second]", seenTokens)
+	}
+	if !ts.invalidated {
+		t.Error("expected Invalidate to be called on 401")
+	}
+}
+
+func TestNewOAuthHTTPClient_NoRetryWhenNotInvalidating(t *testing.T) {
+	var calls int32
+	resource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer resource.Close()
+
+	// Plain TokenSource (no Invalidate) must not trigger a retry.
+	hc := NewOAuthHTTPClient(provider.StaticToken("tok"), nil)
+	req, _ := http.NewRequest(http.MethodGet, resource.URL, nil)
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retry without InvalidatingTokenSource)", calls)
+	}
+}
+
+func TestNewOAuthHTTPClient_TokenError(t *testing.T) {
+	hc := NewOAuthHTTPClient(&fakeErrTS{}, nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+	if _, err := hc.Do(req); err == nil {
+		t.Fatal("expected error when token source fails")
+	}
+}
+
+// ── codeFromRedirect ────────────────────────────────────────────────────────
+
+func TestCodeFromRedirect(t *testing.T) {
+	tests := []struct {
+		name     string
+		redirect string
+		want     string
+		wantState string
+		wantErr  bool
+	}{
+		{name: "full url", redirect: "http://cb?code=abc&state=s1", wantState: "s1", want: "abc"},
+		{name: "bare code", redirect: "abc", want: "abc"},
+		{name: "state mismatch", redirect: "http://cb?code=abc&state=other", wantState: "s1", wantErr: true},
+		{name: "error param", redirect: "http://cb?error=access_denied&error_description=no", wantState: "s1", wantErr: true},
+		{name: "missing code", redirect: "http://cb?state=s1", wantState: "s1", wantErr: true},
+		{name: "empty", redirect: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := codeFromRedirect(tc.redirect, tc.wantState)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("code = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOAuthTokenSource_AuthorizeError(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static",
+		HTTPClient: o.srv.Client(),
+		Authorize: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("user cancelled")
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	if _, err := ts.Token(context.Background()); err == nil || !strings.Contains(err.Error(), "user cancelled") {
+		t.Fatalf("err = %v, want authorization error", err)
+	}
+}
+
+func TestOAuthTokenSource_RefreshFailsFallsBackToAuthorize(t *testing.T) {
+	o := newOAuthServer()
+	o.failRefresh = true // refresh grant is rejected, forcing re-authorization
+	o.accessToken = "after-reauth"
+	defer o.Close()
+
+	store := NewMemoryTokenStore()
+	_ = store.Set(o.URL(), &oauth2.Token{
+		AccessToken:  "old",
+		RefreshToken: "revoked",
+		Expiry:       time.Now().Add(-time.Minute),
+	})
+
+	var authorized bool
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL: o.URL(),
+		ClientID:  "static",
+		Metadata: &AuthServerMetadata{
+			AuthorizationEndpoint: o.srv.URL + "/authorize",
+			TokenEndpoint:         o.srv.URL + "/token",
+		},
+		Store:      store,
+		HTTPClient: o.srv.Client(),
+		Authorize: func(_ context.Context, authURL string) (string, error) {
+			authorized = true
+			u, _ := url.Parse(authURL)
+			return "http://cb?code=fresh-code&state=" + url.QueryEscape(u.Query().Get("state")), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	tok, err := ts.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if !authorized {
+		t.Error("expected fallback to interactive authorization after refresh failure")
+	}
+	if tok != "after-reauth" {
+		t.Errorf("token = %q, want after-reauth", tok)
+	}
+}
+
+func TestNewOAuthTokenSource_DiscoveryFails(t *testing.T) {
+	o := newOAuthServer()
+	o.protectedResource = false
+	o.asMetadata = false
+	defer o.Close()
+
+	if _, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static", // skip registration; isolate discovery failure
+		HTTPClient: o.srv.Client(),
+	}); err == nil {
+		t.Fatal("expected discovery failure error")
+	}
+}
+
+func TestNewOAuthTokenSource_RegistrationFails(t *testing.T) {
+	o := newOAuthServer()
+	o.registrationCode = http.StatusInternalServerError
+	defer o.Close()
+
+	if _, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		HTTPClient: o.srv.Client(),
+	}); err == nil {
+		t.Fatal("expected registration failure error")
+	}
+}
+
+func TestNewOAuthTokenSource_Validation(t *testing.T) {
+	if _, err := NewOAuthTokenSource(context.Background(), OAuthConfig{}); err == nil {
+		t.Fatal("expected error when ServerURL is empty")
+	}
+
+	// No ClientID and no registration endpoint → error.
+	o := newOAuthServer()
+	defer o.Close()
+	o.registration = false
+	if _, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		HTTPClient: o.srv.Client(),
+	}); err == nil {
+		t.Fatal("expected error when no client_id and no registration endpoint")
+	}
+}
+
+// ── test doubles ────────────────────────────────────────────────────────────
+
+type fakeInvalidatingTS struct {
+	tokens      []string
+	idx         int
+	invalidated bool
+}
+
+func (f *fakeInvalidatingTS) Token(_ context.Context) (string, error) {
+	tok := f.tokens[f.idx]
+	if f.idx < len(f.tokens)-1 {
+		f.idx++
+	}
+	return tok, nil
+}
+
+func (f *fakeInvalidatingTS) Invalidate() { f.invalidated = true }
+
+type fakeErrTS struct{}
+
+func (fakeErrTS) Token(_ context.Context) (string, error) {
+	return "", errors.New("boom")
+}

--- a/mcp/oauth_test.go
+++ b/mcp/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -41,6 +42,7 @@ type oauthServer struct {
 	tokenExpiresIn   int
 	registrationCode int  // optional override status for registration
 	failRefresh      bool // reject refresh_token grants with HTTP 400
+	failExchange     bool // reject authorization_code grants with HTTP 400
 }
 
 func newOAuthServer() *oauthServer {
@@ -104,6 +106,13 @@ func (o *oauthServer) handle(w http.ResponseWriter, r *http.Request) {
 		expiresIn := o.tokenExpiresIn
 		o.mu.Unlock()
 		if isRefresh && failRefresh {
+			http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+			return
+		}
+		o.mu.Lock()
+		failExchange := o.failExchange
+		o.mu.Unlock()
+		if !isRefresh && failExchange {
 			http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
 			return
 		}
@@ -623,15 +632,188 @@ func TestNewOAuthTokenSource_Validation(t *testing.T) {
 	}
 }
 
+// ── error-path coverage ─────────────────────────────────────────────────────
+
+func TestDiscoverAuth_NetworkError(t *testing.T) {
+	// Dead host: every getJSON GET fails, DiscoverAuth returns not-found.
+	if _, err := DiscoverAuth(context.Background(), "http://127.0.0.1:1/mcp", nil); err == nil {
+		t.Fatal("expected error against dead host")
+	}
+}
+
+func TestDiscoverAuth_NonJSONProtectedResource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			_, _ = w.Write([]byte("not json")) // getJSON decode error (swallowed)
+		case "/.well-known/oauth-authorization-server":
+			writeJSON(w, map[string]any{"authorization_endpoint": r.Host + "/a", "token_endpoint": "/t"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	if _, err := DiscoverAuth(context.Background(), srv.URL+"/mcp", srv.Client()); err != nil {
+		t.Fatalf("expected fallback to succeed, got %v", err)
+	}
+}
+
+func TestDiscoverAuth_ASMetadataMissingAuthEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-authorization-server" {
+			writeJSON(w, map[string]any{"token_endpoint": "/t"}) // no authorization_endpoint -> continue
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	if _, err := DiscoverAuth(context.Background(), srv.URL+"/mcp", srv.Client()); err == nil {
+		t.Fatal("expected error when AS metadata lacks authorization_endpoint")
+	}
+}
+
+func TestOriginOf_ParseError(t *testing.T) {
+	// A control character makes url.Parse fail outright.
+	if _, err := DiscoverAuth(context.Background(), "http://exa\x7fmple", nil); err == nil {
+		t.Fatal("expected parse error for malformed URL")
+	}
+}
+
+func TestRegisterClient_NetworkError(t *testing.T) {
+	if _, err := RegisterClient(context.Background(), "http://127.0.0.1:1/register", ClientRegistration{}, nil); err == nil {
+		t.Fatal("expected network error")
+	}
+}
+
+func TestNewOAuthTokenSource_NilHTTPClient(t *testing.T) {
+	// Metadata + ClientID provided: constructor needs no network and exercises
+	// the default-HTTPClient branch.
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL: "https://example.com/mcp",
+		ClientID:  "static",
+		Metadata:  &AuthServerMetadata{AuthorizationEndpoint: "https://as/authorize", TokenEndpoint: "https://as/token"},
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	if _, err := ts.Token(context.Background()); !errors.Is(err, ErrAuthorizationRequired) {
+		t.Fatalf("err = %v, want ErrAuthorizationRequired", err)
+	}
+}
+
+func TestOAuthTokenSource_BadRedirectFromAuthorize(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static",
+		HTTPClient: o.srv.Client(),
+		Authorize: func(_ context.Context, _ string) (string, error) {
+			return "http://cb?error=access_denied", nil // codeFromRedirect error
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	if _, err := ts.Token(context.Background()); err == nil {
+		t.Fatal("expected error from bad redirect")
+	}
+}
+
+func TestOAuthTokenSource_ExchangeError(t *testing.T) {
+	o := newOAuthServer()
+	o.failExchange = true
+	defer o.Close()
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static",
+		HTTPClient: o.srv.Client(),
+		Authorize: func(_ context.Context, authURL string) (string, error) {
+			u, _ := url.Parse(authURL)
+			return "http://cb?code=c&state=" + url.QueryEscape(u.Query().Get("state")), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	if _, err := ts.Token(context.Background()); err == nil {
+		t.Fatal("expected token exchange error")
+	}
+}
+
+func TestOAuthTokenSource_StoreSetError(t *testing.T) {
+	o := newOAuthServer()
+	defer o.Close()
+	ts, err := NewOAuthTokenSource(context.Background(), OAuthConfig{
+		ServerURL:  o.URL(),
+		ClientID:   "static",
+		Store:      failingStore{},
+		HTTPClient: o.srv.Client(),
+		Authorize: func(_ context.Context, authURL string) (string, error) {
+			u, _ := url.Parse(authURL)
+			return "http://cb?code=c&state=" + url.QueryEscape(u.Query().Get("state")), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewOAuthTokenSource: %v", err)
+	}
+	if _, err := ts.Token(context.Background()); err == nil {
+		t.Fatal("expected store.Set error")
+	}
+}
+
+func TestNewOAuthHTTPClient_TransportError(t *testing.T) {
+	// base.RoundTrip fails (connection refused).
+	hc := NewOAuthHTTPClient(provider.StaticToken("tok"), nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1:1", nil)
+	if _, err := hc.Do(req); err == nil {
+		t.Fatal("expected transport error")
+	}
+}
+
+func TestNewOAuthHTTPClient_RetryTokenError(t *testing.T) {
+	resource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer resource.Close()
+	// Errors on the second Token() call (the post-401 refresh).
+	ts := &fakeInvalidatingTS{tokens: []string{"first"}, errAfter: 1}
+	hc := NewOAuthHTTPClient(ts, nil)
+	req, _ := http.NewRequest(http.MethodGet, resource.URL, nil)
+	if _, err := hc.Do(req); err == nil {
+		t.Fatal("expected error when retry token fetch fails")
+	}
+}
+
+func TestNewOAuthHTTPClient_CloneBodyError(t *testing.T) {
+	resource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer resource.Close()
+	ts := &fakeInvalidatingTS{tokens: []string{"a", "b"}}
+	hc := NewOAuthHTTPClient(ts, nil)
+	req, _ := http.NewRequest(http.MethodPost, resource.URL, strings.NewReader("body"))
+	req.GetBody = func() (io.ReadCloser, error) { return nil, errors.New("rewind failed") }
+	if _, err := hc.Do(req); err == nil {
+		t.Fatal("expected clone body error on retry")
+	}
+}
+
 // ── test doubles ────────────────────────────────────────────────────────────
 
 type fakeInvalidatingTS struct {
 	tokens      []string
 	idx         int
+	calls       int
+	errAfter    int // when >0, Token returns an error on call number errAfter+
 	invalidated bool
 }
 
 func (f *fakeInvalidatingTS) Token(_ context.Context) (string, error) {
+	f.calls++
+	if f.errAfter > 0 && f.calls > f.errAfter {
+		return "", errors.New("token fetch failed")
+	}
 	tok := f.tokens[f.idx]
 	if f.idx < len(f.tokens)-1 {
 		f.idx++
@@ -646,3 +828,10 @@ type fakeErrTS struct{}
 func (fakeErrTS) Token(_ context.Context) (string, error) {
 	return "", errors.New("boom")
 }
+
+// failingStore returns an error from Set to exercise persistence error paths.
+type failingStore struct{}
+
+func (failingStore) Get(string) (*oauth2.Token, bool) { return nil, false }
+func (failingStore) Set(string, *oauth2.Token) error  { return errors.New("store failed") }
+func (failingStore) Delete(string) error              { return nil }


### PR DESCRIPTION
Closes #78.

Adds native OAuth 2.1 + PKCE support to the MCP client so OAuth-protected
remote servers no longer require the external `mcp-remote` wrapper. Built on
`golang.org/x/oauth2` (already a dependency) and wired through the existing
`WithHTTPClient` option, so **no transport changes are needed**.

## What's included

**`mcp/oauth.go`** — all OAuth logic in one file:

- `DiscoverAuth` — authorization-server discovery (RFC 9728 → RFC 8414)
- `RegisterClient` — dynamic client registration (RFC 7591)
- `GeneratePKCE` — S256 PKCE helpers (RFC 7636)
- `TokenStore` + `NewMemoryTokenStore` — pluggable token persistence
- `NewOAuthTokenSource` — returns a `provider.TokenSource` (implementing
  `provider.InvalidatingTokenSource`) that caches the access token, refreshes
  it with the refresh token, and runs the interactive authorization-code flow
  via an `Authorize` callback (the `OnAuthorizationRequired` hook requested in
  the issue)
- `NewOAuthHTTPClient` — an `http.RoundTripper` that injects the bearer token
  and transparently refreshes + retries once on HTTP 401

This follows the SDK's established auth philosophy (`provider.TokenSource` /
`CachedTokenSource`, as in `provider/vertex/adc.go`) and is the first consumer
of the previously-unused `InvalidatingTokenSource.Invalidate()` contract.

Usage:

```go
ts, _ := mcp.NewOAuthTokenSource(ctx, mcp.OAuthConfig{
    ServerURL:   serverURL,
    RedirectURI: "http://127.0.0.1:8765/callback",
    Authorize:   openBrowserAndAwaitRedirect, // returns the OAuth redirect URL
})
transport := mcp.NewHTTPTransport(serverURL, mcp.WithHTTPClient(mcp.NewOAuthHTTPClient(ts, nil)))
client := mcp.NewClient("my-app", "1.0", mcp.WithTransport(transport))
```

## Separate fix (second commit)

`fix(gemini): strip $schema/$id/$comment meta keywords from tool schemas` — a
pre-existing, independent bug surfaced while testing the example: Gemini's
OpenAPI-subset schema rejects the JSON Schema meta keywords `$schema`, `$id`,
and `$comment`. MCP tool `inputSchema`s commonly carry a top-level `$schema`,
so converting MCP tools for Gemini/Vertex failed with
`Invalid JSON payload ... Unknown name "$schema"`. `SanitizeSchema` already
strips `$defs`/`if`/`then`/`else`; this extends the blocklist. Happy to split
this into its own PR if preferred.

## Docs & example

- `examples/mcp-oauth/main.go` — complete loopback authorization flow, plus an
  optional Gemini step using the MCP tools when `GEMINI_API_KEY` is set
- README MCP section updated with an OAuth snippet
- Public API documented via function-level godoc

## Testing

- Tests use mock HTTP servers (`net/http/httptest`); `mcp/oauth.go` statement
  coverage is 90%; `internal/gemini` stays at 99%
- `go build ./...`, `go vet`, and `golangci-lint` all clean
- Verified end-to-end against real OAuth MCP servers: `DiscoverAuth` confirmed
  against Linear, Sentry, and Notion; full interactive flow (discovery → DCR →
  PKCE → token exchange → connect → tool call → Gemini using the tools)
  verified against Context7