### PR TITLE
ci: switch zenflow-review to Google Gemini (gemini-3-flash-preview)

### DIFF
--- a/.github/workflows/zenflow-review.yml
+++ b/.github/workflows/zenflow-review.yml
@@ -1,8 +1,8 @@
 name: zenflow PR review
 
-# Comment-triggered AI code review using zenflow + FPT Smart Cloud
-# (Qwen3.6-27B). Repo maintainers post `/zenflow-review` on a PR to
-# trigger a two-reviewer pass (Go idiomatics + security) that
+# Comment-triggered AI code review using zenflow + Google Gemini
+# (gemini-3-flash-preview). Repo maintainers post `/zenflow-review` on a
+# PR to trigger a two-reviewer pass (Go idiomatics + security) that
 # synthesises into a single PR comment. See .zenflow/pr-review.yaml for
 # the workflow spec.
 
@@ -66,9 +66,8 @@ jobs:
 
       - name: Run zenflow review
         env:
-          ZENFLOW_MODEL: fptcloud/Qwen3.6-27B
-          FPT_API_KEY: ${{ secrets.FPT_API_KEY }}
-          FPT_REGION: jp
+          ZENFLOW_MODEL: google/gemini-3-flash-preview
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           # --sandbox grants the safe tool set (read, write, grep, glob)
           # without bash. Without an explicit permission flag zenflow


### PR DESCRIPTION
The FPT Smart Cloud key for `Qwen3.6-27B` is rejected (`401 Invalid API Key`), so the zenflow review step failed on every run.

Switch the reviewer model to `google/gemini-3-flash-preview` and read `GEMINI_API_KEY` (added as a repo secret). Drops the now-unused `FPT_API_KEY`/`FPT_REGION` env.

Must land on `main` because `issue_comment`-triggered workflows always run from the default branch's workflow definition.