### PR TITLE
fix(openai): preserve flat error fields when nested error is partial

### DIFF
--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -1605,6 +1605,45 @@ func TestStreamResponses_ErrorEventFlatRateLimit(t *testing.T) {
 	t.Error("expected retryable APIError for flat rate_limit_exceeded")
 }
 
+// TestStreamResponses_ErrorEventPartialNested verifies per-field fallback: when
+// the nested error object carries a code but no message, the flat message is
+// preserved (not clobbered with an empty string) while the nested code still
+// drives classification.
+func TestStreamResponses_ErrorEventPartialNested(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: error\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"error","message":"flat detail","error":{"code":"rate_limit_exceeded"}}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			var apiErr *goai.APIError
+			if errors.As(chunk.Error, &apiErr) {
+				if apiErr.StatusCode != 429 || !apiErr.IsRetryable {
+					t.Errorf("nested code should classify as retryable 429, got status=%d retryable=%v", apiErr.StatusCode, apiErr.IsRetryable)
+				}
+				if apiErr.Message != "flat detail" {
+					t.Errorf("Message = %q, want flat message preserved (not clobbered by empty nested message)", apiErr.Message)
+				}
+				return
+			}
+		}
+	}
+	t.Error("expected APIError for partial nested error event")
+}
+
 func TestStreamResponses_ServerErrorRetryable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -761,9 +761,14 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 				} `json:"error"`
 			}
 			if json.Unmarshal([]byte(data), &ev) == nil {
+				// Prefer the nested error fields when present, but fall back to
+				// the flat fields per-field so a partial nested object (e.g. a
+				// nested code with no nested message) does not clobber a flat
+				// message/code with an empty string.
 				msg, code := ev.Message, ev.Code
 				if ev.Error != nil {
-					msg, code = ev.Error.Message, ev.Error.Code
+					msg = cmp.Or(ev.Error.Message, msg)
+					code = cmp.Or(ev.Error.Code, code)
 				}
 				if !provider.TrySend(ctx, out, responsesStreamError(data, msg, code, "stream error")) {
 					return


### PR DESCRIPTION
Follow-up to #88 (zenflow review finding, responses.go:814).

## Problem

The Responses API `error` event handler overwrote the flat `message`/`code` with the nested `error` object unconditionally:

```go
if ev.Error != nil {
    msg, code = ev.Error.Message, ev.Error.Code
}
```

A partial nested object (e.g. a nested `code` with no `message`) clobbered a flat `message` with an empty string, losing the detail and falling back to the generic "stream error".

## Fix

Per-field fallback with `cmp.Or`: prefer the nested value when set, otherwise keep the flat value.

```go
if ev.Error != nil {
    msg = cmp.Or(ev.Error.Message, msg)
    code = cmp.Or(ev.Error.Code, code)
}
```

## Scope

Isolated to `provider/openai/responses.go` (Responses API streaming). Affects OpenAI Responses mode and Azure (delegates to openai for Responses-only models); no effect on Chat Completions, openaicompat providers, or the shared `errors.go`.

## Tests

New `TestStreamResponses_ErrorEventPartialNested` (flat message + nested code with empty nested message) asserts the flat message is preserved and the nested code still drives 429/retryable classification.