### PR TITLE
Fix: capture redacted_thinking blocks in Anthropic streaming

### DIFF
--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -362,6 +362,9 @@ func (m *chatModel) buildRequest(params provider.GenerateParams, streaming bool)
 	// Thinking / extended thinking.
 	// Read from ProviderOptions["thinking"] -- matches Vercel AI SDK convention.
 	// Accepts: {type: "enabled", budgetTokens: N} or {type: "adaptive"} or {type: "disabled"}.
+	// Adaptive thinking accepts an optional display: "summarized" | "omitted"
+	// (Opus 4.7/4.8 default to "omitted", so thinking text streams empty unless
+	// "summarized" is requested).
 	if thinking, ok := params.ProviderOptions["thinking"]; ok {
 		if tm, ok := thinking.(map[string]any); ok {
 			thinkingReq := map[string]any{}
@@ -370,6 +373,9 @@ func (m *chatModel) buildRequest(params provider.GenerateParams, streaming bool)
 			}
 			if budget, ok := tm["budgetTokens"]; ok {
 				thinkingReq["budget_tokens"] = budget
+			}
+			if display, ok := tm["display"]; ok {
+				thinkingReq["display"] = display
 			}
 			if len(thinkingReq) > 0 {
 				body["thinking"] = thinkingReq

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -889,6 +889,21 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 					}) {
 						return
 					}
+				case "redacted_thinking":
+					// Redacted thinking arrives as a complete block in
+					// content_block_start (no deltas). Surface the encrypted
+					// data so it can be replayed on the next turn.
+					if data, _ := cb["data"].(string); data != "" {
+						if !provider.TrySend(ctx, out, provider.StreamChunk{
+							Type: provider.ChunkReasoning,
+							Text: "",
+							Metadata: map[string]any{
+								"redactedData": data,
+							},
+						}) {
+							return
+						}
+					}
 				default:
 					if isServerToolResultBlock(cbType) {
 						isResultBlock = true

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -1062,6 +1062,27 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 	}
 }
 
+func TestBuildRequest_ThinkingAdaptiveDisplay(t *testing.T) {
+	m := &chatModel{id: "claude-opus-4-8", opts: options{baseURL: defaultBaseURL}}
+	body := m.buildRequest(provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		ProviderOptions: map[string]any{
+			"thinking": map[string]any{"type": "adaptive", "display": "summarized"},
+		},
+	}, true)
+
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatal("thinking not in request body")
+	}
+	if thinking["type"] != "adaptive" {
+		t.Errorf("thinking.type = %v, want adaptive", thinking["type"])
+	}
+	if thinking["display"] != "summarized" {
+		t.Errorf("thinking.display = %v, want summarized", thinking["display"])
+	}
+}
+
 func TestBuildRequest_ProviderOptionsPassthrough(t *testing.T) {
 	m := &chatModel{id: "claude-sonnet-4-20250514", opts: options{baseURL: defaultBaseURL}}
 	body := m.buildRequest(provider.GenerateParams{

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/internal/httpc"
@@ -273,6 +274,35 @@ func TestChat_Stream_RedactedThinking(t *testing.T) {
 	}
 	if data, _ := redacted.Metadata["redactedData"].(string); data != "encrypted-blob-xyz" {
 		t.Errorf("redactedData = %v, want encrypted-blob-xyz", redacted.Metadata["redactedData"])
+	}
+}
+
+func TestParseSSE_RedactedThinking_ContextCancelled(t *testing.T) {
+	// With a cancelled context and an unbuffered channel that has no reader,
+	// TrySend must take the ctx.Done() branch and parseSSE must return without
+	// blocking. Covers the cancellation path of the redacted_thinking case.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	out := make(chan provider.StreamChunk)
+	body := strings.NewReader(`data: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted-blob"}}` + "\n\n")
+
+	done := make(chan struct{})
+	go func() {
+		parseSSE(ctx, body, out, false)
+		close(done)
+	}()
+
+	// With no reader, the unbuffered send is never ready, so TrySend must take
+	// the cancelled-ctx branch and parseSSE must return (and close out).
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("parseSSE did not return after context cancellation")
+	}
+
+	// out is closed now; draining must complete without yielding a chunk.
+	for chunk := range out {
+		t.Errorf("expected no chunk after cancellation, got %+v", chunk)
 	}
 }
 

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -226,6 +226,56 @@ func TestChat_Stream_Reasoning(t *testing.T) {
 	}
 }
 
+func TestChat_Stream_RedactedThinking(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`+"\n\n")
+		// Redacted thinking arrives as a complete block in content_block_start (no deltas).
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted-blob-xyz"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"The answer is 42"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"content_block_stop","index":1}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":20}}`+"\n\n")
+		_, _ = fmt.Fprint(w, `data: {"type":"message_stop"}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("claude-sonnet-4-20250514", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "think about this"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var chunks []provider.StreamChunk
+	for chunk := range result.Stream {
+		chunks = append(chunks, chunk)
+	}
+
+	// The redacted_thinking block must surface as a ChunkReasoning carrying the
+	// encrypted data so it can be replayed on a later turn.
+	var redacted *provider.StreamChunk
+	for i := range chunks {
+		if chunks[i].Type == provider.ChunkReasoning {
+			redacted = &chunks[i]
+			break
+		}
+	}
+	if redacted == nil {
+		t.Fatalf("expected a reasoning chunk for redacted thinking, got %+v", chunks)
+	}
+	if redacted.Text != "" {
+		t.Errorf("redacted reasoning chunk text = %q, want empty", redacted.Text)
+	}
+	if data, _ := redacted.Metadata["redactedData"].(string); data != "encrypted-blob-xyz" {
+		t.Errorf("redactedData = %v, want encrypted-blob-xyz", redacted.Metadata["redactedData"])
+	}
+}
+
 func TestChat_Stream_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
Supersedes #93 (the original PR from a fork could not be updated with the coverage fix because the fork branch rejects maintainer pushes). Commits from #93 are cherry-picked here with original authorship preserved.

### Problem

Streaming dropped `redacted_thinking` blocks. They arrive as a complete block in `content_block_start` with no deltas, but the streaming switch only handled tool-use blocks, so they fell through and were discarded. The non-streaming path already handled them. Because the encrypted `data` never reached the caller, it could not be replayed on the next turn, and Anthropic can reject follow-up requests with missing thinking blocks.

### Fix

- Added a `redacted_thinking` case to the streaming switch that emits the block as a `ChunkReasoning` with `redactedData` metadata, matching what the request serializer reads back.
- Added passthrough for the adaptive thinking `display` option (`summarized` | `omitted`) in `buildRequest`.

### Tests

- `TestChat_Stream_RedactedThinking`, `TestBuildRequest_ThinkingAdaptiveDisplay`.
- `TestParseSSE_RedactedThinking_ContextCancelled` covers the context-cancel branch so codecov patch coverage stays at target.
- `go build`, `go vet`, anthropic suite pass.