### PR TITLE
fix(provider): populate ToolName on synthetic orphan tool results for…

### DIFF
--- a/provider/normalize.go
+++ b/provider/normalize.go
@@ -1,5 +1,7 @@
 package provider
 
+import "slices"
+
 // NormalizeToolMessages prepares messages for providers that require:
 // 1. Every assistant tool-call has a matching tool-result (orphan fix)
 // 2. Alternating user/assistant roles (merge consecutive same-role)
@@ -20,6 +22,7 @@ func NormalizeToolMessages(msgs []Message) []Message {
 // ProviderOptions["resultBlock"], so no following tool-result message is
 // expected.
 func ensureToolResultPairing(msgs []Message) []Message {
+	msgs = cloneMessages(msgs)
 	for i := 0; i < len(msgs); i++ {
 		if msgs[i].Role != RoleAssistant {
 			continue
@@ -73,6 +76,20 @@ func ensureToolResultPairing(msgs []Message) []Message {
 		}
 	}
 	return msgs
+}
+
+func cloneMessages(msgs []Message) []Message {
+	if len(msgs) == 0 {
+		return msgs
+	}
+	out := make([]Message, len(msgs))
+	for i, msg := range msgs {
+		out[i] = Message{
+			Role:    msg.Role,
+			Content: slices.Clone(msg.Content),
+		}
+	}
+	return out
 }
 
 // mergeConsecutiveRoles merges consecutive messages with the same role.

--- a/provider/normalize.go
+++ b/provider/normalize.go
@@ -84,10 +84,11 @@ func cloneMessages(msgs []Message) []Message {
 	}
 	out := make([]Message, len(msgs))
 	for i, msg := range msgs {
-		out[i] = Message{
-			Role:    msg.Role,
-			Content: slices.Clone(msg.Content),
-		}
+		// Copy the whole struct (preserving ProviderOptions and any future
+		// fields), then clone the Content slice, which is the only part this
+		// package appends to.
+		out[i] = msg
+		out[i].Content = slices.Clone(msg.Content)
 	}
 	return out
 }

--- a/provider/normalize.go
+++ b/provider/normalize.go
@@ -24,16 +24,16 @@ func ensureToolResultPairing(msgs []Message) []Message {
 		if msgs[i].Role != RoleAssistant {
 			continue
 		}
-		var callIDs []string
+		var toolCalls []Part
 		for _, p := range msgs[i].Content {
 			if p.Type == PartToolCall && p.ToolCallID != "" {
 				if _, hasInlineResult := p.ProviderOptions["resultBlock"]; hasInlineResult {
 					continue
 				}
-				callIDs = append(callIDs, p.ToolCallID)
+				toolCalls = append(toolCalls, p)
 			}
 		}
-		if len(callIDs) == 0 {
+		if len(toolCalls) == 0 {
 			continue
 		}
 		// Scan all consecutive tool/user messages after assistant
@@ -50,12 +50,13 @@ func ensureToolResultPairing(msgs []Message) []Message {
 			}
 		}
 		var orphans []Part
-		for _, id := range callIDs {
-			if !resultIDs[id] {
+		for _, toolCall := range toolCalls {
+			if !resultIDs[toolCall.ToolCallID] {
 				orphans = append(orphans, Part{
 					Type:       PartToolResult,
-					ToolCallID: id,
+					ToolCallID: toolCall.ToolCallID,
 					ToolOutput: "Tool execution aborted",
+					ToolName:   toolCall.ToolName,
 				})
 			}
 		}

--- a/provider/normalize_test.go
+++ b/provider/normalize_test.go
@@ -121,6 +121,33 @@ func TestNormalizeToolMessages_EndOfConversationOrphan(t *testing.T) {
 	}
 }
 
+func TestEnsureToolResultPairing_SyntheticOrphanCarriesToolName(t *testing.T) {
+	msgs := []Message{
+		{Role: RoleAssistant, Content: []Part{
+			{Type: PartToolCall, ToolCallID: "tc1", ToolName: "lookup_weather"},
+		}},
+		{Role: RoleUser, Content: []Part{{Type: PartText, Text: "cancelled"}}},
+	}
+
+	out := ensureToolResultPairing(msgs)
+
+	var synthetic *Part
+	for _, m := range out {
+		for i := range m.Content {
+			p := &m.Content[i]
+			if p.Type == PartToolResult && p.ToolCallID == "tc1" && p.ToolOutput == "Tool execution aborted" {
+				synthetic = p
+			}
+		}
+	}
+	if synthetic == nil {
+		t.Fatal("expected synthetic tool result for orphaned tc1")
+	}
+	if synthetic.ToolName != "lookup_weather" {
+		t.Errorf("ToolName = %q, want lookup_weather", synthetic.ToolName)
+	}
+}
+
 func TestNormalizeToolMessages_MultipleConsecutiveToolMessages(t *testing.T) {
 	// GoAI buildToolMessages pattern: multiple tool messages after one assistant.
 	msgs := []Message{


### PR DESCRIPTION
## Problem
Google AI rejects requests when a functionResponse has an empty name:

`GenerateContentRequest.contents[N].parts[M].function_response.name: Name cannot be empty`

This happens when orphaned tool calls are patched with synthetic results. The Google AI provider maps `PartToolResult.ToolName` directly to `functionResponse.name` in the request payload, and the API rejects an empty name even when the call ID and output are present.

When `ensureToolResultPairing` injects a placeholder "Tool execution aborted" result for a tool call that never received a matching result, it previously copied only `ToolCallID` leaving `functionResponse.name` empty.

## Solution
When injecting synthetic orphan tool results, `ensureToolResultPairing` now copies ToolName from the original assistant tool-call part, not just ToolCallID.