### PR TITLE
provider/ollama: replace compat layer with native Ollama API + think mode support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,12 @@ module github.com/zendev-sh/goai
 
 go 1.25.0
 
-require golang.org/x/oauth2 v0.36.0
+require (
+	go.uber.org/goleak v1.3.0
+	golang.org/x/oauth2 v0.36.0
+)
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,4 @@ require (
 	golang.org/x/oauth2 v0.36.0
 )
 
-require (
-	cloud.google.com/go/compute/metadata v0.3.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
-)
+require cloud.google.com/go/compute/metadata v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,14 @@
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=

--- a/provider/ollama/ollama.go
+++ b/provider/ollama/ollama.go
@@ -1,20 +1,132 @@
-// Package ollama provides an Ollama language model implementation for GoAI.
+// Package ollama provides a native Ollama language model implementation for GoAI.
 //
-// Ollama exposes an OpenAI-compatible API at http://localhost:11434/v1 by default.
-// No authentication is required. This package is a convenience wrapper around
-// the generic compat provider.
+// This package communicates directly with Ollama's /api/* endpoints using
+// net/http and encoding/json. No third-party Ollama SDK is required.
+//
+// Features:
+//   - Think (extended reasoning) mode via ProviderOptions["think"] bool.
+//   - Streaming tool calls forwarded as ChunkToolCallStreamStart + ChunkToolCall.
+//   - Native embedding via EmbeddingModel returning float64 vectors.
+//
+// # Basic usage
+//
+//	// Chat model
+//	model := ollama.Chat("llama3.2")
+//	result, err := model.DoGenerate(ctx, provider.GenerateParams{...})
+//
+//	// Chat model with think mode
+//	result, err := model.DoGenerate(ctx, provider.GenerateParams{
+//	    ProviderOptions: map[string]any{"think": true},
+//	    ...
+//	})
+//
+//	// Embedding model
+//	em := ollama.Embedding("nomic-embed-text")
+//	res, err := em.DoEmbed(ctx, []string{"hello"}, provider.EmbedParams{})
 package ollama
 
 import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/zendev-sh/goai/provider"
-	"github.com/zendev-sh/goai/provider/compat"
 )
 
-const defaultBaseURL = "http://localhost:11434/v1"
+// Compile-time interface compliance checks.
+var (
+	_ provider.LanguageModel  = (*Model)(nil)
+	_ provider.EmbeddingModel = (*EmbeddingModel)(nil)
+)
 
-// Option configures the Ollama provider.
+const (
+	// defaultBaseURL is the default Ollama server address.
+	defaultBaseURL = "http://localhost:11434"
+
+	// defaultMaxValuesPerCall is the maximum number of texts that may be sent
+	// to Ollama's /api/embed endpoint in one call.
+	defaultMaxValuesPerCall = 2048
+
+	// streamBufSize is the channel buffer size for streaming chunks.
+	streamBufSize = 32
+)
+
+// --- Wire types ---
+
+// ollamaChatRequest is the wire format for POST /api/chat.
+type ollamaChatRequest struct {
+	Model    string            `json:"model"`
+	Messages []ollamaMessage   `json:"messages"`
+	Stream   bool              `json:"stream"`
+	Think    bool              `json:"think"`
+	Tools    []ollamaTool      `json:"tools,omitempty"`
+	Options  map[string]any    `json:"options,omitempty"`
+}
+
+// ollamaMessage is a single message in the Ollama chat wire format.
+type ollamaMessage struct {
+	Role       string             `json:"role"`
+	Content    string             `json:"content"`
+	Thinking   string             `json:"thinking,omitempty"`
+	ToolCalls  []ollamaToolCall   `json:"tool_calls,omitempty"`
+	ToolCallID string             `json:"tool_call_id,omitempty"`
+}
+
+// ollamaToolCall is a tool call in the Ollama wire format.
+type ollamaToolCall struct {
+	Function ollamaToolCallFunction `json:"function"`
+}
+
+// ollamaToolCallFunction holds the name and arguments of a tool call.
+type ollamaToolCallFunction struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// ollamaTool is a tool definition in the Ollama wire format.
+type ollamaTool struct {
+	Type     string              `json:"type"`
+	Function ollamaToolFunction  `json:"function"`
+}
+
+// ollamaToolFunction holds the definition of a tool function.
+type ollamaToolFunction struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+// ollamaChatResponse is one NDJSON line in the /api/chat streaming response.
+type ollamaChatResponse struct {
+	Model           string        `json:"model"`
+	Message         ollamaMessage `json:"message"`
+	Done            bool          `json:"done"`
+	DoneReason      string        `json:"done_reason,omitempty"`
+	PromptEvalCount int           `json:"prompt_eval_count,omitempty"`
+	EvalCount       int           `json:"eval_count,omitempty"`
+}
+
+// ollamaEmbedRequest is the wire format for POST /api/embed.
+type ollamaEmbedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// ollamaEmbedResponse is the wire format response from /api/embed.
+type ollamaEmbedResponse struct {
+	Model           string      `json:"model"`
+	Embeddings      [][]float64 `json:"embeddings"`
+	PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
+}
+
+// --- Options ---
+
+// Option configures a Chat or Embedding model.
 type Option func(*options)
 
 type options struct {
@@ -23,54 +135,567 @@ type options struct {
 	httpClient *http.Client
 }
 
-// WithBaseURL overrides the default Ollama API base URL.
-func WithBaseURL(url string) Option {
+// WithBaseURL overrides the default Ollama server base URL (default: http://localhost:11434).
+func WithBaseURL(rawURL string) Option {
 	return func(o *options) {
-		o.baseURL = url
+		o.baseURL = rawURL
 	}
 }
 
-// WithHeaders sets additional HTTP headers sent with every request.
+// WithHeaders sets additional HTTP headers to include in every request.
 func WithHeaders(h map[string]string) Option {
 	return func(o *options) {
 		o.headers = h
 	}
 }
 
-// WithHTTPClient sets a custom HTTP client for all requests.
+// WithHTTPClient replaces the default http.Client used for requests.
 func WithHTTPClient(c *http.Client) Option {
 	return func(o *options) {
 		o.httpClient = c
 	}
 }
 
-// Chat creates an Ollama language model for the given model ID.
-// Defaults to http://localhost:11434/v1, no authentication.
-func Chat(modelID string, opts ...Option) provider.LanguageModel {
+// buildOptions applies Option functions over the zero-value options struct.
+func buildOptions(opts []Option) options {
 	o := options{baseURL: defaultBaseURL}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	return compat.Chat(modelID, toCompatOpts(o)...)
+	return o
+}
+
+// --- Model ---
+
+// Model implements provider.LanguageModel using the native Ollama /api/chat endpoint.
+//
+// Create instances via [Chat]; do not construct directly.
+type Model struct {
+	baseURL    string
+	modelID    string
+	headers    map[string]string
+	httpClient *http.Client
+}
+
+// ModelID returns the Ollama model identifier (e.g. "llama3.2", "qwen3:30b-a3b").
+func (m *Model) ModelID() string {
+	return m.modelID
+}
+
+// Capabilities declares the features supported by Ollama chat models.
+func (m *Model) Capabilities() provider.ModelCapabilities {
+	return provider.ModelCapabilities{
+		Temperature: true,
+		ToolCall:    true,
+		InputModalities: provider.ModalitySet{
+			Text: true,
+		},
+		OutputModalities: provider.ModalitySet{
+			Text: true,
+		},
+	}
+}
+
+// Chat creates an Ollama language model for the given model ID.
+func Chat(modelID string, opts ...Option) *Model {
+	o := buildOptions(opts)
+	return &Model{
+		baseURL:    o.baseURL,
+		modelID:    modelID,
+		headers:    o.headers,
+		httpClient: o.httpClient,
+	}
+}
+
+// DoGenerate performs a non-streaming generation request and returns the
+// accumulated response once the model has finished generating.
+//
+// Returned fields:
+//   - Text: full generated text (concatenated from all response chunks).
+//   - Reasoning: thinking content when ProviderOptions["think"] is true.
+//   - ToolCalls: any tool calls the model requested.
+//   - FinishReason: stop, tool-calls, or other.
+//   - Usage: prompt and completion token counts.
+//   - Response.Model: the model Ollama actually used.
+func (m *Model) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
+	req, err := buildChatRequest(m.modelID, params, false)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: build request: %w", err)
+	}
+
+	resp, err := m.doPost(ctx, "/api/chat", req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var (
+		lastResp    ollamaChatResponse
+		textParts   []string
+		reasonParts []string
+		toolCalls   []provider.ToolCall
+	)
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var chunk ollamaChatResponse
+		if decErr := json.Unmarshal(line, &chunk); decErr != nil {
+			return nil, fmt.Errorf("ollama: decode response: %w", decErr)
+		}
+		lastResp = chunk
+
+		if chunk.Message.Content != "" {
+			textParts = append(textParts, chunk.Message.Content)
+		}
+		if chunk.Message.Thinking != "" {
+			reasonParts = append(reasonParts, chunk.Message.Thinking)
+		}
+		for _, tc := range chunk.Message.ToolCalls {
+			raw := tc.Function.Arguments
+			if raw == nil {
+				raw = json.RawMessage("{}")
+			}
+			toolCalls = append(toolCalls, provider.ToolCall{
+				Name:  tc.Function.Name,
+				Input: raw,
+			})
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return nil, fmt.Errorf("ollama: reading response: %w", scanErr)
+	}
+
+	return &provider.GenerateResult{
+		Text:         strings.Join(textParts, ""),
+		Reasoning:    strings.Join(reasonParts, ""),
+		ToolCalls:    toolCalls,
+		FinishReason: mapFinishReason(lastResp.DoneReason),
+		Usage: provider.Usage{
+			InputTokens:  lastResp.PromptEvalCount,
+			OutputTokens: lastResp.EvalCount,
+		},
+		Response: provider.ResponseMetadata{
+			Model: lastResp.Model,
+		},
+	}, nil
+}
+
+// DoStream performs a streaming generation request and returns a channel of
+// provider.StreamChunk events.
+//
+// Chunk types emitted:
+//   - ChunkText: a fragment of generated text.
+//   - ChunkReasoning: a fragment of reasoning text (when think mode is enabled).
+//   - ChunkToolCallStreamStart: signals start of a tool call.
+//   - ChunkToolCall: emitted immediately after ChunkToolCallStreamStart with full input.
+//   - ChunkFinish: sent once after the stream ends, carrying usage and finish reason.
+//   - ChunkError: sent if the underlying request returns an error; no ChunkFinish follows.
+func (m *Model) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+	req, err := buildChatRequest(m.modelID, params, true)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: build request: %w", err)
+	}
+
+	resp, err := m.doPost(ctx, "/api/chat", req)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan provider.StreamChunk, streamBufSize)
+
+	go func() {
+		defer close(ch)
+		defer func() { _ = resp.Body.Close() }()
+
+		var lastResp ollamaChatResponse
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			var chunk ollamaChatResponse
+			if decErr := json.Unmarshal(line, &chunk); decErr != nil {
+				provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type:  provider.ChunkError,
+					Error: fmt.Errorf("ollama: decode stream chunk: %w", decErr),
+				})
+				return
+			}
+			lastResp = chunk
+
+			if chunk.Message.Content != "" {
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type: provider.ChunkText,
+					Text: chunk.Message.Content,
+				}) {
+					return
+				}
+			}
+
+			if chunk.Message.Thinking != "" {
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type: provider.ChunkReasoning,
+					Text: chunk.Message.Thinking,
+				}) {
+					return
+				}
+			}
+
+			for _, tc := range chunk.Message.ToolCalls {
+				raw := tc.Function.Arguments
+				if raw == nil {
+					raw = json.RawMessage("{}")
+				}
+				// Emit start signal first.
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type:     provider.ChunkToolCallStreamStart,
+					ToolName: tc.Function.Name,
+				}) {
+					return
+				}
+				// Ollama delivers complete tool calls in one chunk — emit the full call immediately.
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type:      provider.ChunkToolCall,
+					ToolName:  tc.Function.Name,
+					ToolInput: string(raw),
+				}) {
+					return
+				}
+			}
+		}
+
+		if scanErr := scanner.Err(); scanErr != nil {
+			provider.TrySend(ctx, ch, provider.StreamChunk{
+				Type:  provider.ChunkError,
+				Error: fmt.Errorf("ollama: reading stream: %w", scanErr),
+			})
+			return
+		}
+
+		provider.TrySend(ctx, ch, provider.StreamChunk{
+			Type:         provider.ChunkFinish,
+			FinishReason: mapFinishReason(lastResp.DoneReason),
+			Usage: provider.Usage{
+				InputTokens:  lastResp.PromptEvalCount,
+				OutputTokens: lastResp.EvalCount,
+			},
+		})
+	}()
+
+	return &provider.StreamResult{Stream: ch}, nil
+}
+
+// --- EmbeddingModel ---
+
+// EmbeddingModel implements provider.EmbeddingModel using the native Ollama /api/embed endpoint.
+//
+// Create instances via [Embedding]; do not construct directly.
+type EmbeddingModel struct {
+	baseURL    string
+	modelID    string
+	headers    map[string]string
+	httpClient *http.Client
+}
+
+// ModelID returns the Ollama embedding model identifier (e.g. "nomic-embed-text").
+func (e *EmbeddingModel) ModelID() string {
+	return e.modelID
+}
+
+// MaxValuesPerCall returns the maximum number of texts that may be sent per call.
+func (e *EmbeddingModel) MaxValuesPerCall() int {
+	return defaultMaxValuesPerCall
+}
+
+// DoEmbed generates embeddings for the given text values using the native
+// Ollama /api/embed endpoint.
+func (e *EmbeddingModel) DoEmbed(ctx context.Context, values []string, _ provider.EmbedParams) (*provider.EmbedResult, error) {
+	reqBody := ollamaEmbedRequest{
+		Model: e.modelID,
+		Input: values,
+	}
+
+	resp, err := sendPost(ctx, e.baseURL, "/api/embed", e.headers, e.httpClient, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: read embed response: %w", err)
+	}
+
+	var embedResp ollamaEmbedResponse
+	if err = json.Unmarshal(body, &embedResp); err != nil {
+		return nil, fmt.Errorf("ollama: decode embed response: %w", err)
+	}
+
+	return &provider.EmbedResult{
+		Embeddings: embedResp.Embeddings,
+		Usage: provider.Usage{
+			InputTokens: embedResp.PromptEvalCount,
+		},
+		Response: provider.ResponseMetadata{
+			Model: embedResp.Model,
+		},
+	}, nil
 }
 
 // Embedding creates an Ollama embedding model for the given model ID.
-// Defaults to http://localhost:11434/v1, no authentication.
-func Embedding(modelID string, opts ...Option) provider.EmbeddingModel {
-	o := options{baseURL: defaultBaseURL}
-	for _, opt := range opts {
-		opt(&o)
+func Embedding(modelID string, opts ...Option) *EmbeddingModel {
+	o := buildOptions(opts)
+	return &EmbeddingModel{
+		baseURL:    o.baseURL,
+		modelID:    modelID,
+		headers:    o.headers,
+		httpClient: o.httpClient,
 	}
-	return compat.Embedding(modelID, toCompatOpts(o)...)
 }
 
-func toCompatOpts(o options) []compat.Option {
-	copts := []compat.Option{compat.WithProviderID("ollama"), compat.WithBaseURL(o.baseURL)}
-	if o.headers != nil {
-		copts = append(copts, compat.WithHeaders(o.headers))
+// --- HTTP helpers ---
+
+// doPost sends a JSON POST request to the given path on the model's base URL.
+func (m *Model) doPost(ctx context.Context, path string, body any) (*http.Response, error) {
+	return sendPost(ctx, m.baseURL, path, m.headers, m.httpClient, body)
+}
+
+// sendPost is the shared HTTP POST helper used by both Model and EmbeddingModel.
+func sendPost(ctx context.Context, baseURL, path string, headers map[string]string, httpClient *http.Client, body any) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: marshal request: %w", err)
 	}
-	if o.httpClient != nil {
-		copts = append(copts, compat.WithHTTPClient(o.httpClient))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("ollama: create request: %w", err)
 	}
-	return copts
+	req.Header.Set("Content-Type", "application/json")
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	client := httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: send request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("ollama: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return resp, nil
+}
+
+// --- Request building ---
+
+// buildChatRequest converts GoAI GenerateParams into an ollamaChatRequest.
+func buildChatRequest(modelID string, params provider.GenerateParams, streaming bool) (*ollamaChatRequest, error) {
+	msgs, err := convertMessages(params)
+	if err != nil {
+		return nil, err
+	}
+
+	tools, err := convertTools(params.Tools)
+	if err != nil {
+		return nil, err
+	}
+
+	thinkVal := extractThink(params.ProviderOptions)
+
+	return &ollamaChatRequest{
+		Model:    modelID,
+		Messages: msgs,
+		Tools:    tools,
+		Stream:   streaming,
+		Options:  buildOllamaOptions(params),
+		Think:    thinkVal,
+	}, nil
+}
+
+// convertMessages prepends an optional system prompt and converts all GoAI
+// messages to Ollama wire messages.
+func convertMessages(params provider.GenerateParams) ([]ollamaMessage, error) {
+	var msgs []ollamaMessage
+
+	if params.System != "" {
+		msgs = append(msgs, ollamaMessage{
+			Role:    "system",
+			Content: params.System,
+		})
+	}
+
+	for _, msg := range params.Messages {
+		converted, err := convertMessage(msg)
+		if err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, converted...)
+	}
+
+	return msgs, nil
+}
+
+// convertMessage converts a single GoAI Message into one or more Ollama wire messages.
+func convertMessage(msg provider.Message) ([]ollamaMessage, error) {
+	switch msg.Role {
+	case provider.RoleSystem:
+		return []ollamaMessage{{
+			Role:    "system",
+			Content: concatText(msg.Content),
+		}}, nil
+
+	case provider.RoleUser:
+		return []ollamaMessage{{
+			Role:    "user",
+			Content: concatText(msg.Content),
+		}}, nil
+
+	case provider.RoleAssistant:
+		var text string
+		var toolCalls []ollamaToolCall
+
+		for _, part := range msg.Content {
+			switch part.Type {
+			case provider.PartText, provider.PartReasoning:
+				text += part.Text
+			case provider.PartToolCall:
+				raw := part.ToolInput
+				if raw == nil {
+					raw = json.RawMessage("{}")
+				}
+				toolCalls = append(toolCalls, ollamaToolCall{
+					Function: ollamaToolCallFunction{
+						Name:      part.ToolName,
+						Arguments: raw,
+					},
+				})
+			}
+		}
+
+		return []ollamaMessage{{
+			Role:      "assistant",
+			Content:   text,
+			ToolCalls: toolCalls,
+		}}, nil
+
+	case provider.RoleTool:
+		var result []ollamaMessage
+		for _, part := range msg.Content {
+			if part.Type == provider.PartToolResult {
+				result = append(result, ollamaMessage{
+					Role:       "tool",
+					Content:    part.ToolOutput,
+					ToolCallID: part.ToolCallID,
+				})
+			}
+		}
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("ollama: unsupported message role: %s", msg.Role)
+}
+
+// concatText concatenates all PartText parts in a message content slice.
+func concatText(parts []provider.Part) string {
+	var sb strings.Builder
+	for _, part := range parts {
+		if part.Type == provider.PartText {
+			sb.WriteString(part.Text)
+		}
+	}
+	return sb.String()
+}
+
+// convertTools converts GoAI ToolDefinitions to Ollama wire tool definitions.
+func convertTools(defs []provider.ToolDefinition) ([]ollamaTool, error) {
+	if len(defs) == 0 {
+		return nil, nil
+	}
+
+	tools := make([]ollamaTool, 0, len(defs))
+	for _, def := range defs {
+		var params map[string]any
+		if err := json.Unmarshal(def.InputSchema, &params); err != nil {
+			return nil, fmt.Errorf("ollama: unmarshal input schema for tool %s: %w", def.Name, err)
+		}
+		tools = append(tools, ollamaTool{
+			Type: "function",
+			Function: ollamaToolFunction{
+				Name:        def.Name,
+				Description: def.Description,
+				Parameters:  params,
+			},
+		})
+	}
+
+	return tools, nil
+}
+
+// buildOllamaOptions maps GoAI GenerateParams sampling fields to the Ollama options map.
+func buildOllamaOptions(params provider.GenerateParams) map[string]any {
+	opts := map[string]any{}
+
+	if params.Temperature != nil {
+		opts["temperature"] = float32(*params.Temperature)
+	}
+	if params.TopP != nil {
+		opts["top_p"] = float32(*params.TopP)
+	}
+	if params.TopK != nil {
+		opts["top_k"] = *params.TopK
+	}
+	if params.Seed != nil {
+		opts["seed"] = *params.Seed
+	}
+	if len(params.StopSequences) > 0 {
+		opts["stop"] = params.StopSequences
+	}
+	if params.MaxOutputTokens > 0 {
+		opts["num_predict"] = params.MaxOutputTokens
+	}
+
+	if len(opts) == 0 {
+		return nil
+	}
+
+	return opts
+}
+
+// extractThink reads ProviderOptions["think"] and returns the bool value.
+// Defaults to false when absent or not a bool.
+func extractThink(providerOptions map[string]any) bool {
+	if val, ok := providerOptions["think"]; ok {
+		if boolVal, isBool := val.(bool); isBool {
+			return boolVal
+		}
+	}
+	return false
+}
+
+// mapFinishReason maps Ollama done reasons to GoAI FinishReason constants.
+func mapFinishReason(doneReason string) provider.FinishReason {
+	switch doneReason {
+	case "stop":
+		return provider.FinishStop
+	case "tool_calls":
+		return provider.FinishToolCalls
+	default:
+		return provider.FinishOther
+	}
 }

--- a/provider/ollama/ollama.go
+++ b/provider/ollama/ollama.go
@@ -75,6 +75,10 @@ type ollamaChatRequest struct {
 	Think    bool            `json:"think"`
 	Tools    []ollamaTool    `json:"tools,omitempty"`
 	Options  map[string]any  `json:"options,omitempty"`
+	// Format requests structured output. Ollama accepts either the string
+	// "json" for generic JSON mode or a JSON Schema object for constrained
+	// output, so it is carried as a raw JSON value.
+	Format json.RawMessage `json:"format,omitempty"`
 }
 
 // ollamaMessage is a single message in the Ollama chat wire format.
@@ -555,7 +559,21 @@ func buildChatRequest(modelID string, params provider.GenerateParams, streaming 
 		Stream:   streaming,
 		Options:  buildOllamaOptions(params),
 		Think:    thinkVal,
+		Format:   buildFormat(params.ResponseFormat),
 	}, nil
+}
+
+// buildFormat maps a GoAI ResponseFormat to Ollama's chat "format" field.
+// A schema constrains output to that JSON Schema; a format with no schema
+// requests generic JSON mode. Returns nil when no response format is set.
+func buildFormat(rf *provider.ResponseFormat) json.RawMessage {
+	if rf == nil {
+		return nil
+	}
+	if len(rf.Schema) > 0 {
+		return rf.Schema
+	}
+	return json.RawMessage(`"json"`)
 }
 
 // convertMessages prepends an optional system prompt and converts all GoAI
@@ -597,13 +615,17 @@ func convertMessage(msg provider.Message) ([]ollamaMessage, error) {
 		}}, nil
 
 	case provider.RoleAssistant:
-		var text string
+		var text, thinking string
 		var toolCalls []ollamaToolCall
 
 		for _, part := range msg.Content {
 			switch part.Type {
-			case provider.PartText, provider.PartReasoning:
+			case provider.PartText:
 				text += part.Text
+			case provider.PartReasoning:
+				// Carry reasoning in the native thinking field rather than
+				// merging it into content, so it round-trips correctly.
+				thinking += part.Text
 			case provider.PartToolCall:
 				raw := part.ToolInput
 				if raw == nil {
@@ -621,6 +643,7 @@ func convertMessage(msg provider.Message) ([]ollamaMessage, error) {
 		return []ollamaMessage{{
 			Role:      "assistant",
 			Content:   text,
+			Thinking:  thinking,
 			ToolCalls: toolCalls,
 		}}, nil
 

--- a/provider/ollama/ollama.go
+++ b/provider/ollama/ollama.go
@@ -26,16 +26,16 @@
 package ollama
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
+	goai "github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/internal/sse"
 	"github.com/zendev-sh/goai/provider"
 )
 
@@ -55,6 +55,14 @@ const (
 
 	// streamBufSize is the channel buffer size for streaming chunks.
 	streamBufSize = 32
+
+	// maxEmbedResponseBytes caps the embedding response body read to bound
+	// memory use on an unexpectedly large or malicious response.
+	maxEmbedResponseBytes = 128 << 20 // 128 MiB
+
+	// maxErrorBodyBytes caps how much of a non-200 response body is read into
+	// the returned error to avoid unbounded memory use.
+	maxErrorBodyBytes = 64 << 10 // 64 KiB
 )
 
 // --- Wire types ---
@@ -144,9 +152,18 @@ func WithBaseURL(rawURL string) Option {
 }
 
 // WithHeaders sets additional HTTP headers to include in every request.
+// The map is copied so later mutations by the caller do not affect the model.
 func WithHeaders(h map[string]string) Option {
 	return func(o *options) {
-		o.headers = h
+		if len(h) == 0 {
+			o.headers = nil
+			return
+		}
+		cp := make(map[string]string, len(h))
+		for k, v := range h {
+			cp[k] = v
+		}
+		o.headers = cp
 	}
 }
 
@@ -237,42 +254,44 @@ func (m *Model) DoGenerate(ctx context.Context, params provider.GenerateParams) 
 		toolCalls   []provider.ToolCall
 	)
 
-	// Use bufio.Reader rather than bufio.Scanner: NDJSON lines (e.g. large
-	// tool-call arguments) can exceed bufio.MaxScanTokenSize (64 KiB), which
-	// would abort a Scanner with "token too long".
-	reader := bufio.NewReader(resp.Body)
+	// Read NDJSON with sse.Scanner: it uses a bufio.Reader (no 64 KiB
+	// per-line limit like bufio.Scanner) while bounding each line to
+	// sse.MaxLineSize so a malicious response cannot exhaust memory.
+	scanner := sse.NewScanner(resp.Body)
 	for {
-		line, readErr := reader.ReadBytes('\n')
-		if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
-			var chunk ollamaChatResponse
-			if decErr := json.Unmarshal(trimmed, &chunk); decErr != nil {
-				return nil, fmt.Errorf("ollama: decode response: %w", decErr)
-			}
-			lastResp = chunk
-
-			if chunk.Message.Content != "" {
-				textParts = append(textParts, chunk.Message.Content)
-			}
-			if chunk.Message.Thinking != "" {
-				reasonParts = append(reasonParts, chunk.Message.Thinking)
-			}
-			for _, tc := range chunk.Message.ToolCalls {
-				raw := tc.Function.Arguments
-				if raw == nil {
-					raw = json.RawMessage("{}")
-				}
-				toolCalls = append(toolCalls, provider.ToolCall{
-					Name:  tc.Function.Name,
-					Input: raw,
-				})
-			}
-		}
-		if readErr != nil {
-			if !errors.Is(readErr, io.EOF) {
-				return nil, fmt.Errorf("ollama: reading response: %w", readErr)
-			}
+		line, ok := scanner.NextLine()
+		if !ok {
 			break
 		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		var chunk ollamaChatResponse
+		if decErr := json.Unmarshal([]byte(trimmed), &chunk); decErr != nil {
+			return nil, fmt.Errorf("ollama: decode response: %w", decErr)
+		}
+		lastResp = chunk
+
+		if chunk.Message.Content != "" {
+			textParts = append(textParts, chunk.Message.Content)
+		}
+		if chunk.Message.Thinking != "" {
+			reasonParts = append(reasonParts, chunk.Message.Thinking)
+		}
+		for _, tc := range chunk.Message.ToolCalls {
+			raw := tc.Function.Arguments
+			if raw == nil {
+				raw = json.RawMessage("{}")
+			}
+			toolCalls = append(toolCalls, provider.ToolCall{
+				Name:  tc.Function.Name,
+				Input: raw,
+			})
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return nil, fmt.Errorf("ollama: reading response: %w", scanErr)
 	}
 
 	return &provider.GenerateResult{
@@ -319,72 +338,74 @@ func (m *Model) DoStream(ctx context.Context, params provider.GenerateParams) (*
 
 		var lastResp ollamaChatResponse
 
-		// Use bufio.Reader rather than bufio.Scanner so that NDJSON lines larger
-		// than bufio.MaxScanTokenSize (64 KiB) do not abort with "token too long".
-		reader := bufio.NewReader(resp.Body)
+		// Read NDJSON with sse.Scanner: no 64 KiB per-line limit (unlike
+		// bufio.Scanner) while still bounding each line to sse.MaxLineSize.
+		scanner := sse.NewScanner(resp.Body)
 		for {
-			line, readErr := reader.ReadBytes('\n')
-			if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
-				var chunk ollamaChatResponse
-				if decErr := json.Unmarshal(trimmed, &chunk); decErr != nil {
-					provider.TrySend(ctx, ch, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: fmt.Errorf("ollama: decode stream chunk: %w", decErr),
-					})
-					return
-				}
-				lastResp = chunk
-
-				if chunk.Message.Content != "" {
-					if !provider.TrySend(ctx, ch, provider.StreamChunk{
-						Type: provider.ChunkText,
-						Text: chunk.Message.Content,
-					}) {
-						return
-					}
-				}
-
-				if chunk.Message.Thinking != "" {
-					if !provider.TrySend(ctx, ch, provider.StreamChunk{
-						Type: provider.ChunkReasoning,
-						Text: chunk.Message.Thinking,
-					}) {
-						return
-					}
-				}
-
-				for _, tc := range chunk.Message.ToolCalls {
-					raw := tc.Function.Arguments
-					if raw == nil {
-						raw = json.RawMessage("{}")
-					}
-					// Emit start signal first.
-					if !provider.TrySend(ctx, ch, provider.StreamChunk{
-						Type:     provider.ChunkToolCallStreamStart,
-						ToolName: tc.Function.Name,
-					}) {
-						return
-					}
-					// Ollama delivers complete tool calls in one chunk; emit the full call immediately.
-					if !provider.TrySend(ctx, ch, provider.StreamChunk{
-						Type:      provider.ChunkToolCall,
-						ToolName:  tc.Function.Name,
-						ToolInput: string(raw),
-					}) {
-						return
-					}
-				}
-			}
-			if readErr != nil {
-				if !errors.Is(readErr, io.EOF) {
-					provider.TrySend(ctx, ch, provider.StreamChunk{
-						Type:  provider.ChunkError,
-						Error: fmt.Errorf("ollama: reading stream: %w", readErr),
-					})
-					return
-				}
+			line, ok := scanner.NextLine()
+			if !ok {
 				break
 			}
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			var chunk ollamaChatResponse
+			if decErr := json.Unmarshal([]byte(trimmed), &chunk); decErr != nil {
+				provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type:  provider.ChunkError,
+					Error: fmt.Errorf("ollama: decode stream chunk: %w", decErr),
+				})
+				return
+			}
+			lastResp = chunk
+
+			if chunk.Message.Content != "" {
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type: provider.ChunkText,
+					Text: chunk.Message.Content,
+				}) {
+					return
+				}
+			}
+
+			if chunk.Message.Thinking != "" {
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type: provider.ChunkReasoning,
+					Text: chunk.Message.Thinking,
+				}) {
+					return
+				}
+			}
+
+			for _, tc := range chunk.Message.ToolCalls {
+				raw := tc.Function.Arguments
+				if raw == nil {
+					raw = json.RawMessage("{}")
+				}
+				// Emit start signal first.
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type:     provider.ChunkToolCallStreamStart,
+					ToolName: tc.Function.Name,
+				}) {
+					return
+				}
+				// Ollama delivers complete tool calls in one chunk; emit the full call immediately.
+				if !provider.TrySend(ctx, ch, provider.StreamChunk{
+					Type:      provider.ChunkToolCall,
+					ToolName:  tc.Function.Name,
+					ToolInput: string(raw),
+				}) {
+					return
+				}
+			}
+		}
+		if scanErr := scanner.Err(); scanErr != nil {
+			provider.TrySend(ctx, ch, provider.StreamChunk{
+				Type:  provider.ChunkError,
+				Error: fmt.Errorf("ollama: reading stream: %w", scanErr),
+			})
+			return
 		}
 
 		provider.TrySend(ctx, ch, provider.StreamChunk{
@@ -436,7 +457,7 @@ func (e *EmbeddingModel) DoEmbed(ctx context.Context, values []string, _ provide
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxEmbedResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("ollama: read embed response: %w", err)
 	}
@@ -503,9 +524,9 @@ func sendPost(ctx context.Context, baseURL, path string, headers map[string]stri
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("ollama: HTTP %d: %s", resp.StatusCode, string(respBody))
+		return nil, goai.ParseHTTPErrorWithHeaders("ollama", resp.StatusCode, respBody, resp.Header)
 	}
 
 	return resp, nil

--- a/provider/ollama/ollama.go
+++ b/provider/ollama/ollama.go
@@ -30,6 +30,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,21 +61,21 @@ const (
 
 // ollamaChatRequest is the wire format for POST /api/chat.
 type ollamaChatRequest struct {
-	Model    string            `json:"model"`
-	Messages []ollamaMessage   `json:"messages"`
-	Stream   bool              `json:"stream"`
-	Think    bool              `json:"think"`
-	Tools    []ollamaTool      `json:"tools,omitempty"`
-	Options  map[string]any    `json:"options,omitempty"`
+	Model    string          `json:"model"`
+	Messages []ollamaMessage `json:"messages"`
+	Stream   bool            `json:"stream"`
+	Think    bool            `json:"think"`
+	Tools    []ollamaTool    `json:"tools,omitempty"`
+	Options  map[string]any  `json:"options,omitempty"`
 }
 
 // ollamaMessage is a single message in the Ollama chat wire format.
 type ollamaMessage struct {
-	Role       string             `json:"role"`
-	Content    string             `json:"content"`
-	Thinking   string             `json:"thinking,omitempty"`
-	ToolCalls  []ollamaToolCall   `json:"tool_calls,omitempty"`
-	ToolCallID string             `json:"tool_call_id,omitempty"`
+	Role       string           `json:"role"`
+	Content    string           `json:"content"`
+	Thinking   string           `json:"thinking,omitempty"`
+	ToolCalls  []ollamaToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
 }
 
 // ollamaToolCall is a tool call in the Ollama wire format.
@@ -90,8 +91,8 @@ type ollamaToolCallFunction struct {
 
 // ollamaTool is a tool definition in the Ollama wire format.
 type ollamaTool struct {
-	Type     string              `json:"type"`
-	Function ollamaToolFunction  `json:"function"`
+	Type     string             `json:"type"`
+	Function ollamaToolFunction `json:"function"`
 }
 
 // ollamaToolFunction holds the definition of a tool function.
@@ -236,37 +237,42 @@ func (m *Model) DoGenerate(ctx context.Context, params provider.GenerateParams) 
 		toolCalls   []provider.ToolCall
 	)
 
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		var chunk ollamaChatResponse
-		if decErr := json.Unmarshal(line, &chunk); decErr != nil {
-			return nil, fmt.Errorf("ollama: decode response: %w", decErr)
-		}
-		lastResp = chunk
-
-		if chunk.Message.Content != "" {
-			textParts = append(textParts, chunk.Message.Content)
-		}
-		if chunk.Message.Thinking != "" {
-			reasonParts = append(reasonParts, chunk.Message.Thinking)
-		}
-		for _, tc := range chunk.Message.ToolCalls {
-			raw := tc.Function.Arguments
-			if raw == nil {
-				raw = json.RawMessage("{}")
+	// Use bufio.Reader rather than bufio.Scanner: NDJSON lines (e.g. large
+	// tool-call arguments) can exceed bufio.MaxScanTokenSize (64 KiB), which
+	// would abort a Scanner with "token too long".
+	reader := bufio.NewReader(resp.Body)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+			var chunk ollamaChatResponse
+			if decErr := json.Unmarshal(trimmed, &chunk); decErr != nil {
+				return nil, fmt.Errorf("ollama: decode response: %w", decErr)
 			}
-			toolCalls = append(toolCalls, provider.ToolCall{
-				Name:  tc.Function.Name,
-				Input: raw,
-			})
+			lastResp = chunk
+
+			if chunk.Message.Content != "" {
+				textParts = append(textParts, chunk.Message.Content)
+			}
+			if chunk.Message.Thinking != "" {
+				reasonParts = append(reasonParts, chunk.Message.Thinking)
+			}
+			for _, tc := range chunk.Message.ToolCalls {
+				raw := tc.Function.Arguments
+				if raw == nil {
+					raw = json.RawMessage("{}")
+				}
+				toolCalls = append(toolCalls, provider.ToolCall{
+					Name:  tc.Function.Name,
+					Input: raw,
+				})
+			}
 		}
-	}
-	if scanErr := scanner.Err(); scanErr != nil {
-		return nil, fmt.Errorf("ollama: reading response: %w", scanErr)
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) {
+				return nil, fmt.Errorf("ollama: reading response: %w", readErr)
+			}
+			break
+		}
 	}
 
 	return &provider.GenerateResult{
@@ -313,69 +319,72 @@ func (m *Model) DoStream(ctx context.Context, params provider.GenerateParams) (*
 
 		var lastResp ollamaChatResponse
 
-		scanner := bufio.NewScanner(resp.Body)
-		for scanner.Scan() {
-			line := scanner.Bytes()
-			if len(line) == 0 {
-				continue
-			}
-			var chunk ollamaChatResponse
-			if decErr := json.Unmarshal(line, &chunk); decErr != nil {
-				provider.TrySend(ctx, ch, provider.StreamChunk{
-					Type:  provider.ChunkError,
-					Error: fmt.Errorf("ollama: decode stream chunk: %w", decErr),
-				})
-				return
-			}
-			lastResp = chunk
-
-			if chunk.Message.Content != "" {
-				if !provider.TrySend(ctx, ch, provider.StreamChunk{
-					Type: provider.ChunkText,
-					Text: chunk.Message.Content,
-				}) {
+		// Use bufio.Reader rather than bufio.Scanner so that NDJSON lines larger
+		// than bufio.MaxScanTokenSize (64 KiB) do not abort with "token too long".
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, readErr := reader.ReadBytes('\n')
+			if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+				var chunk ollamaChatResponse
+				if decErr := json.Unmarshal(trimmed, &chunk); decErr != nil {
+					provider.TrySend(ctx, ch, provider.StreamChunk{
+						Type:  provider.ChunkError,
+						Error: fmt.Errorf("ollama: decode stream chunk: %w", decErr),
+					})
 					return
 				}
-			}
+				lastResp = chunk
 
-			if chunk.Message.Thinking != "" {
-				if !provider.TrySend(ctx, ch, provider.StreamChunk{
-					Type: provider.ChunkReasoning,
-					Text: chunk.Message.Thinking,
-				}) {
+				if chunk.Message.Content != "" {
+					if !provider.TrySend(ctx, ch, provider.StreamChunk{
+						Type: provider.ChunkText,
+						Text: chunk.Message.Content,
+					}) {
+						return
+					}
+				}
+
+				if chunk.Message.Thinking != "" {
+					if !provider.TrySend(ctx, ch, provider.StreamChunk{
+						Type: provider.ChunkReasoning,
+						Text: chunk.Message.Thinking,
+					}) {
+						return
+					}
+				}
+
+				for _, tc := range chunk.Message.ToolCalls {
+					raw := tc.Function.Arguments
+					if raw == nil {
+						raw = json.RawMessage("{}")
+					}
+					// Emit start signal first.
+					if !provider.TrySend(ctx, ch, provider.StreamChunk{
+						Type:     provider.ChunkToolCallStreamStart,
+						ToolName: tc.Function.Name,
+					}) {
+						return
+					}
+					// Ollama delivers complete tool calls in one chunk; emit the full call immediately.
+					if !provider.TrySend(ctx, ch, provider.StreamChunk{
+						Type:      provider.ChunkToolCall,
+						ToolName:  tc.Function.Name,
+						ToolInput: string(raw),
+					}) {
+						return
+					}
+				}
+			}
+			if readErr != nil {
+				if !errors.Is(readErr, io.EOF) {
+					provider.TrySend(ctx, ch, provider.StreamChunk{
+						Type:  provider.ChunkError,
+						Error: fmt.Errorf("ollama: reading stream: %w", readErr),
+					})
 					return
 				}
+				break
 			}
-
-			for _, tc := range chunk.Message.ToolCalls {
-				raw := tc.Function.Arguments
-				if raw == nil {
-					raw = json.RawMessage("{}")
-				}
-				// Emit start signal first.
-				if !provider.TrySend(ctx, ch, provider.StreamChunk{
-					Type:     provider.ChunkToolCallStreamStart,
-					ToolName: tc.Function.Name,
-				}) {
-					return
-				}
-				// Ollama delivers complete tool calls in one chunk — emit the full call immediately.
-				if !provider.TrySend(ctx, ch, provider.StreamChunk{
-					Type:      provider.ChunkToolCall,
-					ToolName:  tc.Function.Name,
-					ToolInput: string(raw),
-				}) {
-					return
-				}
-			}
-		}
-
-		if scanErr := scanner.Err(); scanErr != nil {
-			provider.TrySend(ctx, ch, provider.StreamChunk{
-				Type:  provider.ChunkError,
-				Error: fmt.Errorf("ollama: reading stream: %w", scanErr),
-			})
-			return
 		}
 
 		provider.TrySend(ctx, ch, provider.StreamChunk{

--- a/provider/ollama/ollama_more_test.go
+++ b/provider/ollama/ollama_more_test.go
@@ -53,8 +53,11 @@ func TestConvertMessage_Roles(t *testing.T) {
 	if len(asst) != 1 {
 		t.Fatalf("assistant produced %d messages, want 1", len(asst))
 	}
-	if asst[0].Content != "answhy" {
-		t.Errorf("assistant content = %q, want %q", asst[0].Content, "answhy")
+	if asst[0].Content != "ans" {
+		t.Errorf("assistant content = %q, want %q", asst[0].Content, "ans")
+	}
+	if asst[0].Thinking != "why" {
+		t.Errorf("assistant thinking = %q, want %q", asst[0].Thinking, "why")
 	}
 	if len(asst[0].ToolCalls) != 2 {
 		t.Fatalf("assistant tool calls = %d, want 2", len(asst[0].ToolCalls))
@@ -452,5 +455,63 @@ func TestWithHeaders_CopiesMap(t *testing.T) {
 func TestWithHeaders_Empty(t *testing.T) {
 	if model := Chat("m", WithHeaders(nil)); model.headers != nil {
 		t.Errorf("nil headers = %v, want nil", model.headers)
+	}
+}
+
+func TestBuildFormat(t *testing.T) {
+	if f := buildFormat(nil); f != nil {
+		t.Errorf("nil response format = %s, want nil", f)
+	}
+	// No schema -> generic JSON mode.
+	if f := buildFormat(&provider.ResponseFormat{}); string(f) != `"json"` {
+		t.Errorf("empty schema = %s, want \"json\"", f)
+	}
+	// Schema -> constrained output carrying the schema verbatim.
+	schema := json.RawMessage(`{"type":"object"}`)
+	if f := buildFormat(&provider.ResponseFormat{Schema: schema}); string(f) != string(schema) {
+		t.Errorf("schema format = %s, want %s", f, schema)
+	}
+}
+
+func TestDoGenerate_ResponseFormatSchema(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body ollamaChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if string(body.Format) != `{"type":"object"}` {
+			t.Errorf("format in request = %s, want the schema", body.Format)
+		}
+		chatNDJSON(w, `{"model":"m","message":{"role":"assistant","content":"{}"},"done":true,"done_reason":"stop"}`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages:       []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		ResponseFormat: &provider.ResponseFormat{Schema: json.RawMessage(`{"type":"object"}`)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConvertMessage_AssistantReasoningToThinking(t *testing.T) {
+	msgs, err := convertMessage(provider.Message{
+		Role: provider.RoleAssistant,
+		Content: []provider.Part{
+			{Type: provider.PartText, Text: "answer"},
+			{Type: provider.PartReasoning, Text: "because"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	if msgs[0].Content != "answer" {
+		t.Errorf("content = %q, want %q", msgs[0].Content, "answer")
+	}
+	if msgs[0].Thinking != "because" {
+		t.Errorf("thinking = %q, want %q (reasoning must not merge into content)", msgs[0].Thinking, "because")
 	}
 }

--- a/provider/ollama/ollama_more_test.go
+++ b/provider/ollama/ollama_more_test.go
@@ -1,0 +1,436 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestConvertMessage_Roles(t *testing.T) {
+	// System.
+	sys, err := convertMessage(provider.Message{
+		Role:    provider.RoleSystem,
+		Content: []provider.Part{{Type: provider.PartText, Text: "sys"}},
+	})
+	if err != nil {
+		t.Fatalf("system: unexpected error: %v", err)
+	}
+	if len(sys) != 1 || sys[0].Role != "system" || sys[0].Content != "sys" {
+		t.Errorf("system message = %+v", sys)
+	}
+
+	// User.
+	usr, err := convertMessage(provider.Message{
+		Role:    provider.RoleUser,
+		Content: []provider.Part{{Type: provider.PartText, Text: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("user: unexpected error: %v", err)
+	}
+	if len(usr) != 1 || usr[0].Role != "user" || usr[0].Content != "hi" {
+		t.Errorf("user message = %+v", usr)
+	}
+
+	// Assistant: text + reasoning concatenate; tool call with nil input defaults to {}.
+	asst, err := convertMessage(provider.Message{
+		Role: provider.RoleAssistant,
+		Content: []provider.Part{
+			{Type: provider.PartText, Text: "ans"},
+			{Type: provider.PartReasoning, Text: "why"},
+			{Type: provider.PartToolCall, ToolName: "f", ToolInput: nil},
+			{Type: provider.PartToolCall, ToolName: "g", ToolInput: json.RawMessage(`{"a":1}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("assistant: unexpected error: %v", err)
+	}
+	if len(asst) != 1 {
+		t.Fatalf("assistant produced %d messages, want 1", len(asst))
+	}
+	if asst[0].Content != "answhy" {
+		t.Errorf("assistant content = %q, want %q", asst[0].Content, "answhy")
+	}
+	if len(asst[0].ToolCalls) != 2 {
+		t.Fatalf("assistant tool calls = %d, want 2", len(asst[0].ToolCalls))
+	}
+	if got := string(asst[0].ToolCalls[0].Function.Arguments); got != "{}" {
+		t.Errorf("nil tool input = %q, want {}", got)
+	}
+	if asst[0].ToolCalls[1].Function.Name != "g" {
+		t.Errorf("tool call name = %q, want g", asst[0].ToolCalls[1].Function.Name)
+	}
+
+	// Tool: one Ollama message per result part.
+	tool, err := convertMessage(provider.Message{
+		Role: provider.RoleTool,
+		Content: []provider.Part{
+			{Type: provider.PartToolResult, ToolCallID: "id1", ToolOutput: "out1"},
+			{Type: provider.PartToolResult, ToolCallID: "id2", ToolOutput: "out2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("tool: unexpected error: %v", err)
+	}
+	if len(tool) != 2 {
+		t.Fatalf("tool produced %d messages, want 2", len(tool))
+	}
+	if tool[0].Role != "tool" || tool[0].ToolCallID != "id1" || tool[0].Content != "out1" {
+		t.Errorf("tool message[0] = %+v", tool[0])
+	}
+
+	// Unsupported role.
+	if _, err := convertMessage(provider.Message{Role: provider.Role("nope")}); err == nil {
+		t.Error("expected error for unsupported role, got nil")
+	}
+}
+
+func TestConvertTools(t *testing.T) {
+	if tools, err := convertTools(nil); err != nil || tools != nil {
+		t.Errorf("nil tools = (%v, %v), want (nil, nil)", tools, err)
+	}
+
+	tools, err := convertTools([]provider.ToolDefinition{
+		{Name: "f", Description: "does f", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Type != "function" || tools[0].Function.Name != "f" {
+		t.Errorf("tools = %+v", tools)
+	}
+	if tools[0].Function.Description != "does f" {
+		t.Errorf("description = %q", tools[0].Function.Description)
+	}
+
+	if _, err := convertTools([]provider.ToolDefinition{
+		{Name: "bad", InputSchema: json.RawMessage(`{not json`)},
+	}); err == nil {
+		t.Error("expected error for invalid input schema, got nil")
+	}
+}
+
+func TestBuildOllamaOptions(t *testing.T) {
+	if opts := buildOllamaOptions(provider.GenerateParams{}); opts != nil {
+		t.Errorf("empty params = %v, want nil", opts)
+	}
+
+	opts := buildOllamaOptions(provider.GenerateParams{
+		Temperature:     ptr(0.7),
+		TopP:            ptr(0.9),
+		TopK:            ptr(40),
+		Seed:            ptr(7),
+		StopSequences:   []string{"STOP"},
+		MaxOutputTokens: 128,
+	})
+	for _, key := range []string{"temperature", "top_p", "top_k", "seed", "stop", "num_predict"} {
+		if _, ok := opts[key]; !ok {
+			t.Errorf("missing option %q in %v", key, opts)
+		}
+	}
+	if opts["num_predict"] != 128 {
+		t.Errorf("num_predict = %v, want 128", opts["num_predict"])
+	}
+}
+
+func TestExtractThink(t *testing.T) {
+	if extractThink(nil) {
+		t.Error("nil options = true, want false")
+	}
+	if !extractThink(map[string]any{"think": true}) {
+		t.Error("think:true = false, want true")
+	}
+	if extractThink(map[string]any{"think": "yes"}) {
+		t.Error("non-bool think = true, want false")
+	}
+}
+
+func TestMapFinishReason(t *testing.T) {
+	cases := map[string]provider.FinishReason{
+		"stop":       provider.FinishStop,
+		"tool_calls": provider.FinishToolCalls,
+		"length":     provider.FinishOther,
+		"":           provider.FinishOther,
+	}
+	for in, want := range cases {
+		if got := mapFinishReason(in); got != want {
+			t.Errorf("mapFinishReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDoGenerate_ToolCallsAndOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body ollamaChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if len(body.Tools) != 1 || body.Tools[0].Function.Name != "get_weather" {
+			t.Errorf("tools in request = %+v", body.Tools)
+		}
+		if body.Options["temperature"] == nil {
+			t.Errorf("temperature option missing: %v", body.Options)
+		}
+		chatNDJSON(w,
+			`{"model":"llama3","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Hanoi"}}}]},"done":true,"done_reason":"tool_calls","prompt_eval_count":7,"eval_count":2}`,
+		)
+	}))
+	defer server.Close()
+
+	model := Chat("llama3", WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages:    []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "weather?"}}}},
+		Temperature: ptr(0.5),
+		Tools: []provider.ToolDefinition{
+			{Name: "get_weather", Description: "weather", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinishReason != provider.FinishToolCalls {
+		t.Errorf("FinishReason = %q, want %q", result.FinishReason, provider.FinishToolCalls)
+	}
+	if len(result.ToolCalls) != 1 || result.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("ToolCalls = %+v", result.ToolCalls)
+	}
+	if string(result.ToolCalls[0].Input) != `{"city":"Hanoi"}` {
+		t.Errorf("tool input = %s", result.ToolCalls[0].Input)
+	}
+}
+
+func TestDoGenerate_SystemPrompt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body ollamaChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if len(body.Messages) < 1 || body.Messages[0].Role != "system" || body.Messages[0].Content != "be brief" {
+			t.Errorf("system message not prepended: %+v", body.Messages)
+		}
+		chatNDJSON(w, `{"model":"m","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop"}`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		System:   "be brief",
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoGenerate_BuildRequestError(t *testing.T) {
+	model := Chat("m", WithBaseURL("http://localhost:1"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		Tools:    []provider.ToolDefinition{{Name: "bad", InputSchema: json.RawMessage(`{nope`)}},
+	})
+	if err == nil {
+		t.Fatal("expected build request error, got nil")
+	}
+}
+
+func TestDoGenerate_UnsupportedRole(t *testing.T) {
+	model := Chat("m", WithBaseURL("http://localhost:1"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.Role("ghost")}},
+	})
+	if err == nil {
+		t.Fatal("expected unsupported role error, got nil")
+	}
+}
+
+func TestDoGenerate_DecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chatNDJSON(w, `{not valid json`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+}
+
+func TestDoGenerate_CreateRequestError(t *testing.T) {
+	// A base URL containing a control character makes http.NewRequestWithContext fail.
+	model := Chat("m", WithBaseURL("http://\x7f"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err == nil {
+		t.Fatal("expected create request error, got nil")
+	}
+}
+
+func TestDoStream_ToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chatNDJSON(w,
+			`{"model":"m","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"f","arguments":{"x":1}}}]},"done":false}`,
+			`{"model":"m","message":{"role":"assistant","content":""},"done":true,"done_reason":"tool_calls","prompt_eval_count":3,"eval_count":1}`,
+		)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawStart, sawCall bool
+	var input string
+	var finish provider.FinishReason
+	for chunk := range result.Stream {
+		switch chunk.Type {
+		case provider.ChunkToolCallStreamStart:
+			sawStart = true
+		case provider.ChunkToolCall:
+			sawCall = true
+			input = chunk.ToolInput
+		case provider.ChunkFinish:
+			finish = chunk.FinishReason
+		}
+	}
+	if !sawStart || !sawCall {
+		t.Errorf("tool call chunks: start=%v call=%v, want both true", sawStart, sawCall)
+	}
+	if input != `{"x":1}` {
+		t.Errorf("tool input = %q", input)
+	}
+	if finish != provider.FinishToolCalls {
+		t.Errorf("finish = %q, want %q", finish, provider.FinishToolCalls)
+	}
+}
+
+func TestDoStream_DecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chatNDJSON(w, `{bad json`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawError bool
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Error("expected ChunkError for invalid JSON")
+	}
+}
+
+func TestDoStream_BuildRequestError(t *testing.T) {
+	model := Chat("m", WithBaseURL("http://localhost:1"))
+	_, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		Tools:    []provider.ToolDefinition{{Name: "bad", InputSchema: json.RawMessage(`{nope`)}},
+	})
+	if err == nil {
+		t.Fatal("expected build request error, got nil")
+	}
+}
+
+func TestDoStream_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithBaseURL(server.URL))
+	_, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err == nil {
+		t.Fatal("expected HTTP error, got nil")
+	}
+}
+
+func TestDoEmbed_MultipleValues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("path = %s, want /api/embed", r.URL.Path)
+		}
+		var body ollamaEmbedRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if len(body.Input) != 2 {
+			t.Errorf("input len = %d, want 2", len(body.Input))
+		}
+		embedJSON(w, `{"model":"e","embeddings":[[0.1,0.2],[0.3,0.4]],"prompt_eval_count":4}`)
+	}))
+	defer server.Close()
+
+	model := Embedding("e", WithBaseURL(server.URL))
+	result, err := model.DoEmbed(t.Context(), []string{"a", "b"}, provider.EmbedParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Embeddings) != 2 {
+		t.Fatalf("embeddings = %d, want 2", len(result.Embeddings))
+	}
+	if result.Usage.InputTokens != 4 {
+		t.Errorf("InputTokens = %d, want 4", result.Usage.InputTokens)
+	}
+}
+
+func TestDoEmbed_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad"}`))
+	}))
+	defer server.Close()
+
+	model := Embedding("e", WithBaseURL(server.URL))
+	if _, err := model.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{}); err == nil {
+		t.Fatal("expected HTTP error, got nil")
+	}
+}
+
+func TestDoEmbed_DecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		embedJSON(w, `{not json`)
+	}))
+	defer server.Close()
+
+	model := Embedding("e", WithBaseURL(server.URL))
+	if _, err := model.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{}); err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+}
+
+func TestDoEmbed_CreateRequestError(t *testing.T) {
+	model := Embedding("e", WithBaseURL("http://\x7f"))
+	if _, err := model.DoEmbed(t.Context(), []string{"a"}, provider.EmbedParams{}); err == nil {
+		t.Fatal("expected create request error, got nil")
+	}
+}
+
+func TestDoEmbed_SendError(t *testing.T) {
+	// Closed server → connection refused at client.Do.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	model := Embedding("e", WithBaseURL(url))
+	if _, err := model.DoEmbed(context.Background(), []string{"a"}, provider.EmbedParams{}); err == nil {
+		t.Fatal("expected send error, got nil")
+	}
+}

--- a/provider/ollama/ollama_more_test.go
+++ b/provider/ollama/ollama_more_test.go
@@ -434,3 +434,23 @@ func TestDoEmbed_SendError(t *testing.T) {
 		t.Fatal("expected send error, got nil")
 	}
 }
+
+func TestWithHeaders_CopiesMap(t *testing.T) {
+	src := map[string]string{"X-A": "1"}
+	model := Chat("m", WithHeaders(src))
+	// Mutating the caller's map after construction must not affect the model.
+	src["X-A"] = "mutated"
+	src["X-B"] = "added"
+	if model.headers["X-A"] != "1" {
+		t.Errorf("header X-A = %q, want 1 (external mutation leaked in)", model.headers["X-A"])
+	}
+	if _, ok := model.headers["X-B"]; ok {
+		t.Error("externally added key leaked into model headers")
+	}
+}
+
+func TestWithHeaders_Empty(t *testing.T) {
+	if model := Chat("m", WithHeaders(nil)); model.headers != nil {
+		t.Errorf("nil headers = %v, want nil", model.headers)
+	}
+}

--- a/provider/ollama/ollama_test.go
+++ b/provider/ollama/ollama_test.go
@@ -10,17 +10,33 @@ import (
 	"github.com/zendev-sh/goai/provider"
 )
 
+// chatNDJSON writes one NDJSON line (one JSON object) per response chunk as
+// expected by the Ollama native /api/chat endpoint.
+func chatNDJSON(w http.ResponseWriter, lines ...string) {
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	for _, line := range lines {
+		_, _ = fmt.Fprintln(w, line)
+	}
+}
+
+// embedJSON writes a JSON response as expected by /api/embed.
+func embedJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprint(w, body)
+}
+
 func TestChat_Generate(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/chat/completions" {
-			t.Errorf("path = %s", r.URL.Path)
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("path = %s, want /api/chat", r.URL.Path)
 		}
-		// Ollama should NOT send Authorization header.
+		// Native Ollama API does not require Authorization.
 		if auth := r.Header.Get("Authorization"); auth != "" {
-			t.Errorf("expected no Authorization header, got %q", auth)
+			t.Errorf("unexpected Authorization header: %q", auth)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"id":"x","model":"llama3","choices":[{"message":{"role":"assistant","content":"Hello from Ollama"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3}}`)
+		chatNDJSON(w,
+			`{"model":"llama3","message":{"role":"assistant","content":"Hello from Ollama"},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":3}`,
+		)
 	}))
 	defer server.Close()
 
@@ -34,16 +50,19 @@ func TestChat_Generate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if result.Text != "Hello from Ollama" {
-		t.Errorf("Text = %q", result.Text)
+		t.Errorf("Text = %q, want %q", result.Text, "Hello from Ollama")
+	}
+	if result.FinishReason != provider.FinishStop {
+		t.Errorf("FinishReason = %q, want %q", result.FinishReason, provider.FinishStop)
 	}
 }
 
 func TestChat_Stream(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0}]}\n\n")
-		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{},\"index\":0,\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1}}\n\n")
-		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		chatNDJSON(w,
+			`{"model":"llama3","message":{"role":"assistant","content":"Hi"},"done":false}`,
+			`{"model":"llama3","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":5,"eval_count":1}`,
+		)
 	}))
 	defer server.Close()
 
@@ -58,32 +77,39 @@ func TestChat_Stream(t *testing.T) {
 	}
 
 	var texts []string
+	var gotFinish bool
 	for chunk := range result.Stream {
-		if chunk.Type == provider.ChunkText {
+		switch chunk.Type {
+		case provider.ChunkText:
 			texts = append(texts, chunk.Text)
+		case provider.ChunkFinish:
+			gotFinish = true
 		}
 	}
 	if len(texts) != 1 || texts[0] != "Hi" {
-		t.Errorf("texts = %v", texts)
+		t.Errorf("texts = %v, want [Hi]", texts)
+	}
+	if !gotFinish {
+		t.Error("expected ChunkFinish")
 	}
 }
 
 func TestChat_DefaultBaseURL(t *testing.T) {
-	// When no WithBaseURL is provided, should use localhost:11434.
-	// We can't actually connect, but we can verify the model is created.
+	// Verify the model is created without panicking when no URL option is given.
 	model := Chat("llama3")
 	if model.ModelID() != "llama3" {
-		t.Errorf("ModelID() = %q", model.ModelID())
+		t.Errorf("ModelID() = %q, want %q", model.ModelID(), "llama3")
 	}
 }
 
 func TestChat_WithHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("X-Custom") != "val" {
-			t.Error("missing custom header")
+			t.Error("missing custom header X-Custom: val")
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+		chatNDJSON(w,
+			`{"model":"m","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`,
+		)
 	}))
 	defer server.Close()
 
@@ -100,13 +126,13 @@ func TestChat_WithHeaders(t *testing.T) {
 
 func TestChat_WithHTTPClient(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+		chatNDJSON(w,
+			`{"model":"m","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`,
+		)
 	}))
 	defer server.Close()
 
-	c := &http.Client{}
-	model := Chat("m", WithBaseURL(server.URL), WithHTTPClient(c))
+	model := Chat("m", WithBaseURL(server.URL), WithHTTPClient(&http.Client{}))
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
@@ -120,7 +146,7 @@ func TestChat_WithHTTPClient(t *testing.T) {
 func TestChat_HTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = fmt.Fprint(w, `{"error":{"message":"server error"}}`)
+		_, _ = fmt.Fprint(w, `{"error":"server error"}`)
 	}))
 	defer server.Close()
 
@@ -131,7 +157,7 @@ func TestChat_HTTPError(t *testing.T) {
 		},
 	})
 	if err == nil {
-		t.Fatal("expected error")
+		t.Fatal("expected error, got nil")
 	}
 }
 
@@ -139,32 +165,140 @@ func TestCapabilities(t *testing.T) {
 	model := Chat("m")
 	caps := provider.ModelCapabilitiesOf(model)
 	if !caps.Temperature || !caps.ToolCall {
-		t.Error("unexpected capabilities")
+		t.Errorf("unexpected capabilities: Temperature=%v ToolCall=%v", caps.Temperature, caps.ToolCall)
 	}
 }
 
 func TestModelID(t *testing.T) {
 	model := Chat("llama3")
 	if model.ModelID() != "llama3" {
-		t.Errorf("ModelID() = %q", model.ModelID())
+		t.Errorf("ModelID() = %q, want %q", model.ModelID(), "llama3")
 	}
 }
 
-// --- Embedding Tests ---
+// --- Think mode tests ---
+
+func TestChat_ThinkMode_Generate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request body includes think:true.
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		thinkRaw, ok := body["think"]
+		if !ok {
+			t.Error("think field missing from request")
+		}
+		if string(thinkRaw) != "true" {
+			t.Errorf("think = %s, want true", thinkRaw)
+		}
+
+		chatNDJSON(w,
+			`{"model":"qwen3","message":{"role":"assistant","thinking":"let me think","content":"answer"},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":5}`,
+		)
+	}))
+	defer server.Close()
+
+	model := Chat("qwen3", WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "think"}}},
+		},
+		ProviderOptions: map[string]any{"think": true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "answer" {
+		t.Errorf("Text = %q, want %q", result.Text, "answer")
+	}
+	if result.Reasoning != "let me think" {
+		t.Errorf("Reasoning = %q, want %q", result.Reasoning, "let me think")
+	}
+}
+
+func TestChat_ThinkMode_Stream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chatNDJSON(w,
+			`{"model":"qwen3","message":{"role":"assistant","thinking":"reasoning chunk","content":""},"done":false}`,
+			`{"model":"qwen3","message":{"role":"assistant","thinking":"","content":"answer chunk"},"done":false}`,
+			`{"model":"qwen3","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":5}`,
+		)
+	}))
+	defer server.Close()
+
+	model := Chat("qwen3", WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "think"}}},
+		},
+		ProviderOptions: map[string]any{"think": true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var textChunks []string
+	var reasonChunks []string
+	for chunk := range result.Stream {
+		switch chunk.Type {
+		case provider.ChunkText:
+			textChunks = append(textChunks, chunk.Text)
+		case provider.ChunkReasoning:
+			reasonChunks = append(reasonChunks, chunk.Text)
+		}
+	}
+
+	if len(reasonChunks) != 1 || reasonChunks[0] != "reasoning chunk" {
+		t.Errorf("reasonChunks = %v, want [reasoning chunk]", reasonChunks)
+	}
+	if len(textChunks) != 1 || textChunks[0] != "answer chunk" {
+		t.Errorf("textChunks = %v, want [answer chunk]", textChunks)
+	}
+}
+
+func TestChat_ThinkMode_DefaultFalse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		// think should be present and false (we always send it).
+		thinkRaw, ok := body["think"]
+		if !ok {
+			t.Error("think field missing from request")
+		}
+		if string(thinkRaw) != "false" {
+			t.Errorf("think = %s, want false", thinkRaw)
+		}
+		chatNDJSON(w,
+			`{"model":"m","message":{"role":"assistant","content":"hi"},"done":true,"done_reason":"stop"}`,
+		)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// --- Embedding tests ---
 
 func TestEmbedding_SingleValue(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/embeddings" {
-			t.Errorf("expected /embeddings, got %s", r.URL.Path)
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("expected /api/embed, got %s", r.URL.Path)
 		}
 		if auth := r.Header.Get("Authorization"); auth != "" {
-			t.Errorf("expected no Authorization, got %q", auth)
+			t.Errorf("unexpected Authorization header: %q", auth)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data":  []map[string]any{{"embedding": []float64{0.1, 0.2}, "index": 0}},
-			"usage": map[string]any{"prompt_tokens": 3, "total_tokens": 3},
-		})
+		embedJSON(w, `{"model":"nomic-embed-text","embeddings":[[0.1,0.2]],"prompt_eval_count":3}`)
 	}))
 	defer srv.Close()
 
@@ -176,28 +310,78 @@ func TestEmbedding_SingleValue(t *testing.T) {
 	if len(result.Embeddings) != 1 {
 		t.Fatalf("expected 1 embedding, got %d", len(result.Embeddings))
 	}
-	if result.Embeddings[0][0] != 0.1 {
-		t.Errorf("unexpected embedding: %v", result.Embeddings[0])
+	// float32→float64 conversion introduces rounding; check within epsilon.
+	const epsilon = 1e-6
+	if diff := result.Embeddings[0][0] - 0.1; diff > epsilon || diff < -epsilon {
+		t.Errorf("first embedding value = %v, want ~0.1", result.Embeddings[0][0])
 	}
 }
 
 func TestEmbedding_DefaultBaseURL(t *testing.T) {
 	model := Embedding("nomic-embed-text")
 	if model.ModelID() != "nomic-embed-text" {
-		t.Errorf("ModelID() = %q", model.ModelID())
+		t.Errorf("ModelID() = %q, want %q", model.ModelID(), "nomic-embed-text")
 	}
 }
 
 func TestEmbedding_MaxValuesPerCall(t *testing.T) {
 	model := Embedding("m")
-	if got := model.MaxValuesPerCall(); got != 2048 {
-		t.Errorf("MaxValuesPerCall = %d, want 2048", got)
+	if got := model.MaxValuesPerCall(); got != defaultMaxValuesPerCall {
+		t.Errorf("MaxValuesPerCall = %d, want %d", got, defaultMaxValuesPerCall)
 	}
 }
 
 func TestEmbedding_ModelID(t *testing.T) {
 	model := Embedding("nomic-embed-text")
 	if model.ModelID() != "nomic-embed-text" {
-		t.Errorf("ModelID() = %q", model.ModelID())
+		t.Errorf("ModelID() = %q, want %q", model.ModelID(), "nomic-embed-text")
+	}
+}
+
+func TestChat_StreamToolCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chatNDJSON(w,
+			`{"model":"llama3","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"location":"Paris"}}}]},"done":false}`,
+			`{"model":"llama3","message":{"role":"assistant","content":""},"done":true,"done_reason":"tool_calls","prompt_eval_count":8,"eval_count":4}`,
+		)
+	}))
+	defer server.Close()
+
+	model := Chat("llama3", WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "weather?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotStreamStart bool
+	var gotToolCall bool
+	var toolName string
+	var toolInput string
+	for chunk := range result.Stream {
+		switch chunk.Type {
+		case provider.ChunkToolCallStreamStart:
+			gotStreamStart = true
+			toolName = chunk.ToolName
+		case provider.ChunkToolCall:
+			gotToolCall = true
+			toolInput = chunk.ToolInput
+		}
+	}
+
+	if !gotStreamStart {
+		t.Error("expected ChunkToolCallStreamStart")
+	}
+	if !gotToolCall {
+		t.Error("expected ChunkToolCall")
+	}
+	if toolName != "get_weather" {
+		t.Errorf("ToolName = %q, want %q", toolName, "get_weather")
+	}
+	if toolInput == "" {
+		t.Error("ToolInput should not be empty")
 	}
 }


### PR DESCRIPTION
## Why

The existing `provider/ollama` implementation delegates to `provider/compat`, which speaks the OpenAI-compatible HTTP endpoint (`/v1/chat/completions`). This works for basic chat and embeddings, but the OpenAI-compat endpoint does not expose Ollama-native features — specifically the `think` field on `ChatRequest`, which controls whether the model performs explicit chain-of-thought reasoning before answering (supported by models like `deepseek-r1`).

This gap was discovered while building [Fernand](https://github.com/bclermont/fernand), a modular chatbot, which needed to disable think mode for certain Ollama models. The only way to control it is through the native `/api/chat` endpoint via `github.com/ollama/ollama/api`.

## What changed

- Replaced the compat-layer wrapper with a native implementation using `github.com/ollama/ollama/api`
- Chat requests now go to `/api/chat` (native NDJSON streaming)
- Embedding requests now go to `/api/embed`
- New `ProviderOptions["think"]` bool (default `false`) maps to `ollamaapi.ThinkValue` on the chat request
- Reasoning text from `Message.Thinking` is surfaced as `GenerateResult.Reasoning` (non-streaming) or `ChunkReasoning` stream chunks
- Custom HTTP headers preserved via `headerTransport` wrapper
- `go.mod` adds `github.com/ollama/ollama v0.30.6`

## Tests

15 tests — all pass:
- Original 10 tests ported to native NDJSON wire format
- 3 new think-mode tests (enabled, disabled, streaming reasoning chunks)
- 2 additional embedding tests