### PR TITLE
fix: detect duplicate tool names in buildToolMap

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1079,7 +1079,11 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 		return nil, errors.New("goai: prompt or messages must not be empty")
 	}
 
-	toolMap := buildToolMap(o.Tools)
+	toolMap, err := buildToolMap(o.Tools)
+	if err != nil {
+		o.StateRef.set(StepIdle, 0)
+		return nil, err
+	}
 
 	if o.MaxSteps > 1 && len(toolMap) > 0 {
 		return streamWithToolLoop(ctx, model, o, toolMap)
@@ -1206,7 +1210,10 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	originalLen := len(params.Messages)
 
 	// Build tool lookup for auto loop.
-	toolMap := buildToolMap(o.Tools)
+	toolMap, err := buildToolMap(o.Tools)
+	if err != nil {
+		return nil, err
+	}
 
 	var totalUsage provider.Usage
 	var hookStopped bool             // true iff WithStopWhen or OnBeforeStep.Stop broke the loop
@@ -1484,9 +1491,9 @@ func isProviderExecuted(tc provider.ToolCall) bool {
 }
 
 // buildToolMap creates a name→Tool lookup from the options.
-func buildToolMap(tools []Tool) map[string]Tool {
+func buildToolMap(tools []Tool) (map[string]Tool, error) {
 	if len(tools) == 0 {
-		return nil
+		return nil, nil
 	}
 	m := make(map[string]Tool, len(tools))
 	for _, t := range tools {
@@ -1495,13 +1502,16 @@ func buildToolMap(tools []Tool) map[string]Tool {
 				fmt.Fprintf(os.Stderr, "goai: tool with empty name skipped\n")
 				continue
 			}
+			if _, exists := m[t.Name]; exists {
+				return nil, fmt.Errorf("goai: duplicate tool name %q: tool names must be unique", t.Name)
+			}
 			m[t.Name] = t
 		}
 	}
 	if len(m) == 0 {
-		return nil
+		return nil, nil
 	}
-	return m
+	return m, nil
 }
 
 // toolOutput holds the result of a single tool execution (package-level type

--- a/generate.go
+++ b/generate.go
@@ -1081,6 +1081,10 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 
 	toolMap, err := buildToolMap(o.Tools)
 	if err != nil {
+		// Pre-loop validation error must still transition any observer
+		// StepStarting->StepIdle so pollers waiting on it do not deadlock,
+		// consistent with the nil-model and empty-prompt checks above.
+		o.StateRef.set(StepStarting, 0)
 		o.StateRef.set(StepIdle, 0)
 		return nil, err
 	}
@@ -1490,21 +1494,30 @@ func isProviderExecuted(tc provider.ToolCall) bool {
 	return false
 }
 
-// buildToolMap creates a name→Tool lookup from the options.
+// buildToolMap creates a name→Tool lookup of executable tools from the options.
+//
+// Tool names must be unique across all tools, not just executable ones: the
+// Vercel AI SDK (our reference) keys its tool set by name, so a collision there
+// is impossible. We validate every named tool to match that guarantee, while
+// the returned map only contains tools that have an Execute function.
 func buildToolMap(tools []Tool) (map[string]Tool, error) {
 	if len(tools) == 0 {
 		return nil, nil
 	}
 	m := make(map[string]Tool, len(tools))
+	seen := make(map[string]struct{}, len(tools))
 	for _, t := range tools {
-		if t.Execute != nil {
-			if t.Name == "" {
+		if t.Name == "" {
+			if t.Execute != nil {
 				fmt.Fprintf(os.Stderr, "goai: tool with empty name skipped\n")
-				continue
 			}
-			if _, exists := m[t.Name]; exists {
-				return nil, fmt.Errorf("goai: duplicate tool name %q: tool names must be unique", t.Name)
-			}
+			continue
+		}
+		if _, exists := seen[t.Name]; exists {
+			return nil, fmt.Errorf("goai: duplicate tool name %q: tool names must be unique", t.Name)
+		}
+		seen[t.Name] = struct{}{}
+		if t.Execute != nil {
 			m[t.Name] = t
 		}
 	}

--- a/generate_test.go
+++ b/generate_test.go
@@ -1252,21 +1252,32 @@ func TestGenerateText_ToolLoop_TextAccumulation(t *testing.T) {
 
 func TestBuildToolMap(t *testing.T) {
 	// No tools → nil.
-	if m := buildToolMap(nil); m != nil {
+	m, err := buildToolMap(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m != nil {
 		t.Error("expected nil for no tools")
 	}
 
 	// Tools without Execute → nil.
-	if m := buildToolMap([]Tool{{Name: "read"}}); m != nil {
+	m, err = buildToolMap([]Tool{{Name: "read"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m != nil {
 		t.Error("expected nil for tools without Execute")
 	}
 
 	// Mixed.
 	exec := func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil }
-	m := buildToolMap([]Tool{
+	m, err = buildToolMap([]Tool{
 		{Name: "read", Execute: exec},
 		{Name: "write"},
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(m) != 1 {
 		t.Errorf("expected 1 executable tool, got %d", len(m))
 	}
@@ -6144,5 +6155,49 @@ func TestExecuteToolsParallel_SkipsProviderExecuted(t *testing.T) {
 	}
 	if results[1].Output != "echoed" {
 		t.Errorf("client tool result = %q, want echoed", results[1].Output)
+	}
+}
+
+func TestBuildToolMap_DuplicateToolName(t *testing.T) {
+	dupe := Tool{
+		Name:    "same",
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+	}
+	_, err := buildToolMap([]Tool{dupe, dupe})
+	if err == nil {
+		t.Fatal("expected error for duplicate tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
+	}
+}
+
+func TestGenerateText_DuplicateToolName(t *testing.T) {
+	dupe := Tool{
+		Name:    "clash",
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+	}
+	model := &mockModel{id: "test"}
+	_, err := GenerateText(t.Context(), model, WithPrompt("hi"), WithTools(dupe, dupe))
+	if err == nil {
+		t.Fatal("expected error for duplicate tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
+	}
+}
+
+func TestStreamText_DuplicateToolName(t *testing.T) {
+	dupe := Tool{
+		Name:    "clash",
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+	}
+	model := &mockModel{id: "test"}
+	_, err := StreamText(t.Context(), model, WithPrompt("hi"), WithTools(dupe, dupe))
+	if err == nil {
+		t.Fatal("expected error for duplicate tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
 	}
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -5985,13 +5985,13 @@ func TestFinalizeStopCause(t *testing.T) {
 	stepWithoutTools := StepResult{}
 
 	cases := []struct {
-		name           string
-		hookStopped    bool
-		current        provider.StopCause
-		steps          []StepResult
-		maxSteps       int
-		wantCause      provider.StopCause
-		wantExhausted  bool
+		name          string
+		hookStopped   bool
+		current       provider.StopCause
+		steps         []StepResult
+		maxSteps      int
+		wantCause     provider.StopCause
+		wantExhausted bool
 	}{
 		{
 			name:          "max-steps guard trips",
@@ -6196,6 +6196,23 @@ func TestStreamText_DuplicateToolName(t *testing.T) {
 	_, err := StreamText(t.Context(), model, WithPrompt("hi"), WithTools(dupe, dupe))
 	if err == nil {
 		t.Fatal("expected error for duplicate tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
+	}
+}
+
+func TestBuildToolMap_DuplicateAcrossExecutable(t *testing.T) {
+	exec := func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil }
+	// Same name on an executable and a non-executable tool must still error:
+	// names are unique across all tools, matching the Vercel AI SDK reference.
+	if _, err := buildToolMap([]Tool{{Name: "dup", Execute: exec}, {Name: "dup"}}); err == nil {
+		t.Fatal("expected error for name shared by executable and non-executable tool")
+	}
+	// Duplicate among purely non-executable tools also errors.
+	_, err := buildToolMap([]Tool{{Name: "x"}, {Name: "x"}})
+	if err == nil {
+		t.Fatal("expected error for duplicate non-executable tool name, got nil")
 	}
 	if !strings.Contains(err.Error(), "duplicate tool name") {
 		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")

--- a/object.go
+++ b/object.go
@@ -604,6 +604,12 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 		return nil, errors.New("goai: prompt or messages must not be empty")
 	}
 
+	// Validate tool name uniqueness like GenerateText/StreamText/GenerateObject.
+	// StreamObject does not run a tool loop, so the map itself is unused.
+	if _, err := buildToolMap(o.Tools); err != nil {
+		return nil, err
+	}
+
 	var timeoutCancel context.CancelFunc
 	if o.Timeout > 0 {
 		ctx, timeoutCancel = context.WithTimeout(ctx, o.Timeout)

--- a/object.go
+++ b/object.go
@@ -423,7 +423,10 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		Schema: schema,
 	}
 
-	toolMap := buildToolMap(o.Tools)
+	toolMap, err := buildToolMap(o.Tools)
+	if err != nil {
+		return nil, err
+	}
 
 	var steps []StepResult
 	var totalUsage provider.Usage

--- a/object_test.go
+++ b/object_test.go
@@ -2289,3 +2289,18 @@ func TestGenerateObject_StopWhenIgnored(t *testing.T) {
 		t.Errorf("warning emitted %d times, want 2 (one per entry point); stderr=%q", n, got)
 	}
 }
+
+func TestGenerateObject_DuplicateToolName(t *testing.T) {
+	dupe := Tool{
+		Name:    "clash",
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+	}
+	model := &mockModel{id: "test"}
+	_, err := GenerateObject[simpleObject](t.Context(), model, WithPrompt("hi"), WithTools(dupe, dupe))
+	if err == nil {
+		t.Fatal("expected error for duplicate tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
+	}
+}

--- a/object_test.go
+++ b/object_test.go
@@ -2304,3 +2304,18 @@ func TestGenerateObject_DuplicateToolName(t *testing.T) {
 		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
 	}
 }
+
+func TestStreamObject_DuplicateToolName(t *testing.T) {
+	dupe := Tool{
+		Name:    "clash",
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) { return "", nil },
+	}
+	model := &mockModel{id: "test"}
+	_, err := StreamObject[simpleObject](t.Context(), model, WithPrompt("hi"), WithTools(dupe, dupe))
+	if err == nil {
+		t.Fatal("expected error for duplicate tool name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate tool name") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
+	}
+}


### PR DESCRIPTION
## Problem

`buildToolMap` builds a `map[string]Tool` with a plain loop and no uniqueness check. When two tools share the same name, the last one silently wins — no error, no warning. This is particularly dangerous when tools come from multiple sources: user-supplied tools, plugin-loaded tools, and framework-injected tools.

## Fix

Changed `buildToolMap` signature to return `(map[string]Tool, error)`. Before inserting into the map, the function now checks for an existing key:

```go
if _, exists := m[t.Name]; exists {
    return nil, fmt.Errorf("goai: duplicate tool name %q: tool names must be unique", t.Name)
}
```

All three callers (`GenerateText`, `StreamText`, `GenerateObject`) propagate the error naturally since they already return errors.

## Tests

Added `TestBuildToolMap_DuplicateToolName`, `TestGenerateText_DuplicateToolName`, and `TestStreamText_DuplicateToolName` demonstrating the collision detection.

## Related

See also: zendev-sh/zenflow#<will update> — same fix applied to zenflow's AgentRunner tool assembly.