### PR TITLE
feat: surface hook and predicate panics instead of swallowing them

### DIFF
--- a/agent_state_test.go
+++ b/agent_state_test.go
@@ -646,9 +646,10 @@ func TestWithStopWhen_NilPredicate_NoOp(t *testing.T) {
 	}
 }
 
-// TestWithStopWhen_Panic_Recovered: a panicking predicate is treated as "do
-// not stop" and logged; loop continues normally.
-func TestWithStopWhen_Panic_Recovered(t *testing.T) {
+// TestWithStopWhen_Panic_Propagates: a panicking predicate is surfaced as a
+// *PanicError returned from GenerateText, and the loop stops immediately. When
+// the panic value is an error, PanicError.Unwrap exposes it.
+func TestWithStopWhen_Panic_Propagates(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	var callCount atomic.Int32
@@ -666,17 +667,25 @@ func TestWithStopWhen_Panic_Recovered(t *testing.T) {
 			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop, Usage: provider.Usage{InputTokens: 1, OutputTokens: 1}}, nil
 		},
 	}
+	boom := errors.New("boom")
 	_, err := GenerateText(t.Context(), model,
 		WithPrompt("go"),
 		WithMaxSteps(5),
 		WithTools(Tool{Name: "t", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
-		WithStopWhen(func(steps []StepResult) bool { panic(errors.New("boom")) }),
+		WithStopWhen(func(steps []StepResult) bool { panic(boom) }),
 	)
-	if err != nil {
-		t.Fatal(err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if callCount.Load() != 2 {
-		t.Errorf("callCount=%d want 2 (loop should have proceeded past panic)", callCount.Load())
+	if pe.Phase != "StopWhen" {
+		t.Errorf("Phase = %q, want StopWhen", pe.Phase)
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("errors.Is(err, boom) = false; PanicError.Unwrap should expose the error panic value")
+	}
+	if callCount.Load() != 1 {
+		t.Errorf("callCount=%d want 1 (loop should stop at the panicking predicate)", callCount.Load())
 	}
 }
 
@@ -1631,7 +1640,7 @@ func TestStopSafe_AliasingContract_ShallowCloneIsolatesTopLevel(t *testing.T) {
 		_ = steps
 		return false
 	})
-	stop := stopSafe(pred, internal)
+	stop := stopSafe(nil, pred, internal)
 	if stop {
 		t.Fatalf("stopSafe returned true; predicate returned false")
 	}
@@ -1665,7 +1674,7 @@ func TestStopSafe_AliasingContract_ShallowCloneIsolatesTopLevel(t *testing.T) {
 		}
 		return false
 	})
-	if stopSafe(hazardous, internal) {
+	if stopSafe(nil, hazardous, internal) {
 		t.Fatalf("hazardous predicate returned false but stopSafe reported true")
 	}
 	if got := internal[0].ToolResults[0].Output; got != "CORRUPTED_BY_PREDICATE" {

--- a/errors.go
+++ b/errors.go
@@ -28,20 +28,30 @@ func (e *ContextOverflowError) Error() string {
 // OnBeforeToolExecute, OnAfterToolExecute) are NOT wrapped in a PanicError:
 // they keep their resilient behavior (converted to a tool error, the agent
 // loop continues). They are still reported to any OnPanic hook.
+//
+// Value and Stack may contain sensitive data (panic arguments, captured
+// variables, credentials). They are deliberately NOT included in Error() so a
+// logged error string cannot leak them; access the fields explicitly and
+// sanitize before logging or exporting.
 type PanicError struct {
 	// Phase identifies the callback that panicked, e.g. "OnStepFinish",
 	// "OnFinish", "OnResponse", "OnRequest", "OnBeforeStep", "StopWhen".
 	Phase string
 
-	// Value is the value passed to panic().
+	// Value is the value passed to panic(). May contain sensitive data; see the
+	// type doc. Not included in Error().
 	Value any
 
-	// Stack is the goroutine stack captured at the recovery point.
+	// Stack is the goroutine stack captured at the recovery point. May contain
+	// sensitive data; see the type doc. Not included in Error().
 	Stack []byte
 }
 
+// Error returns a message identifying the phase only. The panic value is
+// intentionally omitted to avoid leaking sensitive data into logged error
+// strings; read Value/Unwrap for the underlying cause.
 func (e *PanicError) Error() string {
-	return fmt.Sprintf("goai: panic in %s: %v", e.Phase, e.Value)
+	return fmt.Sprintf("goai: panic in %s", e.Phase)
 }
 
 // Unwrap returns the panic value if it is itself an error, enabling

--- a/errors.go
+++ b/errors.go
@@ -18,6 +18,41 @@ func (e *ContextOverflowError) Error() string {
 	return e.Message
 }
 
+// PanicError wraps a value recovered from a panic in a user-provided callback
+// (a lifecycle hook or the StopWhen predicate). It is returned by GenerateText
+// and GenerateObject, and surfaced through stream.Err() for StreamText and
+// StreamObject, so callers can intercept callback panics programmatically
+// instead of having them swallowed.
+//
+// Panics inside the tool path (tool Execute, OnToolCallStart, OnToolCall,
+// OnBeforeToolExecute, OnAfterToolExecute) are NOT wrapped in a PanicError:
+// they keep their resilient behavior (converted to a tool error, the agent
+// loop continues). They are still reported to any OnPanic hook.
+type PanicError struct {
+	// Phase identifies the callback that panicked, e.g. "OnStepFinish",
+	// "OnFinish", "OnResponse", "OnRequest", "OnBeforeStep", "StopWhen".
+	Phase string
+
+	// Value is the value passed to panic().
+	Value any
+
+	// Stack is the goroutine stack captured at the recovery point.
+	Stack []byte
+}
+
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("goai: panic in %s: %v", e.Phase, e.Value)
+}
+
+// Unwrap returns the panic value if it is itself an error, enabling
+// errors.Is/errors.As against the original cause; otherwise it returns nil.
+func (e *PanicError) Unwrap() error {
+	if err, ok := e.Value.(error); ok {
+		return err
+	}
+	return nil
+}
+
 // APIError represents a non-overflow API error.
 type APIError struct {
 	Message         string

--- a/generate.go
+++ b/generate.go
@@ -642,9 +642,14 @@ func buildParams(opts options) provider.GenerateParams {
 	}
 }
 
-func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o options, toolMap map[string]Tool) (*TextStream, error) {
+func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o options, toolMap map[string]Tool) (_ *TextStream, err error) {
 	params := buildParams(o)
 	originalLen := len(params.Messages)
+
+	// Convert a *PanicError from a synchronous step-1 hook (OnRequest, or
+	// OnResponse on the initial DoStream error) into the returned error. Hooks
+	// fired inside the streaming goroutine surface through stream.Err().
+	defer recoverToError(&err)
 
 	var timeoutCancel context.CancelFunc
 	if o.Timeout > 0 {
@@ -659,21 +664,23 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 	// fails, regardless of MaxSteps. Eliminates the split error contract.
 	o.StateRef.set(StepLLMInFlight, 1)
 	for _, fn := range o.OnRequest {
-		fn(RequestInfo{
-			Ctx:          ctx,
-			Model:        model.ModelID(),
-			MessageCount: len(params.Messages),
-			ToolCount:    len(params.Tools),
-			Timestamp:    time.Now(),
-			Messages:     requestMessages(params.System, params.Messages),
+		callHook(o.OnPanic, "OnRequest", func() {
+			fn(RequestInfo{
+				Ctx:          ctx,
+				Model:        model.ModelID(),
+				MessageCount: len(params.Messages),
+				ToolCount:    len(params.Tools),
+				Timestamp:    time.Now(),
+				Messages:     requestMessages(params.System, params.Messages),
+			})
 		})
 	}
 
 	start := time.Now()
-	firstResult, err := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+	firstResult, streamErr := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
-	if err != nil {
+	if streamErr != nil {
 		if timeoutCancel != nil {
 			timeoutCancel()
 		}
@@ -681,18 +688,17 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		// already moved the step counter to 1 (StepLLMInFlight, 1); a poller
 		// observing between the two stores must not see step regress to 0.
 		o.StateRef.set(StepIdle, 1)
-		// OnRequest/OnResponse: not recover-wrapped (caller's goroutine).
-		// OnStepFinish: always recover-wrapped (prevents losing accumulated results).
-		// Inside goroutines: all hooks recover-wrapped.
+		// Step-1 OnResponse runs in the caller's goroutine; callHook surfaces a
+		// panic as a *PanicError via the deferred recoverToError above.
 		for _, fn := range o.OnResponse {
-			info := ResponseInfo{Latency: time.Since(start), Error: err}
+			info := ResponseInfo{Latency: time.Since(start), Error: streamErr}
 			var apiErr *APIError
-			if errors.As(err, &apiErr) {
+			if errors.As(streamErr, &apiErr) {
 				info.StatusCode = apiErr.StatusCode
 			}
-			fn(info)
+			callHook(o.OnPanic, "OnResponse", func() { fn(info) })
 		}
-		return nil, err // SAME error contract as single-step StreamText
+		return nil, streamErr // SAME error contract as single-step StreamText
 	}
 
 	// Step 1 succeeded. Goroutine-local copy of start time avoids closure capture.
@@ -1046,12 +1052,17 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 // When MaxSteps > 1 and executable tools are provided, StreamText runs an automatic
 // tool loop. The initial DoStream failure still returns (nil, error). Subsequent step
 // errors flow through the stream as ChunkError chunks; check stream.Err() after consuming.
-func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Option) (*TextStream, error) {
+func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Option) (_ *TextStream, err error) {
 	// Apply options FIRST so o.StateRef is populated before any early return.
 	// This guarantees pollers waiting for StepIdle do not deadlock when we
 	// return (nil, err) before the streaming goroutine starts (e.g. nil model,
 	// empty prompt, initial DoStream failure).
 	o := applyOptions(opts...)
+
+	// Convert a *PanicError from a synchronous step-1 hook (OnRequest, or
+	// OnResponse on a DoStream error) into the returned error. Hooks fired in
+	// the consume goroutine surface through stream.Err() instead.
+	defer recoverToError(&err)
 
 	if model == nil {
 		// Transition StepStarting→StepIdle for any observer so pollers do not deadlock.
@@ -1090,21 +1101,23 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	o.StateRef.set(StepLLMInFlight, 1)
 
 	for _, fn := range o.OnRequest {
-		fn(RequestInfo{
-			Ctx:          ctx,
-			Model:        model.ModelID(),
-			MessageCount: len(params.Messages),
-			ToolCount:    len(params.Tools),
-			Timestamp:    time.Now(),
-			Messages:     requestMessages(params.System, params.Messages),
+		callHook(o.OnPanic, "OnRequest", func() {
+			fn(RequestInfo{
+				Ctx:          ctx,
+				Model:        model.ModelID(),
+				MessageCount: len(params.Messages),
+				ToolCount:    len(params.Tools),
+				Timestamp:    time.Now(),
+				Messages:     requestMessages(params.System, params.Messages),
+			})
 		})
 	}
 
 	start := time.Now()
-	result, err := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+	result, streamErr := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
-	if err != nil {
+	if streamErr != nil {
 		if timeoutCancel != nil {
 			timeoutCancel()
 		}
@@ -1117,14 +1130,14 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 		// see a monotonically non-decreasing step counter.
 		o.StateRef.set(StepIdle, 1)
 		for _, fn := range o.OnResponse {
-			info := ResponseInfo{Latency: time.Since(start), Error: err}
+			info := ResponseInfo{Latency: time.Since(start), Error: streamErr}
 			var apiErr *APIError
-			if errors.As(err, &apiErr) {
+			if errors.As(streamErr, &apiErr) {
 				info.StatusCode = apiErr.StatusCode
 			}
-			fn(info)
+			callHook(o.OnPanic, "OnResponse", func() { fn(info) })
 		}
-		return nil, err
+		return nil, streamErr
 	}
 
 	ts := newTextStream(ctx, result.Stream)

--- a/generate.go
+++ b/generate.go
@@ -1591,21 +1591,15 @@ func executeToolsParallel(
 			defer func() {
 				if r := recover(); r != nil {
 					if !executed {
-						// Distinguish OnToolCallStart panic from Execute panic.
+						// The full panic value + stack go to OnPanic (firePanic);
+						// the tool error sent to the LLM omits the raw value so a
+						// panic carrying sensitive data is not echoed to the model.
 						if !hookFired {
 							firePanic(hooks.onPanic, "OnToolCallStart", r)
+							results[i] = toolOutput{index: i, err: fmt.Errorf("goai: OnToolCallStart hook for tool %q panicked", tc.Name)}
 						} else {
 							firePanic(hooks.onPanic, "tool:"+tc.Name, r)
-						}
-						panicStr := fmt.Sprintf("%v", r)
-						runes := []rune(panicStr)
-						if len(runes) > 500 {
-							panicStr = string(runes[:500]) + "..."
-						}
-						if !hookFired {
-							results[i] = toolOutput{index: i, err: fmt.Errorf("goai: OnToolCallStart hook for tool %q panicked: %s", tc.Name, panicStr)}
-						} else {
-							results[i] = toolOutput{index: i, err: fmt.Errorf("goai: tool %q panicked: %s", tc.Name, panicStr)}
+							results[i] = toolOutput{index: i, err: fmt.Errorf("goai: tool %q panicked", tc.Name)}
 						}
 					}
 					// executed==true: Execute succeeded, results[i] already set.
@@ -1648,9 +1642,11 @@ func executeToolsParallel(
 					defer func() {
 						if r := recover(); r != nil {
 							firePanic(hooks.onPanic, "OnBeforeToolExecute", r)
+							// Raw value goes to OnPanic only; omit it here so a
+							// panic with sensitive data is not echoed to the model.
 							beforeResult = BeforeToolExecuteResult{
 								Skip:  true,
-								Error: fmt.Errorf("goai: OnBeforeToolExecute hook panicked: %v", r),
+								Error: errors.New("goai: OnBeforeToolExecute hook panicked"),
 							}
 						}
 					}()

--- a/generate.go
+++ b/generate.go
@@ -649,7 +649,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 	// Convert a *PanicError from a synchronous step-1 hook (OnRequest, or
 	// OnResponse on the initial DoStream error) into the returned error. Hooks
 	// fired inside the streaming goroutine surface through stream.Err().
-	defer recoverToError(&err)
+	defer recoverToError(o.OnPanic, &err)
 
 	var timeoutCancel context.CancelFunc
 	if o.Timeout > 0 {
@@ -1062,7 +1062,7 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	// Convert a *PanicError from a synchronous step-1 hook (OnRequest, or
 	// OnResponse on a DoStream error) into the returned error. Hooks fired in
 	// the consume goroutine surface through stream.Err() instead.
-	defer recoverToError(&err)
+	defer recoverToError(o.OnPanic, &err)
 
 	if model == nil {
 		// Transition StepStarting→StepIdle for any observer so pollers do not deadlock.
@@ -1167,7 +1167,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	// Convert a *PanicError raised by a panicking hook or the StopWhen predicate
 	// into the returned error. Registered first so it runs last (after the
 	// StepIdle transition below), catching panics from the whole body.
-	defer recoverToError(&err)
+	defer recoverToError(o.OnPanic, &err)
 
 	var steps []StepResult
 	// highestInflightStep tracks the largest step index we have announced

--- a/generate.go
+++ b/generate.go
@@ -716,8 +716,8 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		// runtime panic is wrapped here so the goroutine never crashes.
 		defer func() {
 			if r := recover(); r != nil {
-				pe, ok := r.(*PanicError)
-				if !ok {
+				pe := asPanicError(r)
+				if pe == nil {
 					pe = newPanicError(o.OnPanic, "stream", r)
 				}
 				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: pe})

--- a/generate.go
+++ b/generate.go
@@ -175,6 +175,7 @@ type TextStream struct {
 	onResponse   []func(ResponseInfo)
 	onStepFinish []func(StepResult)
 	onFinish     []func(FinishInfo)
+	onPanic      []func(PanicInfo)
 	startTime    time.Time
 
 	// stateRef, when non-nil, is transitioned to StepIdle when the consume
@@ -276,6 +277,15 @@ func (ts *TextStream) Err() error {
 
 func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<- string) {
 	defer close(ts.doneCh)
+	// Surface a panic from any user hook fired during teardown (OnStepFinish,
+	// OnResponse, OnFinish) through stream.Err(). Registered near the top so it
+	// runs after (LIFO) the hook defers below, catching panics they re-raise via
+	// callHook. A pre-existing stream error is preserved as the root cause.
+	defer recoverToStreamErr(ts.onPanic, "stream", func(e error) {
+		if ts.streamErr == nil {
+			ts.streamErr = e
+		}
+	})
 	// FIX 34: transition StateRef to StepIdle as the consume goroutine
 	// exits. Single-shot StreamText wires this (stateRef is nil for the
 	// multi-step streamWithToolLoop path, which owns its own StateRef
@@ -304,7 +314,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 	// Deferred BEFORE OnStepFinish so it runs AFTER it (LIFO order).
 	if len(ts.onFinish) > 0 {
 		defer func() {
-			fireOnFinish(ts.onFinish, FinishInfo{
+			fireOnFinish(ts.onPanic, ts.onFinish, FinishInfo{
 				TotalSteps:   1,
 				TotalUsage:   ts.usage,
 				FinishReason: ts.finishReason,
@@ -331,14 +341,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				ProviderMetadata: ts.providerMetadata,
 			}
 			for _, fn := range ts.onStepFinish {
-				func(f func(StepResult)) {
-					defer func() {
-						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-						}
-					}()
-					f(stepResult)
-				}(fn)
+				callHook(ts.onPanic, "OnStepFinish", func() { fn(stepResult) })
 			}
 		}()
 	}
@@ -357,14 +360,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				info.StatusCode = apiErr.StatusCode
 			}
 			for _, fn := range ts.onResponse {
-				func(f func(ResponseInfo)) {
-					defer func() {
-						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-						}
-					}()
-					f(info)
-				}(fn)
+				callHook(ts.onPanic, "OnResponse", func() { fn(info) })
 			}
 		}()
 	}
@@ -706,6 +702,22 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 
 	go func() {
 		defer close(out)
+		// Surface a panic from any inline-fired hook (OnBeforeStep, OnRequest,
+		// OnResponse, OnStepFinish) or the StopWhen predicate as a *PanicError
+		// on the stream: emit it as a ChunkError (consume sets stream.Err() from
+		// it) followed by a ChunkFinish so the stream terminates cleanly. The
+		// OnPanic observers already fired via callHook for a *PanicError; a raw
+		// runtime panic is wrapped here so the goroutine never crashes.
+		defer func() {
+			if r := recover(); r != nil {
+				pe, ok := r.(*PanicError)
+				if !ok {
+					pe = newPanicError(o.OnPanic, "stream", r)
+				}
+				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: pe})
+				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, StoppedBy: provider.StopCauseAbort})
+			}
+		}()
 		if timeoutCancel != nil {
 			defer timeoutCancel()
 		}
@@ -715,10 +727,10 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		var lastReasoning []provider.Part
 		var steps []StepResult
 		var stepsExhausted bool
-		var hookStopped bool              // true iff WithStopWhen or OnBeforeStep.Stop broke the loop
-		var stopCause provider.StopCause  // classifies how the loop exited (FIX 5)
-		firstStep := true                 // true only for step 1 (already have firstResult)
-		stepStart := step1Start           // goroutine-local start time per step
+		var hookStopped bool             // true iff WithStopWhen or OnBeforeStep.Stop broke the loop
+		var stopCause provider.StopCause // classifies how the loop exited (FIX 5)
+		firstStep := true                // true only for step 1 (already have firstResult)
+		stepStart := step1Start          // goroutine-local start time per step
 
 		// highestInflightStep tracks the maximum step counter announced via
 		// o.StateRef.set(StepLLMInFlight, ...). The deferred StepIdle publish
@@ -776,18 +788,13 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				// Steps 2+: OnBeforeStep hook (can inject messages or stop loop).
 				if o.OnBeforeStep != nil {
 					var bsr BeforeStepResult
-					func() {
-						defer func() {
-							if r := recover(); r != nil {
-								fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeStep hook: %v\n", r)
-							}
-						}()
+					callHook(o.OnPanic, "OnBeforeStep", func() {
 						bsr = o.OnBeforeStep(BeforeStepInfo{
 							Ctx:      ctx,
 							Step:     step,
 							Messages: slices.Clone(params.Messages),
 						})
-					}()
+					})
 					if bsr.Stop {
 						// Semantic parity with WithStopWhen: mark as hookStopped.
 						hookStopped = true
@@ -801,13 +808,8 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 
 				// Steps 2+: DoStream inside goroutine.
 				for _, fn := range o.OnRequest {
-					func(f func(RequestInfo)) {
-						defer func() {
-							if r := recover(); r != nil {
-								fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-							}
-						}()
-						f(RequestInfo{
+					callHook(o.OnPanic, "OnRequest", func() {
+						fn(RequestInfo{
 							Ctx:          ctx,
 							Model:        model.ModelID(),
 							MessageCount: len(params.Messages),
@@ -815,7 +817,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 							Timestamp:    time.Now(),
 							Messages:     requestMessages(params.System, params.Messages),
 						})
-					}(fn)
+					})
 				}
 
 				stepStart = time.Now()
@@ -826,21 +828,14 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 					return model.DoStream(ctx, params)
 				})
 				if err != nil {
-					// Fire OnResponse on error (recover-wrapped).
+					// Fire OnResponse on error.
 					for _, fn := range o.OnResponse {
-						func(f func(ResponseInfo)) {
-							defer func() {
-								if r := recover(); r != nil {
-									fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-								}
-							}()
-							info := ResponseInfo{Latency: time.Since(stepStart), Error: err}
-							var apiErr *APIError
-							if errors.As(err, &apiErr) {
-								info.StatusCode = apiErr.StatusCode
-							}
-							f(info)
-						}(fn)
+						info := ResponseInfo{Latency: time.Since(stepStart), Error: err}
+						var apiErr *APIError
+						if errors.As(err, &apiErr) {
+							info.StatusCode = apiErr.StatusCode
+						}
+						callHook(o.OnPanic, "OnResponse", func() { fn(info) })
 					}
 					// responseMessages intentionally not set on error , buildResult falls back to
 					// a minimal assistant message from accumulated text. Intermediate tool round-trip
@@ -853,7 +848,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 					if len(steps) > 0 {
 						lastFinish = steps[len(steps)-1].FinishReason
 					}
-					fireOnFinish(o.OnFinish, FinishInfo{
+					fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 						TotalSteps:   len(steps),
 						TotalUsage:   totalUsage,
 						FinishReason: lastFinish,
@@ -877,7 +872,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				if len(steps) > 0 {
 					lastFinish = steps[len(steps)-1].FinishReason
 				}
-				fireOnFinish(o.OnFinish, FinishInfo{
+				fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 					TotalSteps:   len(steps),
 					TotalUsage:   totalUsage,
 					FinishReason: lastFinish,
@@ -899,18 +894,13 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 
 			// OnResponse: Error is NOT set (call succeeded). Mid-stream errors use stream.Err().
 			for _, fn := range o.OnResponse {
-				func(f func(ResponseInfo)) {
-					defer func() {
-						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-						}
-					}()
-					f(ResponseInfo{
+				callHook(o.OnPanic, "OnResponse", func() {
+					fn(ResponseInfo{
 						Latency:      time.Since(stepStart),
 						Usage:        ds.usage,
 						FinishReason: ds.finishReason,
 					})
-				}(fn)
+				})
 			}
 
 			// --- Build StepResult, fire OnStepFinish ---
@@ -935,16 +925,9 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			// in this window must see StepStepFinished, not StepLLMInFlight.
 			o.StateRef.set(StepStepFinished, step)
 
-			// OnStepFinish (recover-wrapped).
+			// OnStepFinish.
 			for _, fn := range o.OnStepFinish {
-				func(f func(StepResult)) {
-					defer func() {
-						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-						}
-					}()
-					f(stepResult)
-				}(fn)
+				callHook(o.OnPanic, "OnStepFinish", func() { fn(stepResult) })
 			}
 
 			// Normalize: providers that send empty/wrong finish_reason with tool calls
@@ -993,6 +976,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				onToolCall:      o.OnToolCall,
 				onBeforeExecute: o.OnBeforeToolExecute,
 				onAfterExecute:  o.OnAfterToolExecute,
+				onPanic:         o.OnPanic,
 			})
 			// Attach ToolResults to the step BEFORE the stop predicate sees it
 			// (FIX 7 / Vercel DefaultStepResult parity). steps[-1] is this step.
@@ -1022,7 +1006,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			// here is a valid replay transcript (matching tool_use /
 			// tool_result pairs). Matches
 			// vercel-ai/packages/ai/src/generate-text/generate-text.ts.
-			if o.StopWhen != nil && stopSafe(o.StopWhen, steps) {
+			if o.StopWhen != nil && stopSafe(o.OnPanic, o.StopWhen, steps) {
 				hookStopped = true
 				stopCause = provider.StopCausePredicate
 				break
@@ -1036,7 +1020,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 		ts.stepsExhausted = stepsExhausted
 		ts.responseMessages = buildResponseMessages(params.Messages[originalLen:], steps, lastReasoning)
 
-		fireOnFinish(o.OnFinish, FinishInfo{
+		fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 			StepsExhausted: stepsExhausted,
 			TotalSteps:     len(steps),
 			TotalUsage:     totalUsage,
@@ -1148,6 +1132,7 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	ts.onResponse = o.OnResponse
 	ts.onStepFinish = o.OnStepFinish
 	ts.onFinish = o.OnFinish
+	ts.onPanic = o.OnPanic
 	ts.startTime = start
 	// FIX 34: hand StateRef ownership to the consume goroutine; it will
 	// transition to StepIdle when the stream drains / errors. Only set on
@@ -1159,12 +1144,17 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 // GenerateText performs a non-streaming text generation.
 // When tools with Execute functions are provided and MaxSteps > 1,
 // it automatically runs a tool loop: generate → execute tools → re-generate.
-func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Option) (*TextResult, error) {
+func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Option) (_ *TextResult, err error) {
 	// Apply options FIRST so o.StateRef is populated before any early return.
 	// Registered BEFORE nil-model / prompt validation so pre-loop error returns
 	// also transition observers to StepIdle (otherwise pollers waiting for
 	// StepIdle would deadlock on validation errors).
 	o := applyOptions(opts...)
+
+	// Convert a *PanicError raised by a panicking hook or the StopWhen predicate
+	// into the returned error. Registered first so it runs last (after the
+	// StepIdle transition below), catching panics from the whole body.
+	defer recoverToError(&err)
 
 	var steps []StepResult
 	// highestInflightStep tracks the largest step index we have announced
@@ -1213,18 +1203,13 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// OnBeforeStep: step 2+ only (step 1 has no prior tool results to act on).
 		if step > 1 && o.OnBeforeStep != nil {
 			var bsr BeforeStepResult
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeStep hook: %v\n", r)
-					}
-				}()
+			callHook(o.OnPanic, "OnBeforeStep", func() {
 				bsr = o.OnBeforeStep(BeforeStepInfo{
 					Ctx:      ctx,
 					Step:     step,
 					Messages: slices.Clone(params.Messages),
 				})
-			}()
+			})
 			if bsr.Stop {
 				// Semantic parity with WithStopWhen: mark as hookStopped so
 				// post-loop StepsExhausted derivation does not mistake a
@@ -1239,13 +1224,15 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		}
 
 		for _, fn := range o.OnRequest {
-			fn(RequestInfo{
-				Ctx:          ctx,
-				Model:        model.ModelID(),
-				MessageCount: len(params.Messages),
-				ToolCount:    len(params.Tools),
-				Timestamp:    time.Now(),
-				Messages:     requestMessages(params.System, params.Messages),
+			callHook(o.OnPanic, "OnRequest", func() {
+				fn(RequestInfo{
+					Ctx:          ctx,
+					Model:        model.ModelID(),
+					MessageCount: len(params.Messages),
+					ToolCount:    len(params.Tools),
+					Timestamp:    time.Now(),
+					Messages:     requestMessages(params.System, params.Messages),
+				})
 			})
 		}
 
@@ -1257,23 +1244,16 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		})
 
 		for _, fn := range o.OnResponse {
-			func(f func(ResponseInfo)) {
-				defer func() {
-					if r := recover(); r != nil {
-						fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-					}
-				}()
-				info := ResponseInfo{Latency: time.Since(start), Error: err}
-				if err == nil {
-					info.Usage = result.Usage
-					info.FinishReason = result.FinishReason
-				}
-				var apiErr *APIError
-				if errors.As(err, &apiErr) {
-					info.StatusCode = apiErr.StatusCode
-				}
-				f(info)
-			}(fn)
+			info := ResponseInfo{Latency: time.Since(start), Error: err}
+			if err == nil {
+				info.Usage = result.Usage
+				info.FinishReason = result.FinishReason
+			}
+			var apiErr *APIError
+			if errors.As(err, &apiErr) {
+				info.StatusCode = apiErr.StatusCode
+			}
+			callHook(o.OnPanic, "OnResponse", func() { fn(info) })
 		}
 
 		if err != nil {
@@ -1284,7 +1264,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 			if len(steps) > 0 {
 				lastFinish = steps[len(steps)-1].FinishReason
 			}
-			fireOnFinish(o.OnFinish, FinishInfo{
+			fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: lastFinish,
@@ -1313,14 +1293,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		o.StateRef.set(StepStepFinished, step)
 
 		for _, fn := range o.OnStepFinish {
-			func(f func(StepResult)) {
-				defer func() {
-					if r := recover(); r != nil {
-						fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
-					}
-				}()
-				f(stepResult)
-			}(fn)
+			callHook(o.OnPanic, "OnStepFinish", func() { fn(stepResult) })
 		}
 
 		// If no tools have Execute functions, skip the tool loop regardless of MaxSteps.
@@ -1344,7 +1317,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 			if len(result.ToolCalls) > 0 && len(toolMap) == 0 {
 				cause = provider.StopCauseNoExecutableTools
 			}
-			fireOnFinish(o.OnFinish, FinishInfo{
+			fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: tr.FinishReason,
@@ -1364,6 +1337,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 			onToolCall:      o.OnToolCall,
 			onBeforeExecute: o.OnBeforeToolExecute,
 			onAfterExecute:  o.OnAfterToolExecute,
+			onPanic:         o.OnPanic,
 		})
 		// Attach ToolResults to the step BEFORE the stop predicate sees it
 		// (FIX 7 / Vercel DefaultStepResult parity). steps[-1] is this step.
@@ -1379,7 +1353,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// tool_use paired with matching tool_result). Matches
 		// vercel-ai/packages/ai/src/generate-text/generate-text.ts where
 		// stopWhen() gates the next iteration only after tools have run.
-		if o.StopWhen != nil && stopSafe(o.StopWhen, steps) {
+		if o.StopWhen != nil && stopSafe(o.OnPanic, o.StopWhen, steps) {
 			hookStopped = true
 			stopCause = provider.StopCausePredicate
 			break
@@ -1404,7 +1378,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	stopCause, stepsExhausted = finalizeStopCause(hookStopped, stopCause, steps, o.MaxSteps)
 	tr.StepsExhausted = stepsExhausted
 	tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
-	fireOnFinish(o.OnFinish, FinishInfo{
+	fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 		StepsExhausted: tr.StepsExhausted,
 		TotalSteps:     len(steps),
 		TotalUsage:     totalUsage,
@@ -1436,13 +1410,8 @@ func finalizeStopCause(hookStopped bool, current provider.StopCause, steps []Ste
 	return current, stepsExhausted
 }
 
-func stopSafe(pred StopCondition, steps []StepResult) (stop bool) {
-	defer func() {
-		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "goai: recovered panic in StopWhen predicate: %v\n", r)
-			stop = false
-		}
-	}()
+func stopSafe(onPanic []func(PanicInfo), pred StopCondition, steps []StepResult) bool {
+	var stop bool
 	// Pass a shallow defensive copy so predicates cannot re-order or truncate
 	// the internal slice. NOTE: this is a TOP-LEVEL copy only - nested slices
 	// (StepResult.ToolCalls, StepResult.ToolResults, StepResult.Content) are
@@ -1451,19 +1420,16 @@ func stopSafe(pred StopCondition, steps []StepResult) (stop bool) {
 	// state and is a contract violation. Deep-clone would be prohibitively
 	// expensive per-step for a feature (predicate side-effects) that is not
 	// a supported use case.
-	return pred(slices.Clone(steps))
+	//
+	// A panic in the predicate is fired to OnPanic and surfaced as a
+	// *PanicError (returned by GenerateText, or via stream.Err() for StreamText).
+	callHook(onPanic, "StopWhen", func() { stop = pred(slices.Clone(steps)) })
+	return stop
 }
 
-func fireOnFinish(hooks []func(FinishInfo), info FinishInfo) {
+func fireOnFinish(onPanic []func(PanicInfo), hooks []func(FinishInfo), info FinishInfo) {
 	for _, fn := range hooks {
-		func(f func(FinishInfo)) {
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Fprintf(os.Stderr, "goai: recovered panic in OnFinish hook: %v\n", r)
-				}
-			}()
-			f(info)
-		}(fn)
+		callHook(onPanic, "OnFinish", func() { fn(info) })
 	}
 }
 
@@ -1535,11 +1501,12 @@ type toolOutput struct {
 
 // toolHooks bundles the hook functions and options passed to executeToolsParallel.
 type toolHooks struct {
-	sequential         bool // when true, execute tools one at a time
-	onToolCallStart    []func(ToolCallStartInfo)
-	onToolCall         []func(ToolCallInfo)
-	onBeforeExecute    func(BeforeToolExecuteInfo) BeforeToolExecuteResult
-	onAfterExecute     func(AfterToolExecuteInfo) AfterToolExecuteResult
+	sequential      bool // when true, execute tools one at a time
+	onToolCallStart []func(ToolCallStartInfo)
+	onToolCall      []func(ToolCallInfo)
+	onBeforeExecute func(BeforeToolExecuteInfo) BeforeToolExecuteResult
+	onAfterExecute  func(AfterToolExecuteInfo) AfterToolExecuteResult
+	onPanic         []func(PanicInfo)
 }
 
 func executeToolsParallel(
@@ -1577,7 +1544,7 @@ func executeToolsParallel(
 				func(f func(ToolCallStartInfo)) {
 					defer func() {
 						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
+							firePanic(hooks.onPanic, "OnToolCallStart", r)
 						}
 					}()
 					f(ToolCallStartInfo{ToolCallID: tc.ID, ToolName: tc.Name, Step: step, Input: tc.Input})
@@ -1587,7 +1554,7 @@ func executeToolsParallel(
 				func(f func(ToolCallInfo)) {
 					defer func() {
 						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
+							firePanic(hooks.onPanic, "OnToolCall", r)
 						}
 					}()
 					f(ToolCallInfo{
@@ -1611,12 +1578,17 @@ func executeToolsParallel(
 			defer func() {
 				if r := recover(); r != nil {
 					if !executed {
+						// Distinguish OnToolCallStart panic from Execute panic.
+						if !hookFired {
+							firePanic(hooks.onPanic, "OnToolCallStart", r)
+						} else {
+							firePanic(hooks.onPanic, "tool:"+tc.Name, r)
+						}
 						panicStr := fmt.Sprintf("%v", r)
 						runes := []rune(panicStr)
 						if len(runes) > 500 {
 							panicStr = string(runes[:500]) + "..."
 						}
-						// Distinguish OnToolCallStart panic from Execute panic.
 						if !hookFired {
 							results[i] = toolOutput{index: i, err: fmt.Errorf("goai: OnToolCallStart hook for tool %q panicked: %s", tc.Name, panicStr)}
 						} else {
@@ -1634,7 +1606,7 @@ func executeToolsParallel(
 				func(f func(ToolCallStartInfo)) {
 					defer func() {
 						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
+							firePanic(hooks.onPanic, "OnToolCallStart", r)
 							hookPanicked = true
 						}
 					}()
@@ -1662,7 +1634,7 @@ func executeToolsParallel(
 				func() {
 					defer func() {
 						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeToolExecute hook: %v\n", r)
+							firePanic(hooks.onPanic, "OnBeforeToolExecute", r)
 							beforeResult = BeforeToolExecuteResult{
 								Skip:  true,
 								Error: fmt.Errorf("goai: OnBeforeToolExecute hook panicked: %v", r),
@@ -1689,7 +1661,7 @@ func executeToolsParallel(
 						func(f func(ToolCallInfo)) {
 							defer func() {
 								if r := recover(); r != nil {
-									fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
+									firePanic(hooks.onPanic, "OnToolCall", r)
 								}
 							}()
 							f(ToolCallInfo{
@@ -1725,7 +1697,7 @@ func executeToolsParallel(
 				func() {
 					defer func() {
 						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in OnAfterToolExecute hook: %v\n", r)
+							firePanic(hooks.onPanic, "OnAfterToolExecute", r)
 							// Preserve original result on panic.
 						}
 					}()
@@ -1755,7 +1727,7 @@ func executeToolsParallel(
 				func(f func(ToolCallInfo)) {
 					defer func() {
 						if r := recover(); r != nil {
-							fmt.Fprintf(os.Stderr, "goai: recovered panic in hook: %v\n", r)
+							firePanic(hooks.onPanic, "OnToolCall", r)
 						}
 					}()
 					info := ToolCallInfo{
@@ -1879,7 +1851,7 @@ func appendToolRoundTrip(
 			ToolCallID:      tc.ID,
 			ToolName:        tc.Name,
 			ToolInput:       append(json.RawMessage(nil), tc.Input...), // clone byte slice
-			ProviderOptions: maps.Clone(tc.Metadata),                  // shallow clone (matches buildFinalAssistantMessages)
+			ProviderOptions: maps.Clone(tc.Metadata),                   // shallow clone (matches buildFinalAssistantMessages)
 		})
 	}
 	msgs = append(msgs, provider.Message{Role: provider.RoleAssistant, Content: parts})
@@ -2012,10 +1984,10 @@ func buildFinalAssistantMessages(text string, toolCalls []provider.ToolCall, rea
 }
 
 type drainResult struct {
-	text          string          // text-only (ChunkText), used for appendToolRoundTrip
-	reasoning     []provider.Part // reasoning/thinking parts, echoed back for providers that require it (e.g. Bedrock)
-	reasoningText string          // consolidated reasoning text (PartReasoning), surfaced via StepResult.Reasoning
-	toolCalls     []provider.ToolCall
+	text             string          // text-only (ChunkText), used for appendToolRoundTrip
+	reasoning        []provider.Part // reasoning/thinking parts, echoed back for providers that require it (e.g. Bedrock)
+	reasoningText    string          // consolidated reasoning text (PartReasoning), surfaced via StepResult.Reasoning
+	toolCalls        []provider.ToolCall
 	usage            provider.Usage
 	finishReason     provider.FinishReason
 	sources          []provider.Source
@@ -2030,10 +2002,10 @@ func drainStep(
 	out chan<- provider.StreamChunk,
 ) drainResult {
 	var (
-		textBuf      strings.Builder // ChunkText only (reasoning excluded)
-		reasoningBuf strings.Builder // accumulated reasoning text
-		reasoningMeta map[string]any // last metadata (contains signature)
-		dr           drainResult
+		textBuf       strings.Builder // ChunkText only (reasoning excluded)
+		reasoningBuf  strings.Builder // accumulated reasoning text
+		reasoningMeta map[string]any  // last metadata (contains signature)
+		dr            drainResult
 	)
 
 	for chunk := range source {

--- a/generate_test.go
+++ b/generate_test.go
@@ -4087,12 +4087,15 @@ func TestStreamText_OnStepFinishPanic(t *testing.T) {
 	for range stream.Stream() {
 	}
 
-	result := stream.Result()
-	if stream.Err() != nil {
-		t.Fatalf("unexpected error: %v", stream.Err())
+	var pe *PanicError
+	if !errors.As(stream.Err(), &pe) {
+		t.Fatalf("stream.Err() = %v, want *PanicError", stream.Err())
 	}
-	if result.Text != "hello" {
-		t.Errorf("Text = %q, want %q", result.Text, "hello")
+	if pe.Phase != "OnStepFinish" {
+		t.Errorf("Phase = %q, want OnStepFinish", pe.Phase)
+	}
+	if pe.Value != "hook panic" {
+		t.Errorf("Value = %v, want %q", pe.Value, "hook panic")
 	}
 }
 
@@ -4120,12 +4123,12 @@ func TestStreamText_OnResponsePanic(t *testing.T) {
 	for range stream.Stream() {
 	}
 
-	result := stream.Result()
-	if stream.Err() != nil {
-		t.Fatalf("unexpected error: %v", stream.Err())
+	var pe *PanicError
+	if !errors.As(stream.Err(), &pe) {
+		t.Fatalf("stream.Err() = %v, want *PanicError", stream.Err())
 	}
-	if result.Text != "hello" {
-		t.Errorf("Text = %q, want %q", result.Text, "hello")
+	if pe.Phase != "OnResponse" {
+		t.Errorf("Phase = %q, want OnResponse", pe.Phase)
 	}
 }
 
@@ -4140,17 +4143,18 @@ func TestGenerateText_OnStepFinishPanic(t *testing.T) {
 		},
 	}
 
-	result, err := GenerateText(t.Context(), model,
+	_, err := GenerateText(t.Context(), model,
 		WithPrompt("hi"),
 		WithOnStepFinish(func(_ StepResult) {
 			panic("hook panic")
 		}),
 	)
-	if err != nil {
-		t.Fatal(err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if result.Text != "ok" {
-		t.Errorf("Text = %q, want %q", result.Text, "ok")
+	if pe.Phase != "OnStepFinish" {
+		t.Errorf("Phase = %q, want OnStepFinish", pe.Phase)
 	}
 }
 
@@ -4165,17 +4169,18 @@ func TestGenerateText_OnResponsePanic(t *testing.T) {
 		},
 	}
 
-	result, err := GenerateText(t.Context(), model,
+	_, err := GenerateText(t.Context(), model,
 		WithPrompt("hi"),
 		WithOnResponse(func(_ ResponseInfo) {
 			panic("hook panic")
 		}),
 	)
-	if err != nil {
-		t.Fatal(err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if result.Text != "ok" {
-		t.Errorf("Text = %q, want %q", result.Text, "ok")
+	if pe.Phase != "OnResponse" {
+		t.Errorf("Phase = %q, want OnResponse", pe.Phase)
 	}
 }
 
@@ -4219,8 +4224,8 @@ func TestBuildToolMap_EmptyToolName(t *testing.T) {
 }
 
 // TestStreamText_ToolLoop_OnRequestPanic verifies that a panicking OnRequest
-// hook on step 2+ is safely recovered: the process does not crash and the
-// stream still delivers the final text from step 2.
+// hook on step 2+ is surfaced as a *PanicError through stream.Err() (the
+// goroutine does not crash the process).
 func TestStreamText_ToolLoop_OnRequestPanic(t *testing.T) {
 	var callCount atomic.Int32
 	model := &mockModel{
@@ -4262,12 +4267,13 @@ func TestStreamText_ToolLoop_OnRequestPanic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := stream.Result()
-	if err := stream.Err(); err != nil {
-		t.Fatalf("unexpected stream error: %v", err)
+	stream.Result()
+	var pe *PanicError
+	if !errors.As(stream.Err(), &pe) {
+		t.Fatalf("stream.Err() = %v, want *PanicError", stream.Err())
 	}
-	if !strings.Contains(result.Text, "done") {
-		t.Errorf("Text = %q, want containing 'done'", result.Text)
+	if pe.Phase != "OnRequest" {
+		t.Errorf("Phase = %q, want OnRequest", pe.Phase)
 	}
 }
 
@@ -4314,8 +4320,8 @@ func TestStreamText_ToolLoop_OnResponsePanicOnError(t *testing.T) {
 }
 
 // TestStreamText_ToolLoop_OnResponsePanicOnSuccess verifies that a panicking
-// OnResponse hook fired after a successful step 2+ drain is safely recovered
-// and the stream still delivers the final text.
+// OnResponse hook fired after a successful step 2+ drain is surfaced as a
+// *PanicError through stream.Err().
 func TestStreamText_ToolLoop_OnResponsePanicOnSuccess(t *testing.T) {
 	var callCount atomic.Int32
 	model := &mockModel{
@@ -4352,18 +4358,16 @@ func TestStreamText_ToolLoop_OnResponsePanicOnSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := stream.Result()
-	if err := stream.Err(); err != nil {
-		t.Fatalf("unexpected stream error: %v", err)
+	stream.Result()
+	var pe *PanicError
+	if !errors.As(stream.Err(), &pe) {
+		t.Fatalf("stream.Err() = %v, want *PanicError", stream.Err())
 	}
-	if !strings.Contains(result.Text, "final") {
-		t.Errorf("Text = %q, want containing 'final'", result.Text)
+	if pe.Phase != "OnResponse" {
+		t.Errorf("Phase = %q, want OnResponse", pe.Phase)
 	}
 }
 
-// TestStreamText_ToolLoop_OnStepFinishPanic verifies that a panicking
-// OnStepFinish hook on step 2+ is safely recovered and the stream still
-// delivers the final text.
 // TestOnToolCall_PanicIsolation verifies that a panicking OnToolCall hook
 // does not prevent a second hook from firing.
 func TestOnToolCall_PanicIsolation(t *testing.T) {
@@ -4452,10 +4456,10 @@ func TestOnToolCallStart_PanicIsolation(t *testing.T) {
 	}
 }
 
-// TestGenerateText_OnResponse_PanicIsolation verifies that in the GenerateText
-// multi-step loop, a panicking OnResponse hook does not prevent the second hook
-// from firing (recover-wrapped path).
-func TestGenerateText_OnResponse_PanicIsolation(t *testing.T) {
+// TestGenerateText_OnResponse_PanicPropagates verifies that a panicking
+// OnResponse hook is surfaced as a *PanicError and prevents subsequent
+// callbacks from firing (propagate-fatal contract).
+func TestGenerateText_OnResponse_PanicPropagates(t *testing.T) {
 	var secondFired atomic.Bool
 	model := &mockModel{
 		id: "test",
@@ -4467,22 +4471,25 @@ func TestGenerateText_OnResponse_PanicIsolation(t *testing.T) {
 		},
 	}
 
-	result, err := GenerateText(t.Context(), model,
+	_, err := GenerateText(t.Context(), model,
 		WithPrompt("hi"),
 		WithOnResponse(func(_ ResponseInfo) { panic("hook1 panic") }),
 		WithOnResponse(func(_ ResponseInfo) { secondFired.Store(true) }),
 	)
-	if err != nil {
-		t.Fatal(err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if result.Text != "ok" {
-		t.Errorf("Text = %q, want ok", result.Text)
+	if pe.Phase != "OnResponse" {
+		t.Errorf("Phase = %q, want OnResponse", pe.Phase)
 	}
-	if !secondFired.Load() {
-		t.Error("second OnResponse hook should fire even if first panics (GenerateText multi-step is recover-wrapped)")
+	if secondFired.Load() {
+		t.Error("second OnResponse hook should NOT fire after the first panics (propagate-fatal)")
 	}
 }
 
+// TestStreamText_ToolLoop_OnStepFinishPanic verifies that a panicking
+// OnStepFinish hook on step 2+ is surfaced as a *PanicError through stream.Err().
 func TestStreamText_ToolLoop_OnStepFinishPanic(t *testing.T) {
 	var callCount atomic.Int32
 	model := &mockModel{
@@ -4519,12 +4526,13 @@ func TestStreamText_ToolLoop_OnStepFinishPanic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := stream.Result()
-	if err := stream.Err(); err != nil {
-		t.Fatalf("unexpected stream error: %v", err)
+	stream.Result()
+	var pe *PanicError
+	if !errors.As(stream.Err(), &pe) {
+		t.Fatalf("stream.Err() = %v, want *PanicError", stream.Err())
 	}
-	if !strings.Contains(result.Text, "final") {
-		t.Errorf("Text = %q, want containing 'final'", result.Text)
+	if pe.Phase != "OnStepFinish" {
+		t.Errorf("Phase = %q, want OnStepFinish", pe.Phase)
 	}
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -109,9 +109,11 @@ type ToolCallInfo struct {
 }
 
 // WithOnStepFinish adds a callback invoked after each generation step completes.
-// Multiple callbacks are called in registration order. Each callback is individually
-// panic-recovered in all paths (GenerateText, StreamText, GenerateObject, StreamObject).
-// A panic in one callback does not prevent subsequent callbacks from firing.
+// Multiple callbacks are called in registration order.
+//
+// A panic in a callback is reported to any OnPanic hook and then surfaced as a
+// *PanicError: returned by GenerateText/GenerateObject, or via stream.Err() for
+// StreamText/StreamObject. Subsequent callbacks do not run.
 //
 // Timing: OnStepFinish fires after the LLM call for the step returns and
 // BEFORE any tool executions for that step run. The StepResult passed to
@@ -156,8 +158,11 @@ type FinishInfo struct {
 }
 
 // WithOnFinish adds a callback invoked once after all generation steps complete.
-// Multiple callbacks are called in registration order. Each callback is individually
-// panic-recovered so a panic in one does not prevent subsequent callbacks from firing.
+// Multiple callbacks are called in registration order.
+//
+// A panic in a callback is reported to any OnPanic hook and then surfaced as a
+// *PanicError: returned by GenerateText/GenerateObject, or via stream.Err() for
+// StreamText/StreamObject. Subsequent callbacks do not run.
 //
 // This hook fires in all code paths:
 //   - GenerateText: after the tool loop exits (natural, max_steps, or hook_stopped)
@@ -176,27 +181,29 @@ func WithOnFinish(fn func(FinishInfo)) Option {
 
 // WithOnRequest adds a callback invoked before each model call.
 // Multiple callbacks are called in registration order.
-// In GenerateText, GenerateObject, and StreamText's first step, panics propagate
-// to the caller (a panic in one callback prevents subsequent callbacks from firing).
-// In StreamText step 2+ (goroutine), each callback is individually panic-recovered.
+//
+// A panic in a callback is reported to any OnPanic hook and then surfaced as a
+// *PanicError: returned by GenerateText/GenerateObject, or via stream.Err() for
+// StreamText/StreamObject (step 2+ panics, fired in the stream goroutine, also
+// surface through stream.Err()). Subsequent callbacks do not run.
 func WithOnRequest(fn func(RequestInfo)) Option {
 	return func(o *options) { o.OnRequest = append(o.OnRequest, fn) }
 }
 
 // WithOnResponse adds a callback invoked after each model call completes.
 // Multiple callbacks are called in registration order.
-// Each callback is individually panic-recovered in GenerateText (all steps),
-// all StreamText success paths (single-step consume goroutine and multi-step goroutine),
-// GenerateObject (all steps), StreamObject's success path (consume goroutine),
-// and StreamObject's error path.
-// In StreamText's first-step error path, panics propagate to the caller.
+//
+// A panic in a callback is reported to any OnPanic hook and then surfaced as a
+// *PanicError: returned by GenerateText/GenerateObject, or via stream.Err() for
+// StreamText/StreamObject. Subsequent callbacks do not run.
 func WithOnResponse(fn func(ResponseInfo)) Option {
 	return func(o *options) { o.OnResponse = append(o.OnResponse, fn) }
 }
 
 // WithOnToolCall adds a callback invoked after each tool execution.
 // Multiple callbacks are called in registration order. Each callback is individually
-// panic-recovered so a panic in one does not prevent others from firing.
+// panic-recovered (and reported to any OnPanic hook) so a panic in one does not
+// prevent others from firing or abort the agent loop.
 func WithOnToolCall(fn func(ToolCallInfo)) Option {
 	return func(o *options) { o.OnToolCall = append(o.OnToolCall, fn) }
 }
@@ -218,8 +225,8 @@ type ToolCallStartInfo struct {
 
 // WithOnToolCallStart adds a callback invoked before each tool execution.
 // Multiple callbacks are called in registration order. Each callback is individually
-// panic-recovered so a panic in one does not prevent others from firing. If any callback
-// panics, the tool does not execute.
+// panic-recovered (and reported to any OnPanic hook) so a panic in one does not
+// prevent others from firing. If any callback panics, the tool does not execute.
 func WithOnToolCallStart(fn func(ToolCallStartInfo)) Option {
 	return func(o *options) { o.OnToolCallStart = append(o.OnToolCallStart, fn) }
 }
@@ -286,7 +293,8 @@ type BeforeToolExecuteResult struct {
 // The callback can inspect the tool call and return a BeforeToolExecuteResult to skip
 // execution (e.g., for permission checks, rate limiting, or doom-loop detection).
 // Only one callback is supported; setting a second replaces the first.
-// The callback is panic-recovered; a panic skips the tool with an error result.
+// The callback is panic-recovered (and reported to any OnPanic hook); a panic
+// skips the tool with an error result.
 func WithOnBeforeToolExecute(fn func(BeforeToolExecuteInfo) BeforeToolExecuteResult) Option {
 	return func(o *options) { o.OnBeforeToolExecute = fn }
 }
@@ -341,7 +349,8 @@ type AfterToolExecuteResult struct {
 // Not called when OnBeforeToolExecute skips execution or for unknown tools.
 // Use OnToolCall with Skipped=true to observe skipped tool results.
 // Only one callback is supported; setting a second replaces the first.
-// The callback is panic-recovered; a panic preserves the original tool result.
+// The callback is panic-recovered (and reported to any OnPanic hook); a panic
+// preserves the original tool result.
 func WithOnAfterToolExecute(fn func(AfterToolExecuteInfo) AfterToolExecuteResult) Option {
 	return func(o *options) { o.OnAfterToolExecute = fn }
 }
@@ -381,9 +390,44 @@ type BeforeStepResult struct {
 // tool loop (step 2+, after tool execution). The callback can inject additional
 // messages or stop the loop early.
 // Only one callback is supported; setting a second replaces the first.
-// The callback is panic-recovered; a panic is logged and the step proceeds normally.
+//
+// A panic in the callback is reported to any OnPanic hook and then surfaced as a
+// *PanicError: returned by GenerateText/GenerateObject, or via stream.Err() for
+// StreamText. The loop stops at the panicking step.
 func WithOnBeforeStep(fn func(BeforeStepInfo) BeforeStepResult) Option {
 	return func(o *options) { o.OnBeforeStep = fn }
+}
+
+// PanicInfo is passed to the OnPanic hook when a user callback or the StopWhen
+// predicate panics.
+type PanicInfo struct {
+	// Phase identifies the callback that panicked, e.g. "OnStepFinish",
+	// "OnFinish", "OnResponse", "OnRequest", "OnBeforeStep", "StopWhen",
+	// "OnToolCallStart", "OnToolCall", "OnBeforeToolExecute",
+	// "OnAfterToolExecute", or "tool:<name>" for a tool's Execute function.
+	Phase string
+
+	// Value is the value passed to panic().
+	Value any
+
+	// Stack is the goroutine stack captured at the recovery point.
+	Stack []byte
+}
+
+// WithOnPanic adds a callback invoked whenever a user callback or the StopWhen
+// predicate panics. Multiple callbacks are called in registration order.
+//
+// It fires for every panicking callback, both the propagate-fatal lifecycle
+// hooks (OnRequest, OnResponse, OnStepFinish, OnFinish, OnBeforeStep, StopWhen)
+// and the resilient tool-path callbacks (tool Execute, OnToolCallStart,
+// OnToolCall, OnBeforeToolExecute, OnAfterToolExecute). Use it for observability
+// (otel spans, metrics, logging) regardless of how the panic is ultimately
+// handled.
+//
+// OnPanic fires before the panic is surfaced or recovered. A panic inside an
+// OnPanic callback itself is recovered and discarded.
+func WithOnPanic(fn func(PanicInfo)) Option {
+	return func(o *options) { o.OnPanic = append(o.OnPanic, fn) }
 }
 
 // WrapOnBeforeToolExecute returns an Option that wraps the existing OnBeforeToolExecute hook.

--- a/hooks.go
+++ b/hooks.go
@@ -399,7 +399,8 @@ func WithOnBeforeStep(fn func(BeforeStepInfo) BeforeStepResult) Option {
 }
 
 // PanicInfo is passed to the OnPanic hook when a user callback or the StopWhen
-// predicate panics.
+// predicate panics. Value and Stack may contain sensitive data (panic arguments,
+// captured variables, credentials); sanitize before logging or exporting.
 type PanicInfo struct {
 	// Phase identifies the callback that panicked, e.g. "OnStepFinish",
 	// "OnFinish", "OnResponse", "OnRequest", "OnBeforeStep", "StopWhen",
@@ -407,10 +408,11 @@ type PanicInfo struct {
 	// "OnAfterToolExecute", or "tool:<name>" for a tool's Execute function.
 	Phase string
 
-	// Value is the value passed to panic().
+	// Value is the value passed to panic(). May contain sensitive data.
 	Value any
 
 	// Stack is the goroutine stack captured at the recovery point.
+	// May contain sensitive data.
 	Stack []byte
 }
 

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -3,6 +3,7 @@ package goai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -1133,10 +1134,10 @@ func TestOnBeforeToolExecute_SkipFiresOnToolCallWithSkipped(t *testing.T) {
 	}
 }
 
-// --- Finding 7: OnBeforeStep panic recovery ---
+// --- Finding 7: OnBeforeStep panic propagation ---
 
-func TestOnBeforeStep_PanicRecovery_GenerateText(t *testing.T) {
-	// OnBeforeStep panics --should be recovered, step proceeds normally.
+func TestOnBeforeStep_PanicPropagates_GenerateText(t *testing.T) {
+	// OnBeforeStep panics --surfaced as *PanicError, loop stops before step 2.
 	callCount := 0
 	model := &mockModel{
 		id: "test",
@@ -1152,7 +1153,7 @@ func TestOnBeforeStep_PanicRecovery_GenerateText(t *testing.T) {
 		},
 	}
 
-	result, err := GenerateText(t.Context(), model,
+	_, err := GenerateText(t.Context(), model,
 		WithPrompt("go"),
 		WithMaxSteps(3),
 		WithTools(Tool{
@@ -1163,18 +1164,19 @@ func TestOnBeforeStep_PanicRecovery_GenerateText(t *testing.T) {
 			panic("step panic!")
 		}),
 	)
-	if err != nil {
-		t.Fatal(err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if callCount != 2 {
-		t.Errorf("LLM called %d times, want 2 (panic recovered, step proceeded)", callCount)
+	if pe.Phase != "OnBeforeStep" {
+		t.Errorf("Phase = %q, want OnBeforeStep", pe.Phase)
 	}
-	if result.Text != "done after panic" {
-		t.Errorf("Text = %q, want 'done after panic'", result.Text)
+	if callCount != 1 {
+		t.Errorf("LLM called %d times, want 1 (loop stops at the panicking hook before step 2)", callCount)
 	}
 }
 
-func TestOnBeforeStep_PanicRecovery_StreamText(t *testing.T) {
+func TestOnBeforeStep_PanicPropagates_StreamText(t *testing.T) {
 	callCount := 0
 	model := &mockModel{
 		id: "test",
@@ -1207,12 +1209,16 @@ func TestOnBeforeStep_PanicRecovery_StreamText(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result := stream.Result()
-	if callCount != 2 {
-		t.Errorf("LLM called %d times, want 2", callCount)
+	stream.Result()
+	var pe *PanicError
+	if !errors.As(stream.Err(), &pe) {
+		t.Fatalf("stream.Err() = %v, want *PanicError", stream.Err())
 	}
-	if result.Text != "recovered" {
-		t.Errorf("Text = %q, want recovered", result.Text)
+	if pe.Phase != "OnBeforeStep" {
+		t.Errorf("Phase = %q, want OnBeforeStep", pe.Phase)
+	}
+	if callCount != 1 {
+		t.Errorf("LLM called %d times, want 1 (loop stops at the panicking hook)", callCount)
 	}
 }
 
@@ -1419,8 +1425,8 @@ func TestOnBeforeStep_GenerateObject_InjectMessages(t *testing.T) {
 	}
 }
 
-func TestOnBeforeStep_GenerateObject_PanicRecovery(t *testing.T) {
-	// OnBeforeStep panics in GenerateObject -- recovered, step proceeds.
+func TestOnBeforeStep_GenerateObject_PanicPropagates(t *testing.T) {
+	// OnBeforeStep panics in GenerateObject -- surfaced as *PanicError.
 	callCount := 0
 	model := &mockModel{
 		id: "test",
@@ -1444,7 +1450,7 @@ func TestOnBeforeStep_GenerateObject_PanicRecovery(t *testing.T) {
 		Value int    `json:"value"`
 	}
 
-	result, err := GenerateObject[TestObj](t.Context(), model,
+	_, err := GenerateObject[TestObj](t.Context(), model,
 		WithPrompt("go"),
 		WithMaxSteps(3),
 		WithTools(Tool{
@@ -1455,14 +1461,15 @@ func TestOnBeforeStep_GenerateObject_PanicRecovery(t *testing.T) {
 			panic("object step panic!")
 		}),
 	)
-	if err != nil {
-		t.Fatal(err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if callCount != 2 {
-		t.Errorf("LLM called %d times, want 2 (panic recovered)", callCount)
+	if pe.Phase != "OnBeforeStep" {
+		t.Errorf("Phase = %q, want OnBeforeStep", pe.Phase)
 	}
-	if result.Object.Name != "recovered" {
-		t.Errorf("Object.Name = %q, want recovered", result.Object.Name)
+	if callCount != 1 {
+		t.Errorf("LLM called %d times, want 1 (loop stops at the panicking hook)", callCount)
 	}
 }
 
@@ -2350,8 +2357,8 @@ func TestOnFinish_StreamText(t *testing.T) {
 	}
 }
 
-func TestOnFinish_PanicRecovery(t *testing.T) {
-	// OnFinish panics. Verify no crash and second hook still fires.
+func TestOnFinish_PanicPropagates(t *testing.T) {
+	// OnFinish panics. Surfaced as *PanicError; the second hook does NOT fire.
 	var secondCalled bool
 	model := &mockModel{
 		id: "test",
@@ -2373,11 +2380,15 @@ func TestOnFinish_PanicRecovery(t *testing.T) {
 			secondCalled = true
 		}),
 	)
-	if err != nil {
-		t.Fatal(err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if !secondCalled {
-		t.Error("second OnFinish hook should fire even when first panics")
+	if pe.Phase != "OnFinish" {
+		t.Errorf("Phase = %q, want OnFinish", pe.Phase)
+	}
+	if secondCalled {
+		t.Error("second OnFinish hook should NOT fire after the first panics (propagate-fatal)")
 	}
 }
 

--- a/object.go
+++ b/object.go
@@ -386,7 +386,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 	o := applyOptions(opts...)
 
 	// Convert a *PanicError raised by a panicking hook into the returned error.
-	defer recoverToError(&err)
+	defer recoverToError(o.OnPanic, &err)
 
 	if o.StopWhen != nil {
 		warnStopWhenIgnoredForObject("GenerateObject")
@@ -588,7 +588,7 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 	// Convert a *PanicError from a pre-stream hook (OnRequest, or OnResponse on a
 	// DoStream error) into the returned error. Hooks fired inside the consume
 	// goroutine surface through stream.Err() instead.
-	defer recoverToError(&err)
+	defer recoverToError(o.OnPanic, &err)
 
 	if o.StopWhen != nil {
 		warnStopWhenIgnoredForObject("StreamObject")

--- a/object.go
+++ b/object.go
@@ -144,6 +144,7 @@ type ObjectStream[T any] struct {
 	onResponse   []func(ResponseInfo)
 	onStepFinish []func(StepResult)
 	onFinish     []func(FinishInfo)
+	onPanic      []func(PanicInfo)
 	startTime    time.Time
 
 	// Accumulated state.
@@ -235,6 +236,15 @@ func (os *ObjectStream[T]) Err() error {
 
 func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 	defer close(os.doneCh)
+	// Surface a panic from any user hook fired during teardown (OnStepFinish,
+	// OnResponse, OnFinish) through stream.Err(). Registered near the top so it
+	// runs after (LIFO) the hook defers below. A pre-existing stream error is
+	// preserved as the root cause.
+	defer recoverToStreamErr(os.onPanic, "stream", func(e error) {
+		if os.streamErr == nil {
+			os.streamErr = e
+		}
+	})
 	if os.timeoutCancel != nil {
 		defer os.timeoutCancel()
 	}
@@ -246,7 +256,7 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 	// Deferred BEFORE OnStepFinish so it runs AFTER it (LIFO order).
 	if len(os.onFinish) > 0 {
 		defer func() {
-			fireOnFinish(os.onFinish, FinishInfo{
+			fireOnFinish(os.onPanic, os.onFinish, FinishInfo{
 				TotalSteps:   1,
 				TotalUsage:   os.usage,
 				FinishReason: os.finishReason,
@@ -260,22 +270,15 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 	if len(os.onStepFinish) > 0 {
 		defer func() {
 			stepResult := StepResult{
-				Number:       1,
-				Text:         os.text.String(),
-				FinishReason: os.finishReason,
-				Usage:        os.usage,
-				Response:     os.response,
+				Number:           1,
+				Text:             os.text.String(),
+				FinishReason:     os.finishReason,
+				Usage:            os.usage,
+				Response:         os.response,
 				ProviderMetadata: os.providerMetadata,
 			}
 			for _, fn := range os.onStepFinish {
-				func(f func(StepResult)) {
-					defer func() {
-						if r := recover(); r != nil {
-							_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
-						}
-					}()
-					f(stepResult)
-				}(fn)
+				callHook(os.onPanic, "OnStepFinish", func() { fn(stepResult) })
 			}
 		}()
 	}
@@ -294,14 +297,7 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 				info.StatusCode = apiErr.StatusCode
 			}
 			for _, fn := range os.onResponse {
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
-						}
-					}()
-					fn(info)
-				}()
+				callHook(os.onPanic, "OnResponse", func() { fn(info) })
 			}
 		}()
 	}
@@ -382,12 +378,15 @@ func (os *ObjectStream[T]) consume(partialOut chan<- *T) {
 // If MaxSteps is exhausted before a "stop" step occurs, an error is returned.
 // This differs slightly from Vercel AI SDK, which returns a partial result with
 // a nil output field - in Go, returning an error is the idiomatic equivalent.
-func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, opts ...Option) (*ObjectResult[T], error) {
+func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, opts ...Option) (_ *ObjectResult[T], err error) {
 	if model == nil {
 		return nil, errors.New("goai: model must not be nil")
 	}
 
 	o := applyOptions(opts...)
+
+	// Convert a *PanicError raised by a panicking hook into the returned error.
+	defer recoverToError(&err)
 
 	if o.StopWhen != nil {
 		warnStopWhenIgnoredForObject("GenerateObject")
@@ -433,18 +432,13 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		// OnBeforeStep: step 2+ only (step 1 has no prior tool results to act on).
 		if step > 1 && o.OnBeforeStep != nil {
 			var bsr BeforeStepResult
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						fmt.Fprintf(os.Stderr, "goai: recovered panic in OnBeforeStep hook: %v\n", r)
-					}
-				}()
+			callHook(o.OnPanic, "OnBeforeStep", func() {
 				bsr = o.OnBeforeStep(BeforeStepInfo{
 					Ctx:      ctx,
 					Step:     step,
 					Messages: slices.Clone(params.Messages),
 				})
-			}()
+			})
 			if bsr.Stop {
 				break
 			}
@@ -454,13 +448,15 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		}
 
 		for _, fn := range o.OnRequest {
-			fn(RequestInfo{
-				Ctx:          ctx,
-				Model:        model.ModelID(),
-				MessageCount: len(params.Messages),
-				ToolCount:    len(params.Tools),
-				Timestamp:    time.Now(),
-				Messages:     requestMessages(params.System, params.Messages),
+			callHook(o.OnPanic, "OnRequest", func() {
+				fn(RequestInfo{
+					Ctx:          ctx,
+					Model:        model.ModelID(),
+					MessageCount: len(params.Messages),
+					ToolCount:    len(params.Tools),
+					Timestamp:    time.Now(),
+					Messages:     requestMessages(params.System, params.Messages),
+				})
 			})
 		}
 
@@ -470,23 +466,16 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		})
 
 		for _, fn := range o.OnResponse {
-			func(f func(ResponseInfo)) {
-				defer func() {
-					if r := recover(); r != nil {
-						_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
-					}
-				}()
-				info := ResponseInfo{Latency: time.Since(start), Error: err}
-				if err == nil {
-					info.Usage = result.Usage
-					info.FinishReason = result.FinishReason
-				}
-				var apiErr *APIError
-				if errors.As(err, &apiErr) {
-					info.StatusCode = apiErr.StatusCode
-				}
-				f(info)
-			}(fn)
+			info := ResponseInfo{Latency: time.Since(start), Error: err}
+			if err == nil {
+				info.Usage = result.Usage
+				info.FinishReason = result.FinishReason
+			}
+			var apiErr *APIError
+			if errors.As(err, &apiErr) {
+				info.StatusCode = apiErr.StatusCode
+			}
+			callHook(o.OnPanic, "OnResponse", func() { fn(info) })
 		}
 
 		if err != nil {
@@ -494,7 +483,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 			if len(steps) > 0 {
 				lastFinish = steps[len(steps)-1].FinishReason
 			}
-			fireOnFinish(o.OnFinish, FinishInfo{
+			fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: lastFinish,
@@ -517,14 +506,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		totalUsage = addUsage(totalUsage, result.Usage)
 
 		for _, fn := range o.OnStepFinish {
-			func(f func(StepResult)) {
-				defer func() {
-					if r := recover(); r != nil {
-						_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
-					}
-				}()
-				f(stepResult)
-			}(fn)
+			callHook(o.OnPanic, "OnStepFinish", func() { fn(stepResult) })
 		}
 
 		// If no tools have Execute functions, skip the tool loop regardless of MaxSteps.
@@ -542,7 +524,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 				// Raw model output is truncated to 200 chars to limit information disclosure.
 				return nil, fmt.Errorf("parsing structured output: %w (raw: %s)", err, truncate(text, 200))
 			}
-			fireOnFinish(o.OnFinish, FinishInfo{
+			fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 				TotalSteps:   len(steps),
 				TotalUsage:   totalUsage,
 				FinishReason: result.FinishReason,
@@ -569,6 +551,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 			onToolCall:      o.OnToolCall,
 			onBeforeExecute: o.OnBeforeToolExecute,
 			onAfterExecute:  o.OnAfterToolExecute,
+			onPanic:         o.OnPanic,
 		})
 		params.Messages = appendToolRoundTrip(params.Messages, result.Text, nil, result.ToolCalls, toolMessages)
 	}
@@ -578,7 +561,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 	if len(steps) > 0 {
 		lastFinish = steps[len(steps)-1].FinishReason
 	}
-	fireOnFinish(o.OnFinish, FinishInfo{
+	fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 		StepsExhausted: true,
 		TotalSteps:     len(steps),
 		TotalUsage:     totalUsage,
@@ -595,12 +578,17 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 // one streaming request and returns immediately. Tool loops are not supported
 // because the caller consumes the stream asynchronously; use GenerateObject when
 // you need tools and multi-step behaviour.
-func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts ...Option) (*ObjectStream[T], error) {
+func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts ...Option) (_ *ObjectStream[T], err error) {
 	if model == nil {
 		return nil, errors.New("goai: model must not be nil")
 	}
 
 	o := applyOptions(opts...)
+
+	// Convert a *PanicError from a pre-stream hook (OnRequest, or OnResponse on a
+	// DoStream error) into the returned error. Hooks fired inside the consume
+	// goroutine surface through stream.Err() instead.
+	defer recoverToError(&err)
 
 	if o.StopWhen != nil {
 		warnStopWhenIgnoredForObject("StreamObject")
@@ -633,40 +621,35 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 	}
 
 	for _, fn := range o.OnRequest {
-		fn(RequestInfo{
-			Ctx:          ctx,
-			Model:        model.ModelID(),
-			MessageCount: len(params.Messages),
-			ToolCount:    len(params.Tools),
-			Timestamp:    time.Now(),
-			Messages:     requestMessages(params.System, params.Messages),
+		callHook(o.OnPanic, "OnRequest", func() {
+			fn(RequestInfo{
+				Ctx:          ctx,
+				Model:        model.ModelID(),
+				MessageCount: len(params.Messages),
+				ToolCount:    len(params.Tools),
+				Timestamp:    time.Now(),
+				Messages:     requestMessages(params.System, params.Messages),
+			})
 		})
 	}
 
 	start := time.Now()
-	result, err := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+	result, streamErr := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
-	if err != nil {
+	if streamErr != nil {
 		if timeoutCancel != nil {
 			timeoutCancel()
 		}
 		for _, fn := range o.OnResponse {
-			func(f func(ResponseInfo)) {
-				defer func() {
-					if r := recover(); r != nil {
-						_, _ = fmt.Fprintf(osStderr, "goai: recovered panic in hook: %v\n", r)
-					}
-				}()
-				info := ResponseInfo{Latency: time.Since(start), Error: err}
-				var apiErr *APIError
-				if errors.As(err, &apiErr) {
-					info.StatusCode = apiErr.StatusCode
-				}
-				f(info)
-			}(fn)
+			info := ResponseInfo{Latency: time.Since(start), Error: streamErr}
+			var apiErr *APIError
+			if errors.As(streamErr, &apiErr) {
+				info.StatusCode = apiErr.StatusCode
+			}
+			callHook(o.OnPanic, "OnResponse", func() { fn(info) })
 		}
-		return nil, err
+		return nil, streamErr
 	}
 
 	os := newObjectStream[T](ctx, result.Stream)
@@ -674,6 +657,7 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 	os.onResponse = o.OnResponse
 	os.onStepFinish = o.OnStepFinish
 	os.onFinish = o.OnFinish
+	os.onPanic = o.OnPanic
 	os.startTime = start
 	return os, nil
 }

--- a/object_test.go
+++ b/object_test.go
@@ -1940,9 +1940,9 @@ func TestGenerateObject_ToolLoop_OnToolCallStart(t *testing.T) {
 	}
 }
 
-// TestGenerateObject_OnStepFinishPanicRecovery verifies that a panicking
-// OnStepFinish hook in GenerateObject is recovered and does not crash the caller.
-func TestGenerateObject_OnStepFinishPanicRecovery(t *testing.T) {
+// TestGenerateObject_OnStepFinishPanicPropagates verifies that a panicking
+// OnStepFinish hook in GenerateObject is surfaced as a *PanicError.
+func TestGenerateObject_OnStepFinishPanicPropagates(t *testing.T) {
 	model := &mockModel{
 		id: "test",
 		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
@@ -1954,21 +1954,23 @@ func TestGenerateObject_OnStepFinishPanicRecovery(t *testing.T) {
 		},
 	}
 
-	result, err := GenerateObject[simpleObject](t.Context(), model,
+	_, err := GenerateObject[simpleObject](t.Context(), model,
 		WithPrompt("generate"),
 		WithOnStepFinish(func(_ StepResult) { panic("test panic in OnStepFinish") }),
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if result.Object.Name != "Dave" {
-		t.Errorf("Object.Name = %q, want Dave", result.Object.Name)
+	if pe.Phase != "OnStepFinish" {
+		t.Errorf("Phase = %q, want OnStepFinish", pe.Phase)
 	}
 }
 
-// TestStreamObject_OnResponsePanicRecovery verifies that a panicking OnResponse
-// hook in ObjectStream.consume is recovered and does not crash the caller.
-func TestStreamObject_OnResponsePanicRecovery(t *testing.T) {
+// TestStreamObject_OnResponsePanicPropagates verifies that a panicking OnResponse
+// hook in ObjectStream.consume is surfaced as a *PanicError through stream.Err()
+// without crashing the caller.
+func TestStreamObject_OnResponsePanicPropagates(t *testing.T) {
 	model := &mockModel{
 		id: "test",
 		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
@@ -1989,13 +1991,13 @@ func TestStreamObject_OnResponsePanicRecovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Panic is recovered inside consume(); result should be returned cleanly.
-	result, err := stream.Result()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err = stream.Result()
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
 	}
-	if result.Object.Name != "Carol" {
-		t.Errorf("Object.Name = %q, want Carol", result.Object.Name)
+	if pe.Phase != "OnResponse" {
+		t.Errorf("Phase = %q, want OnResponse", pe.Phase)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -120,6 +120,11 @@ type options struct {
 	// Only one callback supported; setting a second replaces the first.
 	OnBeforeStep func(BeforeStepInfo) BeforeStepResult
 
+	// OnPanic is called whenever a user callback or the StopWhen predicate panics,
+	// before the panic is surfaced (as a *PanicError) or, for the tool path,
+	// recovered. Multiple callbacks are called in registration order.
+	OnPanic []func(PanicInfo)
+
 	// ExplicitSchema overrides auto-generated JSON Schema for GenerateObject/StreamObject.
 	ExplicitSchema json.RawMessage
 

--- a/panic.go
+++ b/panic.go
@@ -1,0 +1,79 @@
+package goai
+
+import "runtime/debug"
+
+// firePanicHooks notifies every registered OnPanic observer. It never itself
+// panics: a panic inside an OnPanic callback is recovered and discarded so it
+// cannot disrupt the panic-handling flow it is observing.
+func firePanicHooks(onPanic []func(PanicInfo), phase string, r any, stack []byte) {
+	for _, fn := range onPanic {
+		func(f func(PanicInfo)) {
+			defer func() { _ = recover() }()
+			f(PanicInfo{Phase: phase, Value: r, Stack: stack})
+		}(fn)
+	}
+}
+
+// firePanic captures the current stack and notifies the OnPanic observers. It
+// is used by the resilient tool path, which recovers and continues (converting
+// the panic to a tool error) rather than propagating it.
+func firePanic(onPanic []func(PanicInfo), phase string, r any) {
+	firePanicHooks(onPanic, phase, r, debug.Stack())
+}
+
+// newPanicError captures the current stack, fires the OnPanic observers exactly
+// once, and returns the resulting *PanicError.
+func newPanicError(onPanic []func(PanicInfo), phase string, r any) *PanicError {
+	stack := debug.Stack()
+	firePanicHooks(onPanic, phase, r, stack)
+	return &PanicError{Phase: phase, Value: r, Stack: stack}
+}
+
+// callHook runs fn and, if it panics, fires OnPanic and re-panics the recovered
+// value wrapped in a *PanicError. If the recovered value is already a
+// *PanicError (a nested propagation), it is re-panicked as-is without firing
+// OnPanic again. The re-panicked *PanicError is converted into a returned error
+// by recoverToError (sync entry points) or into stream.Err() by
+// recoverToStreamErr (streaming goroutines).
+//
+// Used only by the propagate-fatal callbacks: OnRequest, OnResponse,
+// OnStepFinish, OnFinish, OnBeforeStep, and the StopWhen predicate.
+func callHook(onPanic []func(PanicInfo), phase string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			if pe, ok := r.(*PanicError); ok {
+				panic(pe)
+			}
+			panic(newPanicError(onPanic, phase, r))
+		}
+	}()
+	fn()
+}
+
+// recoverToError is deferred at synchronous entry points (GenerateText,
+// GenerateObject). It converts a *PanicError panic into the named return error
+// and re-panics any other value (genuine runtime panics are not masked).
+func recoverToError(err *error) {
+	if r := recover(); r != nil {
+		if pe, ok := r.(*PanicError); ok {
+			*err = pe
+			return
+		}
+		panic(r)
+	}
+}
+
+// recoverToStreamErr is deferred at streaming goroutine boundaries (StreamText,
+// StreamObject). It converts a *PanicError panic into a stored stream error via
+// set so it is reported through stream.Err(). A non-*PanicError value is wrapped
+// with newPanicError(phase) so a callback panic in a background goroutine never
+// crashes the process.
+func recoverToStreamErr(onPanic []func(PanicInfo), phase string, set func(error)) {
+	if r := recover(); r != nil {
+		if pe, ok := r.(*PanicError); ok {
+			set(pe)
+			return
+		}
+		set(newPanicError(onPanic, phase, r))
+	}
+}

--- a/panic.go
+++ b/panic.go
@@ -1,6 +1,9 @@
 package goai
 
-import "runtime/debug"
+import (
+	"errors"
+	"runtime/debug"
+)
 
 // firePanicHooks notifies every registered OnPanic observer. It never itself
 // panics: a panic inside an OnPanic callback is recovered and discarded so it
@@ -41,12 +44,9 @@ func newPanicError(onPanic []func(PanicInfo), phase string, r any) *PanicError {
 func callHook(onPanic []func(PanicInfo), phase string, fn func()) {
 	defer func() {
 		if r := recover(); r != nil {
-			// r is the recover() value (any). The direct type assertion is
-			// intentional, NOT errors.As: we detect whether THIS exact value is
-			// the sentinel we already wrapped, to avoid double-wrapping and
-			// re-firing OnPanic. errors.As would wrongly match a panic value that
-			// merely wraps a *PanicError and would drop the current phase.
-			if pe, ok := r.(*PanicError); ok {
+			// Already a *PanicError (re-panicked from an inner callHook): pass it
+			// through unchanged so OnPanic is not fired twice.
+			if pe := asPanicError(r); pe != nil {
 				panic(pe)
 			}
 			panic(newPanicError(onPanic, phase, r))
@@ -55,12 +55,25 @@ func callHook(onPanic []func(PanicInfo), phase string, fn func()) {
 	fn()
 }
 
+// asPanicError reports whether a recover() value is (or wraps) a *PanicError,
+// returning it if so. It bridges recover()'s any to errors.As: a non-error
+// panic value (e.g. a string) yields nil.
+func asPanicError(r any) *PanicError {
+	if err, ok := r.(error); ok {
+		var pe *PanicError
+		if errors.As(err, &pe) {
+			return pe
+		}
+	}
+	return nil
+}
+
 // recoverToError is deferred at synchronous entry points (GenerateText,
 // GenerateObject). It converts a *PanicError panic into the named return error
 // and re-panics any other value (genuine runtime panics are not masked).
 func recoverToError(err *error) {
 	if r := recover(); r != nil {
-		if pe, ok := r.(*PanicError); ok {
+		if pe := asPanicError(r); pe != nil {
 			*err = pe
 			return
 		}
@@ -75,7 +88,7 @@ func recoverToError(err *error) {
 // crashes the process.
 func recoverToStreamErr(onPanic []func(PanicInfo), phase string, set func(error)) {
 	if r := recover(); r != nil {
-		if pe, ok := r.(*PanicError); ok {
+		if pe := asPanicError(r); pe != nil {
 			set(pe)
 			return
 		}

--- a/panic.go
+++ b/panic.go
@@ -69,15 +69,18 @@ func asPanicError(r any) *PanicError {
 }
 
 // recoverToError is deferred at synchronous entry points (GenerateText,
-// GenerateObject). It converts a *PanicError panic into the named return error
-// and re-panics any other value (genuine runtime panics are not masked).
-func recoverToError(err *error) {
+// GenerateObject, StreamText, StreamObject). It converts any panic into the
+// named return error: a *PanicError passes through; any other value is wrapped
+// with newPanicError(phase="internal") and reported to OnPanic. This catch-all
+// (consistent with recoverToStreamErr) keeps a panic carrying sensitive data
+// from being printed to stderr as an uncaught crash dump.
+func recoverToError(onPanic []func(PanicInfo), err *error) {
 	if r := recover(); r != nil {
 		if pe := asPanicError(r); pe != nil {
 			*err = pe
 			return
 		}
-		panic(r)
+		*err = newPanicError(onPanic, "internal", r)
 	}
 }
 

--- a/panic.go
+++ b/panic.go
@@ -41,6 +41,11 @@ func newPanicError(onPanic []func(PanicInfo), phase string, r any) *PanicError {
 func callHook(onPanic []func(PanicInfo), phase string, fn func()) {
 	defer func() {
 		if r := recover(); r != nil {
+			// r is the recover() value (any). The direct type assertion is
+			// intentional, NOT errors.As: we detect whether THIS exact value is
+			// the sentinel we already wrapped, to avoid double-wrapping and
+			// re-firing OnPanic. errors.As would wrongly match a panic value that
+			// merely wraps a *PanicError and would drop the current phase.
 			if pe, ok := r.(*PanicError); ok {
 				panic(pe)
 			}

--- a/panic_test.go
+++ b/panic_test.go
@@ -239,6 +239,70 @@ func TestRecoverToStreamErr(t *testing.T) {
 	}()
 }
 
+// TestStreamText_Step1OnRequestPanic verifies that a panic in the synchronous
+// step-1 OnRequest hook (single-step StreamText) is surfaced as a *PanicError
+// returned by StreamText, not propagated raw into the caller's goroutine.
+func TestStreamText_Step1OnRequestPanic(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hi"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	var fired int
+	_, err := StreamText(t.Context(), model,
+		WithPrompt("hi"),
+		WithOnRequest(func(_ RequestInfo) { panic("step1 onrequest boom") }),
+		WithOnPanic(func(_ PanicInfo) { fired++ }),
+	)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
+	}
+	if pe.Phase != "OnRequest" {
+		t.Errorf("Phase = %q, want OnRequest", pe.Phase)
+	}
+	if fired != 1 {
+		t.Errorf("OnPanic fired %d times, want 1", fired)
+	}
+}
+
+// TestStreamText_ToolLoop_Step1OnRequestPanic verifies the same for the
+// multi-step path (streamWithToolLoop), where step-1 hooks also run
+// synchronously in the caller's goroutine.
+func TestStreamText_ToolLoop_Step1OnRequestPanic(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "hi"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+			), nil
+		},
+	}
+
+	_, err := StreamText(t.Context(), model,
+		WithPrompt("hi"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "t",
+			Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil },
+		}),
+		WithOnRequest(func(_ RequestInfo) { panic("step1 onrequest boom") }),
+	)
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
+	}
+	if pe.Phase != "OnRequest" {
+		t.Errorf("Phase = %q, want OnRequest", pe.Phase)
+	}
+}
+
 // TestOnPanic_MultipleObserversInOrder verifies all registered OnPanic hooks fire.
 func TestOnPanic_MultipleObserversInOrder(t *testing.T) {
 	model := &mockModel{

--- a/panic_test.go
+++ b/panic_test.go
@@ -14,8 +14,13 @@ import (
 func TestPanicError_ErrorAndUnwrap(t *testing.T) {
 	cause := errors.New("boom")
 	pe := &PanicError{Phase: "OnFinish", Value: cause}
-	if got := pe.Error(); got != "goai: panic in OnFinish: boom" {
-		t.Errorf("Error() = %q", got)
+	// Error() identifies the phase only; the raw value is omitted to avoid
+	// leaking sensitive data into logged error strings.
+	if got := pe.Error(); got != "goai: panic in OnFinish" {
+		t.Errorf("Error() = %q, want %q", got, "goai: panic in OnFinish")
+	}
+	if strings.Contains(pe.Error(), "boom") {
+		t.Error("Error() must not contain the raw panic value")
 	}
 	if !errors.Is(pe, cause) {
 		t.Error("errors.Is(pe, cause) = false; Unwrap should expose an error panic value")

--- a/panic_test.go
+++ b/panic_test.go
@@ -1,0 +1,264 @@
+package goai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestPanicError_ErrorAndUnwrap(t *testing.T) {
+	cause := errors.New("boom")
+	pe := &PanicError{Phase: "OnFinish", Value: cause}
+	if got := pe.Error(); got != "goai: panic in OnFinish: boom" {
+		t.Errorf("Error() = %q", got)
+	}
+	if !errors.Is(pe, cause) {
+		t.Error("errors.Is(pe, cause) = false; Unwrap should expose an error panic value")
+	}
+
+	// A non-error panic value unwraps to nil.
+	peStr := &PanicError{Phase: "OnStepFinish", Value: "plain string"}
+	if peStr.Unwrap() != nil {
+		t.Errorf("Unwrap() = %v, want nil for non-error value", peStr.Unwrap())
+	}
+}
+
+// TestOnPanic_FiresWithInfo verifies the OnPanic hook receives PanicInfo with
+// the phase, value, and a non-empty stack for a propagate-fatal hook.
+func TestOnPanic_FiresWithInfo(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	var got PanicInfo
+	var fired atomic.Int32
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("hi"),
+		WithOnStepFinish(func(_ StepResult) { panic("kaboom") }),
+		WithOnPanic(func(info PanicInfo) {
+			got = info
+			fired.Add(1)
+		}),
+	)
+
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
+	}
+	if fired.Load() != 1 {
+		t.Fatalf("OnPanic fired %d times, want 1", fired.Load())
+	}
+	if got.Phase != "OnStepFinish" {
+		t.Errorf("Phase = %q, want OnStepFinish", got.Phase)
+	}
+	if got.Value != "kaboom" {
+		t.Errorf("Value = %v, want kaboom", got.Value)
+	}
+	if len(got.Stack) == 0 {
+		t.Error("Stack is empty, want a captured goroutine stack")
+	}
+}
+
+// TestOnPanic_FiresForToolPath verifies OnPanic fires for a tool Execute panic
+// even though the tool path stays resilient (no *PanicError propagation).
+func TestOnPanic_FiresForToolPath(t *testing.T) {
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "boomtool", Input: json.RawMessage(`{}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	var got PanicInfo
+	var fired atomic.Int32
+	result, err := GenerateText(t.Context(), model,
+		WithPrompt("go"),
+		WithMaxSteps(3),
+		WithTools(Tool{
+			Name:    "boomtool",
+			Execute: func(_ context.Context, _ json.RawMessage) (string, error) { panic("tool boom") },
+		}),
+		WithOnPanic(func(info PanicInfo) {
+			got = info
+			fired.Add(1)
+		}),
+	)
+	// Tool panic does NOT propagate: the loop continues and returns normally.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want done (loop should continue past a tool panic)", result.Text)
+	}
+	if fired.Load() != 1 {
+		t.Fatalf("OnPanic fired %d times, want 1", fired.Load())
+	}
+	if got.Phase != "tool:boomtool" {
+		t.Errorf("Phase = %q, want tool:boomtool", got.Phase)
+	}
+	if got.Value != "tool boom" {
+		t.Errorf("Value = %v, want 'tool boom'", got.Value)
+	}
+}
+
+// TestOnPanic_HandlerPanicIsContained verifies that a panic inside an OnPanic
+// callback itself is swallowed and does not disrupt the *PanicError propagation.
+func TestOnPanic_HandlerPanicIsContained(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("hi"),
+		WithOnFinish(func(_ FinishInfo) { panic("original") }),
+		WithOnPanic(func(_ PanicInfo) { panic("handler also panics") }),
+	)
+
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *PanicError", err)
+	}
+	if pe.Phase != "OnFinish" || pe.Value != "original" {
+		t.Errorf("PanicError = {%q, %v}, want {OnFinish, original}", pe.Phase, pe.Value)
+	}
+}
+
+// --- Direct unit tests for the panic helpers' defensive branches ---
+
+// callHook should re-panic an already-wrapped *PanicError as-is, without firing
+// OnPanic a second time.
+func TestCallHook_NestedPanicErrorPassesThrough(t *testing.T) {
+	orig := &PanicError{Phase: "Inner", Value: "x"}
+	var fired int
+	onPanic := []func(PanicInfo){func(PanicInfo) { fired++ }}
+
+	defer func() {
+		r := recover()
+		if r != orig {
+			t.Fatalf("re-panicked %v, want the original *PanicError", r)
+		}
+		if fired != 0 {
+			t.Errorf("OnPanic fired %d times, want 0 (already wrapped)", fired)
+		}
+	}()
+	callHook(onPanic, "Outer", func() { panic(orig) })
+}
+
+// recoverToError converts a *PanicError to the error pointer and re-panics any
+// other value (genuine runtime panics are not masked).
+func TestRecoverToError(t *testing.T) {
+	// *PanicError -> assigned.
+	func() {
+		var err error
+		defer func() {
+			if err == nil {
+				t.Error("recoverToError did not set err for *PanicError")
+			}
+			var pe *PanicError
+			if !errors.As(err, &pe) {
+				t.Errorf("err = %v, want *PanicError", err)
+			}
+		}()
+		defer recoverToError(&err)
+		panic(&PanicError{Phase: "X", Value: "y"})
+	}()
+
+	// Non-*PanicError -> re-panicked, err untouched.
+	func() {
+		var err error
+		defer func() {
+			if r := recover(); r != "raw" {
+				t.Errorf("recovered %v, want raw re-panic", r)
+			}
+			if err != nil {
+				t.Errorf("err = %v, want nil (non-PanicError must not be captured)", err)
+			}
+		}()
+		defer recoverToError(&err)
+		panic("raw")
+	}()
+}
+
+// recoverToStreamErr stores a *PanicError directly and wraps a raw panic value
+// (firing OnPanic) so a goroutine panic never escapes.
+func TestRecoverToStreamErr(t *testing.T) {
+	// *PanicError -> stored verbatim, OnPanic not re-fired.
+	func() {
+		var got error
+		var fired int
+		defer func() {
+			var pe *PanicError
+			if !errors.As(got, &pe) || pe.Phase != "X" {
+				t.Errorf("got = %v, want *PanicError{Phase:X}", got)
+			}
+			if fired != 0 {
+				t.Errorf("OnPanic fired %d times, want 0", fired)
+			}
+		}()
+		defer recoverToStreamErr([]func(PanicInfo){func(PanicInfo) { fired++ }}, "stream", func(e error) { got = e })
+		panic(&PanicError{Phase: "X", Value: "y"})
+	}()
+
+	// Raw value -> wrapped with the fallback phase, OnPanic fired.
+	func() {
+		var got error
+		var fired int
+		defer func() {
+			var pe *PanicError
+			if !errors.As(got, &pe) {
+				t.Fatalf("got = %v, want *PanicError", got)
+			}
+			if pe.Phase != "stream" || pe.Value != "raw" {
+				t.Errorf("PanicError = {%q, %v}, want {stream, raw}", pe.Phase, pe.Value)
+			}
+			if fired != 1 {
+				t.Errorf("OnPanic fired %d times, want 1", fired)
+			}
+		}()
+		defer recoverToStreamErr([]func(PanicInfo){func(PanicInfo) { fired++ }}, "stream", func(e error) { got = e })
+		panic("raw")
+	}()
+}
+
+// TestOnPanic_MultipleObserversInOrder verifies all registered OnPanic hooks fire.
+func TestOnPanic_MultipleObserversInOrder(t *testing.T) {
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	var order []string
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("hi"),
+		WithOnStepFinish(func(_ StepResult) { panic("x") }),
+		WithOnPanic(func(_ PanicInfo) { order = append(order, "a") }),
+		WithOnPanic(func(_ PanicInfo) { order = append(order, "b") }),
+	)
+	if err == nil {
+		t.Fatal("want *PanicError, got nil")
+	}
+	if strings.Join(order, ",") != "a,b" {
+		t.Errorf("OnPanic order = %v, want [a b]", order)
+	}
+}

--- a/panic_test.go
+++ b/panic_test.go
@@ -168,37 +168,46 @@ func TestCallHook_NestedPanicErrorPassesThrough(t *testing.T) {
 	callHook(onPanic, "Outer", func() { panic(orig) })
 }
 
-// recoverToError converts a *PanicError to the error pointer and re-panics any
-// other value (genuine runtime panics are not masked).
+// recoverToError converts a *PanicError to the error pointer as-is, and wraps
+// any other panic value as a *PanicError(phase="internal") rather than letting
+// it escape as an uncaught crash.
 func TestRecoverToError(t *testing.T) {
-	// *PanicError -> assigned.
+	// *PanicError -> assigned, phase preserved.
 	func() {
 		var err error
 		defer func() {
-			if err == nil {
-				t.Error("recoverToError did not set err for *PanicError")
-			}
 			var pe *PanicError
 			if !errors.As(err, &pe) {
-				t.Errorf("err = %v, want *PanicError", err)
+				t.Fatalf("err = %v, want *PanicError", err)
+			}
+			if pe.Phase != "X" {
+				t.Errorf("Phase = %q, want X", pe.Phase)
 			}
 		}()
-		defer recoverToError(&err)
+		defer recoverToError(nil, &err)
 		panic(&PanicError{Phase: "X", Value: "y"})
 	}()
 
-	// Non-*PanicError -> re-panicked, err untouched.
+	// Non-*PanicError -> wrapped as internal, OnPanic fired, no re-panic escapes.
 	func() {
 		var err error
+		var fired int
 		defer func() {
-			if r := recover(); r != "raw" {
-				t.Errorf("recovered %v, want raw re-panic", r)
+			if r := recover(); r != nil {
+				t.Errorf("recoverToError must not re-panic; got %v", r)
 			}
-			if err != nil {
-				t.Errorf("err = %v, want nil (non-PanicError must not be captured)", err)
+			var pe *PanicError
+			if !errors.As(err, &pe) {
+				t.Fatalf("err = %v, want *PanicError", err)
+			}
+			if pe.Phase != "internal" || pe.Value != "raw" {
+				t.Errorf("PanicError = {%q, %v}, want {internal, raw}", pe.Phase, pe.Value)
+			}
+			if fired != 1 {
+				t.Errorf("OnPanic fired %d times, want 1", fired)
 			}
 		}()
-		defer recoverToError(&err)
+		defer recoverToError([]func(PanicInfo){func(PanicInfo) { fired++ }}, &err)
 		panic("raw")
 	}()
 }


### PR DESCRIPTION
## Problem

Lifecycle hooks and the `StopWhen` predicate ran inside a `recover` that
printed the panic to stderr and discarded it (issue #82). Callers could not
intercept the panic programmatically, and observability handlers (otel,
langfuse) never saw it.

## Change

- Add `WithOnPanic(func(PanicInfo))` and a `PanicError` type (`Phase`, `Value`,
  `Stack`; `Unwrap` exposes an error panic value).
- **Propagate-fatal callbacks** (`OnRequest`, `OnResponse`, `OnStepFinish`,
  `OnFinish`, `OnBeforeStep`, `StopWhen`): a panic is reported to `OnPanic` and
  then surfaced as a `*PanicError` - returned by `GenerateText`/`GenerateObject`,
  or via `stream.Err()` for `StreamText`/`StreamObject`. Subsequent callbacks of
  that hook do not run. Aligns with Vercel AI SDK, where a throwing callback
  rejects the call.
- **Tool path** (tool `Execute`, `OnToolCallStart`, `OnToolCall`,
  `OnBeforeToolExecute`, `OnAfterToolExecute`) stays resilient: panics are
  converted to a tool error so one bad tool does not abort the agent loop, and
  are still reported to `OnPanic`.

## Breaking change

A panicking lifecycle hook or `StopWhen` predicate now fails the call (returned
error / `stream.Err()`) instead of being silently swallowed. Code that relied on
the old swallow-and-continue behavior must register `OnPanic` or stop panicking
in hooks.

## Tests

Existing hook-panic tests rewritten to assert propagation; new `panic_test.go`
covers `PanicError`, `OnPanic` (lifecycle + tool path), handler-panic
containment, ordering, and the recover helpers. Root package coverage 97.5%
(panic.go 100%); full suite + both observability submodules pass; race-tested.

Closes #82