### PR TITLE
feat: add NewTool typed constructor for tool definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,27 +191,17 @@ final, err := stream.Result()
 
 ## Tools
 
-Define tools with JSON Schema and an `Execute` handler. Set `MaxSteps` to enable the auto tool loop.
+Define a tool from a typed input struct with `goai.NewTool` - the JSON Schema is
+generated from the struct and arguments are unmarshaled for you. Set `MaxSteps`
+to enable the auto tool loop.
 
 ```go
-import "encoding/json"
-
-weatherTool := goai.Tool{
-	Name:        "get_weather",
-	Description: "Get the current weather for a city.",
-	InputSchema: json.RawMessage(`{
-		"type": "object",
-		"properties": {"city": {"type": "string", "description": "City name"}},
-		"required": ["city"]
-	}`),
-	Execute: func(ctx context.Context, input json.RawMessage) (string, error) {
-		var args struct{ City string `json:"city"` }
-		if err := json.Unmarshal(input, &args); err != nil {
-			return "", err
-		}
+weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+	func(ctx context.Context, args struct {
+		City string `json:"city" jsonschema:"description=City name"`
+	}) (string, error) {
 		return fmt.Sprintf("22°C and sunny in %s", args.City), nil
-	},
-}
+	})
 
 result, err := goai.GenerateText(ctx, model,
 	goai.WithPrompt("What's the weather in Tokyo?"),

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -40,7 +40,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 **Example:**
 
 ```go
-model := google.Chat("gemini-2.0-flash") // auto-reads GOOGLE_GENERATIVE_AI_API_KEY or GEMINI_API_KEY
+model := google.Chat("gemini-3-flash-preview") // auto-reads GOOGLE_GENERATIVE_AI_API_KEY or GEMINI_API_KEY
 
 result, err := goai.GenerateText(context.Background(), model,
     goai.WithSystem("You are a helpful assistant. Be concise."),

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -185,6 +185,25 @@ When `Execute` is non-nil and `MaxSteps > 1`, `GenerateText` automatically invok
 
 When using provider-defined tools (web search, code execution, etc.), set `ProviderDefinedType` and leave `Execute` nil - the provider handles execution server-side.
 
+### NewTool
+
+Builds a `Tool` from a typed input struct and a typed execute function. The JSON Schema is generated from `In` via `SchemaFrom`, and the model's raw JSON arguments are unmarshaled into `In` before execute runs - so callers neither hand-write JSON Schema nor unmarshal input.
+
+```go
+func NewTool[In any](name, description string, execute func(ctx context.Context, input In) (string, error)) Tool
+```
+
+```go
+weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+    func(ctx context.Context, in struct {
+        City string `json:"city" jsonschema:"description=City name"`
+    }) (string, error) {
+        return forecast(in.City), nil
+    })
+```
+
+`In` is typically a struct using `json`/`jsonschema` tags (see [SchemaFrom](#schemafrom)); use `struct{}` for a no-parameter tool. If the model's arguments fail to unmarshal into `In`, execute is not called and the error is returned to the model as the tool result. For a hand-written schema or a provider-defined tool, build the `Tool` struct directly instead.
+
 ### Option
 
 A function that configures a generation call. See [Options](options.md) for all available option functions.

--- a/docs/concepts/token-source.md
+++ b/docs/concepts/token-source.md
@@ -135,7 +135,7 @@ ts := provider.CachedTokenSource(func(ctx context.Context) (*provider.Token, err
     }, nil
 })
 
-model := vertex.Chat("gemini-2.0-flash", vertex.WithTokenSource(ts))
+model := vertex.Chat("gemini-3-flash-preview", vertex.WithTokenSource(ts))
 ```
 
 ### Custom OAuth

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -9,7 +9,33 @@ Tools let the model call functions defined in your code. The model decides when 
 
 ## Defining a Tool
 
-A `goai.Tool` has a name, description, JSON Schema for input, and an `Execute` function:
+`goai.NewTool` builds a tool from a typed input struct and a typed `execute`
+function. The JSON Schema is generated from the struct (via `SchemaFrom`), and
+the model's arguments are unmarshaled into the struct before `execute` runs - so
+you write no JSON Schema by hand and no manual unmarshaling:
+
+```go
+weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+    func(ctx context.Context, params struct {
+        City string `json:"city" jsonschema:"description=City name"`
+    }) (string, error) {
+        // Call your weather API here.
+        return fmt.Sprintf("72F and sunny in %s", params.City), nil
+    })
+```
+
+The input struct uses `json` and `jsonschema` tags (see [Structured
+Output](/getting-started/structured-output) for the supported tags). Use
+`struct{}` for a tool that takes no parameters. If the model sends arguments that
+do not unmarshal into the struct, `execute` is not called and the error is
+returned to the model as the tool result.
+
+### Building a Tool by hand
+
+For full control - a hand-written JSON Schema, a dynamically built schema, or a
+provider-defined tool - construct the `goai.Tool` struct directly. It has a name,
+description, JSON Schema for input, and an `Execute` function that receives raw
+JSON:
 
 ```go
 weatherTool := goai.Tool{

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -235,24 +235,21 @@ Tools let the model call functions defined in your code.
 
 ### Defining a Tool
 
+`goai.NewTool` builds a tool from a typed input struct: the JSON Schema is
+generated from the struct and the model's arguments are unmarshaled into it
+before execute runs (no hand-written schema, no manual unmarshaling).
+
 ```go
-tool := goai.Tool{
-    Name:        "get_weather",
-    Description: "Get weather for a city.",
-    InputSchema: json.RawMessage(`{
-        "type": "object",
-        "properties": {
-            "city": {"type": "string", "description": "City name"}
-        },
-        "required": ["city"]
-    }`),
-    Execute: func(ctx context.Context, input json.RawMessage) (string, error) {
-        var params struct { City string `json:"city"` }
-        json.Unmarshal(input, &params)
+tool := goai.NewTool("get_weather", "Get weather for a city.",
+    func(ctx context.Context, params struct {
+        City string `json:"city" jsonschema:"description=City name"`
+    }) (string, error) {
         return fmt.Sprintf("72F and sunny in %s", params.City), nil
-    },
-}
+    })
 ```
+
+For a hand-written JSON Schema or a provider-defined tool, build the `goai.Tool`
+struct directly (set `InputSchema` and an `Execute` that receives raw JSON).
 
 ### Auto Tool Loop
 

--- a/examples/agent-loop/main.go
+++ b/examples/agent-loop/main.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -20,43 +19,24 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	// Define multiple tools for a multi-step workflow.
-	searchTool := goai.Tool{
-		Name:        "search",
-		Description: "Search for information on a topic.",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"query": {"type": "string", "description": "Search query"}
-			},
-			"required": ["query"]
-		}`),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args struct{ Query string }
-			_ = json.Unmarshal(input, &args)
+	searchTool := goai.NewTool("search", "Search for information on a topic.",
+		func(_ context.Context, args struct {
+			Query string `json:"query" jsonschema:"description=Search query"`
+		}) (string, error) {
 			return fmt.Sprintf("Search results for %q: Go was created by Google in 2009.", args.Query), nil
-		},
-	}
+		})
 
-	calculatorTool := goai.Tool{
-		Name:        "calculate",
-		Description: "Calculate: subtract second number from first. Input: {\"a\": 2026, \"b\": 2009}",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"a": {"type": "integer", "description": "First number"},
-				"b": {"type": "integer", "description": "Second number"}
-			},
-			"required": ["a", "b"]
-		}`),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args struct{ A, B int }
-			_ = json.Unmarshal(input, &args)
+	calculatorTool := goai.NewTool("calculate",
+		"Calculate: subtract second number from first. Input: {\"a\": 2026, \"b\": 2009}",
+		func(_ context.Context, args struct {
+			A int `json:"a" jsonschema:"description=First number"`
+			B int `json:"b" jsonschema:"description=Second number"`
+		}) (string, error) {
 			return fmt.Sprintf("%d", args.A-args.B), nil
-		},
-	}
+		})
 
 	result, err := goai.GenerateText(context.Background(), model,
 		goai.WithSystem("You are a research assistant. Use tools to find information and calculate."),

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	result, err := goai.GenerateText(context.Background(), model,
 		goai.WithSystem("You are a helpful assistant. Be concise."),

--- a/examples/citations/main.go
+++ b/examples/citations/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	result, err := goai.GenerateText(context.Background(), model,
 		goai.WithPrompt("What is the Go programming language? Give a brief history."),

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -27,43 +26,23 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	// Define tools.
-	readFile := goai.Tool{
-		Name:        "read_file",
-		Description: "Read the contents of a file.",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"path": {"type": "string", "description": "File path to read"}
-			},
-			"required": ["path"]
-		}`),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args struct {
-				Path string `json:"path"`
-			}
-			json.Unmarshal(input, &args)
+	readFile := goai.NewTool("read_file", "Read the contents of a file.",
+		func(_ context.Context, args struct {
+			Path string `json:"path" jsonschema:"description=File path to read"`
+		}) (string, error) {
 			// Simulate returning sensitive content.
 			return fmt.Sprintf("Contents of %s:\nAPI_KEY=sk-secret-12345\nDB_HOST=prod.example.com", args.Path), nil
-		},
-	}
+		})
 
-	deleteFile := goai.Tool{
-		Name:        "delete_file",
-		Description: "Delete a file from disk.",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"path": {"type": "string", "description": "File path to delete"}
-			},
-			"required": ["path"]
-		}`),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
+	deleteFile := goai.NewTool("delete_file", "Delete a file from disk.",
+		func(_ context.Context, _ struct {
+			Path string `json:"path" jsonschema:"description=File path to delete"`
+		}) (string, error) {
 			return "deleted", nil
-		},
-	}
+		})
 
 	result, err := goai.GenerateText(context.Background(), model,
 		goai.WithPrompt("Read the .env file, then delete the temp.log file."),

--- a/examples/langfuse/main.go
+++ b/examples/langfuse/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -30,22 +29,16 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	// Tool that simulates fetching weather data.
-	weatherTool := goai.Tool{
-		Name:        "get_weather",
-		Description: "Get the current weather for a city.",
-		InputSchema: goai.SchemaFrom[struct {
-			City string `json:"city" jsonschema:"description=City name,required"`
-		}](),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args struct{ City string }
-			_ = json.Unmarshal(input, &args)
+	weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+		func(_ context.Context, args struct {
+			City string `json:"city" jsonschema:"description=City name"`
+		}) (string, error) {
 			time.Sleep(50 * time.Millisecond)
 			return fmt.Sprintf(`{"city":%q,"temp":"22°C","condition":"sunny"}`, args.City), nil
-		},
-	}
+		})
 
 	ctx := context.Background()
 

--- a/examples/mcp-tools/main.go
+++ b/examples/mcp-tools/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(apiKey))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(apiKey))
 
 	// Prefer the local MCP test server if present; otherwise fall back to the
 	// public filesystem MCP server so this example still runs in OSS checkouts.

--- a/examples/multi-turn/main.go
+++ b/examples/multi-turn/main.go
@@ -14,7 +14,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -25,26 +24,14 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
-	weatherTool := goai.Tool{
-		Name:        "get_weather",
-		Description: "Get the current weather for a city.",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"city": {"type": "string", "description": "City name"}
-			},
-			"required": ["city"]
-		}`),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args struct{ City string }
-			if err := json.Unmarshal(input, &args); err != nil {
-				return "", err
-			}
+	weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+		func(_ context.Context, args struct {
+			City string `json:"city" jsonschema:"description=City name"`
+		}) (string, error) {
 			return fmt.Sprintf("Weather in %s: 22C, sunny", args.City), nil
-		},
-	}
+		})
 
 	ctx := context.Background()
 	var messages []provider.Message

--- a/examples/otel/main.go
+++ b/examples/otel/main.go
@@ -13,7 +13,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -53,22 +52,16 @@ func main() {
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 	otel.SetTracerProvider(tp)
 
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	// Tool that simulates fetching weather data.
-	weatherTool := goai.Tool{
-		Name:        "get_weather",
-		Description: "Get the current weather for a city.",
-		InputSchema: goai.SchemaFrom[struct {
-			City string `json:"city" jsonschema:"description=City name,required"`
-		}](),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args struct{ City string }
-			_ = json.Unmarshal(input, &args)
+	weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+		func(_ context.Context, args struct {
+			City string `json:"city" jsonschema:"description=City name"`
+		}) (string, error) {
 			time.Sleep(50 * time.Millisecond)
 			return fmt.Sprintf(`{"city":%q,"temp":"22°C","condition":"sunny"}`, args.City), nil
-		},
-	}
+		})
 
 	ctx := context.Background()
 

--- a/examples/streaming-tools/main.go
+++ b/examples/streaming-tools/main.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -23,26 +22,12 @@ import (
 func main() {
 	model := openai.Chat("gpt-4o-mini", openai.WithAPIKey(os.Getenv("OPENAI_API_KEY")))
 
-	weatherTool := goai.Tool{
-		Name:        "get_weather",
-		Description: "Get the current weather for a city.",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"city": {"type": "string", "description": "City name"}
-			},
-			"required": ["city"]
-		}`),
-		Execute: func(_ context.Context, input json.RawMessage) (string, error) {
-			var args struct {
-				City string `json:"city"`
-			}
-			if err := json.Unmarshal(input, &args); err != nil {
-				return "", err
-			}
+	weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+		func(_ context.Context, args struct {
+			City string `json:"city" jsonschema:"description=City name"`
+		}) (string, error) {
 			return fmt.Sprintf(`{"city": %q, "temp": "18°C", "condition": "partly cloudy"}`, args.City), nil
-		},
-	}
+		})
 
 	stream, err := goai.StreamText(context.Background(), model,
 		goai.WithSystem("You are a helpful weather assistant. Be concise."),

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
 	stream, err := goai.StreamText(context.Background(), model,
 		goai.WithSystem("You are a helpful assistant."),

--- a/examples/tools/main.go
+++ b/examples/tools/main.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -20,29 +19,15 @@ import (
 )
 
 func main() {
-	model := google.Chat("gemini-2.0-flash", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+	model := google.Chat("gemini-3-flash-preview", google.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 
-	weatherTool := goai.Tool{
-		Name:        "get_weather",
-		Description: "Get the current weather for a city.",
-		InputSchema: json.RawMessage(`{
-			"type": "object",
-			"properties": {
-				"city": {"type": "string", "description": "City name"}
-			},
-			"required": ["city"]
-		}`),
-		Execute: func(ctx context.Context, input json.RawMessage) (string, error) {
-			var args struct {
-				City string `json:"city"`
-			}
-			if err := json.Unmarshal(input, &args); err != nil {
-				return "", err
-			}
+	weatherTool := goai.NewTool("get_weather", "Get the current weather for a city.",
+		func(ctx context.Context, args struct {
+			City string `json:"city" jsonschema:"description=City name"`
+		}) (string, error) {
 			// Simulated weather lookup.
 			return fmt.Sprintf("The weather in %s is 22°C and sunny.", args.City), nil
-		},
-	}
+		})
 
 	// MaxSteps=2: step 1 = model calls tool, step 2 = model uses result.
 	result, err := goai.GenerateText(context.Background(), model,

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package goai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 )
 
 // Tool defines a tool that can be called by the model during generation.
@@ -32,4 +33,40 @@ type Tool struct {
 	// result message. Do not include sensitive data (credentials, internal paths)
 	// in error messages as they will be sent to the LLM provider's API.
 	Execute func(ctx context.Context, input json.RawMessage) (string, error)
+}
+
+// NewTool builds a Tool from a typed input struct and a typed execute function.
+// The JSON Schema is generated from In via SchemaFrom, and the raw JSON
+// arguments from the model are unmarshaled into In before execute runs - so
+// callers neither hand-write JSON Schema nor unmarshal input themselves.
+//
+// In is typically a struct whose exported fields carry json and jsonschema tags
+// (see SchemaFrom for the supported tags). Use struct{} for a tool that takes no
+// parameters.
+//
+// If the model sends arguments that do not unmarshal into In, execute is not
+// called and the error is returned to the model as the tool result. Empty
+// arguments leave In at its zero value.
+//
+//	weather := goai.NewTool("get_weather", "Get the weather for a city",
+//		func(ctx context.Context, in struct {
+//			City string `json:"city" jsonschema:"description=City name"`
+//		}) (string, error) {
+//			return forecast(in.City), nil
+//		})
+func NewTool[In any](name, description string, execute func(ctx context.Context, input In) (string, error)) Tool {
+	return Tool{
+		Name:        name,
+		Description: description,
+		InputSchema: SchemaFrom[In](),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var in In
+			if len(raw) > 0 {
+				if err := json.Unmarshal(raw, &in); err != nil {
+					return "", fmt.Errorf("goai: tool %q: invalid input: %w", name, err)
+				}
+			}
+			return execute(ctx, in)
+		},
+	}
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,150 @@
+package goai
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestNewTool_SchemaAndExecute(t *testing.T) {
+	type weatherIn struct {
+		City string `json:"city" jsonschema:"description=City name"`
+		Days int    `json:"days"`
+	}
+
+	var gotCity string
+	var gotDays int
+	tool := NewTool("get_weather", "Get the weather",
+		func(_ context.Context, in weatherIn) (string, error) {
+			gotCity = in.City
+			gotDays = in.Days
+			return "sunny in " + in.City, nil
+		})
+
+	if tool.Name != "get_weather" {
+		t.Errorf("Name = %q, want get_weather", tool.Name)
+	}
+	if tool.Description != "Get the weather" {
+		t.Errorf("Description = %q", tool.Description)
+	}
+
+	// InputSchema is generated from the struct.
+	want := SchemaFrom[weatherIn]()
+	if string(tool.InputSchema) != string(want) {
+		t.Errorf("InputSchema = %s, want %s", tool.InputSchema, want)
+	}
+	if !strings.Contains(string(tool.InputSchema), `"city"`) {
+		t.Errorf("InputSchema missing city property: %s", tool.InputSchema)
+	}
+
+	// Execute unmarshals raw JSON into the typed struct.
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"city":"NYC","days":3}`))
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if out != "sunny in NYC" {
+		t.Errorf("output = %q, want 'sunny in NYC'", out)
+	}
+	if gotCity != "NYC" || gotDays != 3 {
+		t.Errorf("decoded input = {%q, %d}, want {NYC, 3}", gotCity, gotDays)
+	}
+}
+
+func TestNewTool_InvalidInput(t *testing.T) {
+	called := false
+	tool := NewTool("t", "d", func(_ context.Context, _ struct {
+		N int `json:"n"`
+	}) (string, error) {
+		called = true
+		return "ok", nil
+	})
+
+	// "n" expects a number; a string fails to unmarshal.
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"n":"not-a-number"}`))
+	if err == nil {
+		t.Fatal("expected error for invalid input, got nil")
+	}
+	if called {
+		t.Error("execute must not run when input fails to unmarshal")
+	}
+	if out != "" {
+		t.Errorf("output = %q, want empty", out)
+	}
+	if !strings.Contains(err.Error(), `tool "t"`) || !strings.Contains(err.Error(), "invalid input") {
+		t.Errorf("error = %q, want it to name the tool and 'invalid input'", err)
+	}
+}
+
+func TestNewTool_EmptyInput(t *testing.T) {
+	// A no-parameter tool: empty/zero args leave In at its zero value and
+	// execute still runs.
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(""), json.RawMessage("{}")} {
+		ran := false
+		tool := NewTool("noop", "no params", func(_ context.Context, _ struct{}) (string, error) {
+			ran = true
+			return "done", nil
+		})
+		out, err := tool.Execute(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("raw=%q: unexpected error: %v", raw, err)
+		}
+		if !ran || out != "done" {
+			t.Errorf("raw=%q: ran=%v out=%q, want true/done", raw, ran, out)
+		}
+	}
+}
+
+func TestNewTool_ExecuteErrorPropagates(t *testing.T) {
+	sentinel := "boom from tool"
+	tool := NewTool("t", "d", func(_ context.Context, _ struct{}) (string, error) {
+		return "", &simpleErr{sentinel}
+	})
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err == nil || err.Error() != sentinel {
+		t.Fatalf("err = %v, want %q (execute error forwarded verbatim)", err, sentinel)
+	}
+}
+
+type simpleErr struct{ s string }
+
+func (e *simpleErr) Error() string { return e.s }
+
+func TestNewTool_WorksInGenerateLoop(t *testing.T) {
+	// End-to-end: NewTool plugs into the auto tool loop like a hand-built Tool.
+	callCount := 0
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			callCount++
+			if callCount == 1 {
+				return &provider.GenerateResult{
+					ToolCalls:    []provider.ToolCall{{ID: "tc1", Name: "echo", Input: json.RawMessage(`{"msg":"hi"}`)}},
+					FinishReason: provider.FinishToolCalls,
+				}, nil
+			}
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	var seen string
+	tool := NewTool("echo", "echo a message", func(_ context.Context, in struct {
+		Msg string `json:"msg"`
+	}) (string, error) {
+		seen = in.Msg
+		return "echoed: " + in.Msg, nil
+	})
+
+	res, err := GenerateText(t.Context(), model, WithPrompt("go"), WithMaxSteps(3), WithTools(tool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen != "hi" {
+		t.Errorf("tool saw msg=%q, want hi", seen)
+	}
+	if res.Text != "done" {
+		t.Errorf("Text = %q, want done", res.Text)
+	}
+}


### PR DESCRIPTION
## What

`goai.NewTool[In](name, description, execute)` builds a `Tool` from a typed input struct: the JSON Schema is generated from `In` via `SchemaFrom`, and the model's raw JSON arguments are unmarshaled into `In` before `execute` runs - so callers no longer hand-write JSON Schema or unmarshal input (issue #83).

```go
weatherTool := goai.NewTool("get_weather", "Get the weather for a city.",
    func(ctx context.Context, in struct {
        City string `json:"city" jsonschema:"description=City name"`
    }) (string, error) {
        return forecast(in.City), nil
    })
```

If the model's arguments fail to unmarshal into `In`, `execute` is not called and the error is returned to the model as the tool result. The raw `goai.Tool` struct form remains for hand-written schemas and provider-defined tools.

## Also

- Migrate all example tools and the tool-use docs (README, concepts/tools, api/types, llms-full) to `NewTool`.
- Bump example model ids `gemini-2.0-flash` -> `gemini-3-flash-preview`.

## Tests

New `types_test.go` covers schema generation, typed decode, invalid/empty input, error propagation, and an end-to-end tool loop. Root coverage 97.6%.

Closes #83