### PR TITLE
fix(openai): handle nested error fields in Responses API stream error…

### DIFF
--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -1532,6 +1532,79 @@ func TestStreamResponses_RateLimitRetryable(t *testing.T) {
 	t.Error("expected retryable APIError for rate_limit_exceeded")
 }
 
+func TestStreamResponses_ErrorEventNestedRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: error\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"error","error":{"type":"tokens","code":"rate_limit_exceeded","message":"Rate limit reached for gpt-4o","param":null},"sequence_number":2}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
+				if !apiErr.IsRetryable {
+					t.Error("rate_limit_exceeded should be retryable")
+				}
+				if apiErr.StatusCode != 429 {
+					t.Errorf("expected StatusCode=429, got %d", apiErr.StatusCode)
+				}
+				if apiErr.Message != "Rate limit reached for gpt-4o" {
+					t.Errorf("Message = %q", apiErr.Message)
+				}
+				return
+			}
+		}
+	}
+	t.Error("expected retryable APIError for nested rate_limit_exceeded")
+}
+
+func TestStreamResponses_ErrorEventFlatRateLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: error\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"error","code":"rate_limit_exceeded","message":"Rate limit reached","param":null,"sequence_number":1}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
+				if !apiErr.IsRetryable {
+					t.Error("rate_limit_exceeded should be retryable")
+				}
+				if apiErr.StatusCode != 429 {
+					t.Errorf("expected StatusCode=429, got %d", apiErr.StatusCode)
+				}
+				return
+			}
+		}
+	}
+	t.Error("expected retryable APIError for flat rate_limit_exceeded")
+}
+
 func TestStreamResponses_ServerErrorRetryable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -744,84 +744,29 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 				} `json:"response"`
 			}
 			if json.Unmarshal([]byte(data), &ev) == nil {
-				msg := cmp.Or(ev.Response.Error.Message, "response failed")
-				code := ev.Response.Error.Code
-				switch code {
-				case "context_length_exceeded":
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.ContextOverflowError{Message: msg, ResponseBody: data},
-					}) {
-						return
-					}
-				case "insufficient_quota":
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.APIError{Message: "Quota exceeded. Check your plan and billing details.", IsRetryable: false},
-					}) {
-						return
-					}
-				case "usage_not_included":
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.APIError{Message: "Usage not included in response. Check your plan supports usage reporting for this model.", IsRetryable: false},
-					}) {
-						return
-					}
-				case "invalid_prompt":
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.APIError{Message: msg, IsRetryable: false},
-					}) {
-						return
-					}
-				case "rate_limit_exceeded", "429":
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.APIError{Message: msg, StatusCode: 429, IsRetryable: true},
-					}) {
-						return
-					}
-				case "server_error", "503", "502", "500":
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.APIError{Message: msg, IsRetryable: true},
-					}) {
-						return
-					}
-				default:
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.APIError{Message: msg},
-					}) {
-						return
-					}
+				if !provider.TrySend(ctx, out, responsesStreamError(data, ev.Response.Error.Message, ev.Response.Error.Code, "response failed")) {
+					return
 				}
 			}
 			return
 
 		case "error":
+			// OpenAI documents flat message/code fields, but production often nests them under error.
 			var ev struct {
 				Message string `json:"message"`
 				Code    string `json:"code"`
+				Error   *struct {
+					Message string `json:"message"`
+					Code    string `json:"code"`
+				} `json:"error"`
 			}
 			if json.Unmarshal([]byte(data), &ev) == nil {
-				msg := cmp.Or(ev.Message, "stream error")
-				if ev.Code == "context_overflow" || ev.Code == "max_tokens" ||
-					ev.Code == "context_length_exceeded" {
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.ContextOverflowError{Message: msg, ResponseBody: data},
-					}) {
-						return
-					}
-				} else {
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: &goai.APIError{Message: msg},
-					}) {
-						return
-					}
+				msg, code := ev.Message, ev.Code
+				if ev.Error != nil {
+					msg, code = ev.Error.Message, ev.Error.Code
+				}
+				if !provider.TrySend(ctx, out, responsesStreamError(data, msg, code, "stream error")) {
+					return
 				}
 			}
 			return
@@ -834,6 +779,26 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 		if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: fmt.Errorf("reading stream: %w", err)}) {
 			return
 		}
+	}
+}
+
+func responsesStreamError(data, msg, code, defaultMsg string) provider.StreamChunk {
+	msg = cmp.Or(msg, defaultMsg)
+	switch code {
+	case "context_length_exceeded", "context_overflow", "max_tokens":
+		return provider.StreamChunk{Type: provider.ChunkError, Error: &goai.ContextOverflowError{Message: msg, ResponseBody: data}}
+	case "insufficient_quota":
+		return provider.StreamChunk{Type: provider.ChunkError, Error: &goai.APIError{Message: "Quota exceeded. Check your plan and billing details.", IsRetryable: false}}
+	case "usage_not_included":
+		return provider.StreamChunk{Type: provider.ChunkError, Error: &goai.APIError{Message: "Usage not included in response. Check your plan supports usage reporting for this model.", IsRetryable: false}}
+	case "invalid_prompt":
+		return provider.StreamChunk{Type: provider.ChunkError, Error: &goai.APIError{Message: msg, IsRetryable: false}}
+	case "rate_limit_exceeded", "429":
+		return provider.StreamChunk{Type: provider.ChunkError, Error: &goai.APIError{Message: msg, StatusCode: 429, IsRetryable: true}}
+	case "server_error", "503", "502", "500":
+		return provider.StreamChunk{Type: provider.ChunkError, Error: &goai.APIError{Message: msg, IsRetryable: true}}
+	default:
+		return provider.StreamChunk{Type: provider.ChunkError, Error: &goai.APIError{Message: msg}}
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix OpenAI Responses API streaming so error SSE events are parsed correctly when production payloads nest message and code under an error object instead of using the flat shape shown in the docs.

## Problem
The Responses API streaming handler for event: error only read top-level message and code fields. OpenAI’s docs describe that flat shape, but production often returns a nested object:

```
{
  "type": "error",
  "error": {
    "type": "tokens",
    "code": "rate_limit_exceeded",
    "headers": {
      "x-ratelimit-limit-requests": "500",
      "x-ratelimit-limit-tokens": "30000",
      "x-ratelimit-remaining-requests": "499",
      "x-ratelimit-remaining-tokens": "4735",
      "x-ratelimit-reset-requests": "120ms",
      "x-ratelimit-reset-tokens": "50.529s"
    },
    "message": "Rate limit reached for gpt-4o in organization org-abc on tokens per min (TPM): Limit 30000, Used 25265, Requested 8020. Please try again in 6.57s. Visit https://platform.openai.com/account/rate-limits to learn more.",
    "param": null
  },
  "sequence_number": 2
}
```
With the old parser, nested error.code and error.message were ignored. That meant:

- Rate limit errors surfaced as generic, non-retryable APIErrors instead of retryable 429s

- The provider’s retry logic did not kick in for a common production failure mode

- Error messages fell back to a generic default instead of the detailed rate-limit text from the API

## Solution

- Parse both flat and nested error shapes for error stream events, preferring error.message / error.code when the nested object is present

- Extract shared error mapping into responsesStreamError, used by both response.failed and error events, so codes like rate_limit_exceeded consistently map to StatusCode: 429 and IsRetryable: true

- Add tests for nested and flat rate_limit_exceeded error events