### PR TITLE
fix: preserve split tool call stream metadata

### DIFF
--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -485,7 +485,7 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 				activeTools[tc.Index] = active
 			}
 
-			if tc.ID != "" {
+			if tc.ID != "" && !active.started {
 				active.id = tc.ID
 			} else if active.id == "" && tc.Function.Name != "" {
 				// First chunk for a tool call with no ID -- generate one.
@@ -504,6 +504,28 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 					return
 				}
 				active.started = true
+
+				if pending := active.args.String(); pending != "" {
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type:       provider.ChunkToolCallDelta,
+						ToolCallID: active.id,
+						ToolName:   active.name,
+						ToolInput:  pending,
+					}) {
+						return
+					}
+					if json.Valid([]byte(pending)) {
+						if !provider.TrySend(ctx, out, provider.StreamChunk{
+							Type:       provider.ChunkToolCall,
+							ToolCallID: active.id,
+							ToolName:   active.name,
+							ToolInput:  pending,
+						}) {
+							return
+						}
+						active.args.Reset()
+					}
+				}
 			}
 
 			if tc.Function.Arguments != "" {
@@ -519,19 +541,19 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 					}) {
 						return
 					}
-				}
 
-				// Emit ChunkToolCall when accumulated args form valid JSON.
-				if accumulated := active.args.String(); json.Valid([]byte(accumulated)) {
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:       provider.ChunkToolCall,
-						ToolCallID: active.id,
-						ToolName:   active.name,
-						ToolInput:  accumulated,
-					}) {
-						return
+					// Emit ChunkToolCall when accumulated args form valid JSON.
+					if accumulated := active.args.String(); json.Valid([]byte(accumulated)) {
+						if !provider.TrySend(ctx, out, provider.StreamChunk{
+							Type:       provider.ChunkToolCall,
+							ToolCallID: active.id,
+							ToolName:   active.name,
+							ToolInput:  accumulated,
+						}) {
+							return
+						}
+						active.args.Reset()
 					}
-					active.args.Reset()
 				}
 			}
 		}
@@ -540,7 +562,7 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 		if choice.FinishReason != "" {
 			if choice.FinishReason == "tool_calls" {
 				for _, active := range activeTools {
-					if remaining := active.args.String(); remaining != "" {
+					if remaining := active.args.String(); remaining != "" && active.started {
 						if !provider.TrySend(ctx, out, provider.StreamChunk{
 							Type:       provider.ChunkToolCall,
 							ToolCallID: active.id,

--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -76,7 +76,7 @@ func BuildRequest(params provider.GenerateParams, modelID string, streaming bool
 
 	// Extract structuredOutputs and strictJsonSchema once -- used by both tools and response format.
 	structuredOutputs := true // default true, matching Vercel
-	strictJSON := false      // default false, matching Vercel
+	strictJSON := false       // default false, matching Vercel
 	if v, ok := params.ProviderOptions["structuredOutputs"]; ok {
 		if b, ok := v.(bool); ok {
 			structuredOutputs = b
@@ -359,9 +359,10 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 	defer close(out)
 	// Track active tool calls by index, accumulating argument fragments.
 	type activeToolCall struct {
-		id   string
-		name string
-		args strings.Builder
+		id      string
+		name    string
+		args    strings.Builder
+		started bool
 	}
 	activeTools := make(map[int]*activeToolCall)
 	var usage provider.Usage
@@ -478,41 +479,46 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 
 		// Tool calls -- item 17: generate fallback ID if provider omits it.
 		for _, tc := range delta.ToolCalls {
-			tcID := tc.ID
-			if tcID == "" && tc.Function.Name != "" {
-				// First chunk for a tool call with no ID -- generate one.
-				if active := activeTools[tc.Index]; active == nil {
-					tcID = generateToolCallID()
-				}
+			active := activeTools[tc.Index]
+			if active == nil {
+				active = &activeToolCall{}
+				activeTools[tc.Index] = active
 			}
 
-			if tcID != "" {
-				activeTools[tc.Index] = &activeToolCall{id: tcID, name: tc.Function.Name}
+			if tc.ID != "" {
+				active.id = tc.ID
+			} else if active.id == "" && tc.Function.Name != "" {
+				// First chunk for a tool call with no ID -- generate one.
+				active.id = generateToolCallID()
+			}
+			if tc.Function.Name != "" {
+				active.name = tc.Function.Name
+			}
+
+			if active.id != "" && active.name != "" && !active.started {
 				if !provider.TrySend(ctx, out, provider.StreamChunk{
 					Type:       provider.ChunkToolCallStreamStart,
-					ToolCallID: tcID,
-					ToolName:   tc.Function.Name,
+					ToolCallID: active.id,
+					ToolName:   active.name,
 				}) {
 					return
 				}
+				active.started = true
 			}
 
 			if tc.Function.Arguments != "" {
-				active := activeTools[tc.Index]
-				if active == nil {
-					active = &activeToolCall{}
-					activeTools[tc.Index] = active
-				}
 				active.args.WriteString(tc.Function.Arguments)
 
 				// Emit delta for UI streaming progress.
-				if !provider.TrySend(ctx, out, provider.StreamChunk{
-					Type:       provider.ChunkToolCallDelta,
-					ToolCallID: active.id,
-					ToolName:   active.name,
-					ToolInput:  tc.Function.Arguments,
-				}) {
-					return
+				if active.started {
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type:       provider.ChunkToolCallDelta,
+						ToolCallID: active.id,
+						ToolName:   active.name,
+						ToolInput:  tc.Function.Arguments,
+					}) {
+						return
+					}
 				}
 
 				// Emit ChunkToolCall when accumulated args form valid JSON.

--- a/internal/openaicompat/openaicompat_test.go
+++ b/internal/openaicompat/openaicompat_test.go
@@ -407,6 +407,89 @@ data: [DONE]
 	}
 }
 
+func TestParseStream_ToolCallArgsBeforeName(t *testing.T) {
+	input := `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"arguments":"{\"path\":"}}]},"index":0}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"read","arguments":"\"main.go\"}"}}]},"index":0}]}
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls","index":0}]}
+data: [DONE]
+`
+	scanner := sse.NewScanner(strings.NewReader(input))
+	out := make(chan provider.StreamChunk, 10)
+
+	go ParseStream(t.Context(), scanner, out)
+
+	var startChunk, toolCall provider.StreamChunk
+	var deltas []provider.StreamChunk
+	for chunk := range out {
+		switch chunk.Type {
+		case provider.ChunkToolCallStreamStart:
+			startChunk = chunk
+		case provider.ChunkToolCallDelta:
+			deltas = append(deltas, chunk)
+		case provider.ChunkToolCall:
+			toolCall = chunk
+		}
+	}
+
+	if startChunk.ToolCallID != "call_1" || startChunk.ToolName != "read" {
+		t.Fatalf("start chunk = %+v, want id call_1 name read", startChunk)
+	}
+	if len(deltas) != 2 {
+		t.Fatalf("got %d deltas, want 2", len(deltas))
+	}
+	if deltas[0].ToolInput != `{"path":` {
+		t.Errorf("delta[0] input = %q", deltas[0].ToolInput)
+	}
+	if deltas[1].ToolInput != `"main.go"}` {
+		t.Errorf("delta[1] input = %q", deltas[1].ToolInput)
+	}
+	for i, delta := range deltas {
+		if delta.ToolCallID != "call_1" || delta.ToolName != "read" {
+			t.Errorf("delta[%d] = %+v, want id call_1 name read", i, delta)
+		}
+	}
+	if toolCall.ToolCallID != "call_1" || toolCall.ToolName != "read" {
+		t.Fatalf("tool call = %+v, want id call_1 name read", toolCall)
+	}
+	if toolCall.ToolInput != `{"path":"main.go"}` {
+		t.Errorf("tool input = %q, want %q", toolCall.ToolInput, `{"path":"main.go"}`)
+	}
+}
+
+func TestParseStream_LateProviderIDDoesNotReplaceGeneratedID(t *testing.T) {
+	input := `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"read","arguments":""}}]},"index":0}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_late","function":{"arguments":"{\"x\":1}"}}]},"index":0}]}
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls","index":0}]}
+data: [DONE]
+`
+	scanner := sse.NewScanner(strings.NewReader(input))
+	out := make(chan provider.StreamChunk, 10)
+
+	go ParseStream(t.Context(), scanner, out)
+
+	var startChunk, deltaChunk, toolCall provider.StreamChunk
+	for chunk := range out {
+		switch chunk.Type {
+		case provider.ChunkToolCallStreamStart:
+			startChunk = chunk
+		case provider.ChunkToolCallDelta:
+			deltaChunk = chunk
+		case provider.ChunkToolCall:
+			toolCall = chunk
+		}
+	}
+
+	if !strings.HasPrefix(startChunk.ToolCallID, "call_") || startChunk.ToolCallID == "call_late" {
+		t.Fatalf("start ID = %q, want generated ID", startChunk.ToolCallID)
+	}
+	if deltaChunk.ToolCallID != startChunk.ToolCallID || toolCall.ToolCallID != startChunk.ToolCallID {
+		t.Fatalf("stream IDs changed: start=%q delta=%q call=%q", startChunk.ToolCallID, deltaChunk.ToolCallID, toolCall.ToolCallID)
+	}
+	if toolCall.ToolName != "read" || toolCall.ToolInput != `{"x":1}` {
+		t.Fatalf("tool call = %+v, want read with {\"x\":1}", toolCall)
+	}
+}
+
 func TestParseStream_Reasoning(t *testing.T) {
 	input := `data: {"choices":[{"delta":{"reasoning_content":"Let me think..."},"index":0}]}
 data: {"choices":[{"delta":{"content":"The answer is 42."},"index":0}]}
@@ -586,15 +669,15 @@ data: [DONE]
 		chunks = append(chunks, chunk)
 	}
 
-	// Should not panic -- the nil active guard creates a new activeToolCall
+	// Should not panic or emit an unnamed tool call.
 	var foundToolCall bool
 	for _, c := range chunks {
 		if c.Type == provider.ChunkToolCall {
 			foundToolCall = true
 		}
 	}
-	if !foundToolCall {
-		t.Error("expected tool call chunk from args without ID")
+	if foundToolCall {
+		t.Error("unexpected tool call chunk from args without ID or name")
 	}
 }
 

--- a/internal/openaicompat/openaicompat_test.go
+++ b/internal/openaicompat/openaicompat_test.go
@@ -362,6 +362,51 @@ data: [DONE]
 	}
 }
 
+func TestParseStream_ToolCallNameAfterID(t *testing.T) {
+	input := `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{}}]},"index":0}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"read","arguments":""}}]},"index":0}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":"}}]},"index":0}]}
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"main.go\"}"}}]},"index":0}]}
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls","index":0}]}
+data: [DONE]
+`
+	scanner := sse.NewScanner(strings.NewReader(input))
+	out := make(chan provider.StreamChunk, 10)
+
+	go ParseStream(t.Context(), scanner, out)
+
+	var startChunk, toolCall provider.StreamChunk
+	var deltas []provider.StreamChunk
+	for chunk := range out {
+		switch chunk.Type {
+		case provider.ChunkToolCallStreamStart:
+			startChunk = chunk
+		case provider.ChunkToolCallDelta:
+			deltas = append(deltas, chunk)
+		case provider.ChunkToolCall:
+			toolCall = chunk
+		}
+	}
+
+	if startChunk.ToolCallID != "call_1" || startChunk.ToolName != "read" {
+		t.Fatalf("start chunk = %+v, want id call_1 name read", startChunk)
+	}
+	if len(deltas) != 2 {
+		t.Fatalf("got %d deltas, want 2", len(deltas))
+	}
+	for i, delta := range deltas {
+		if delta.ToolCallID != "call_1" || delta.ToolName != "read" {
+			t.Errorf("delta[%d] = %+v, want id call_1 name read", i, delta)
+		}
+	}
+	if toolCall.ToolCallID != "call_1" || toolCall.ToolName != "read" {
+		t.Fatalf("tool call = %+v, want id call_1 name read", toolCall)
+	}
+	if toolCall.ToolInput != `{"path":"main.go"}` {
+		t.Errorf("tool input = %q, want %q", toolCall.ToolInput, `{"path":"main.go"}`)
+	}
+}
+
 func TestParseStream_Reasoning(t *testing.T) {
 	input := `data: {"choices":[{"delta":{"reasoning_content":"Let me think..."},"index":0}]}
 data: {"choices":[{"delta":{"content":"The answer is 42."},"index":0}]}


### PR DESCRIPTION
## Summary

- Preserve OpenAI-compatible tool-call stream state when providers split `id` and `function.name` across deltas.
- Emit `tool_call_streaming_start` once the active tool call has both ID and name, so later deltas and final tool calls keep complete metadata.
- Add a regression test for an ID-first/name-later tool-call stream.

## Test plan

- [x] `go test ./internal/openaicompat`
- [x] `go test ./...`
- [ ] `golangci-lint run` (not installed locally)

## Related issues

None found.
