### PR TITLE
feat: expose retry steps via RetryObserver (#95)

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -59,7 +59,7 @@ func Embed(ctx context.Context, model provider.EmbeddingModel, value string, opt
 		ProviderOptions: o.EmbeddingProviderOptions,
 	}
 
-	result, err := withRetry(ctx, o.MaxRetries, func() (*provider.EmbedResult, error) {
+	result, err := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.EmbedResult, error) {
 		return model.DoEmbed(ctx, []string{value}, embedParams)
 	})
 	if err != nil {
@@ -110,7 +110,7 @@ func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []stri
 
 	// Single call when no chunking needed.
 	if maxPerCall <= 0 || len(values) <= maxPerCall {
-		result, err := withRetry(ctx, o.MaxRetries, func() (*provider.EmbedResult, error) {
+		result, err := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.EmbedResult, error) {
 			return model.DoEmbed(ctx, values, embedParams)
 		})
 		if err != nil {
@@ -151,7 +151,7 @@ func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []stri
 				results[i] = embedChunkResult{err: err}
 				continue
 			}
-			r, err := withRetry(ctx, o.MaxRetries, func() (*provider.EmbedResult, error) {
+			r, err := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.EmbedResult, error) {
 				return model.DoEmbed(ctx, chunk, embedParams)
 			})
 			results[i] = embedChunkResult{result: r, err: err}
@@ -173,7 +173,7 @@ func EmbedMany(ctx context.Context, model provider.EmbeddingModel, values []stri
 					return
 				}
 
-				r, err := withRetry(ctx, o.MaxRetries, func() (*provider.EmbedResult, error) {
+				r, err := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.EmbedResult, error) {
 					return model.DoEmbed(ctx, chunk, embedParams)
 				})
 				results[i] = embedChunkResult{result: r, err: err}

--- a/generate.go
+++ b/generate.go
@@ -677,7 +677,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 	}
 
 	start := time.Now()
-	firstResult, streamErr := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+	firstResult, streamErr := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
 	if streamErr != nil {
@@ -830,7 +830,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 				o.StateRef.set(StepLLMInFlight, step)
 				highestInflightStep = step
 				var err error
-				result, err = withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+				result, err = withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.StreamResult, error) {
 					return model.DoStream(ctx, params)
 				})
 				if err != nil {
@@ -1122,7 +1122,7 @@ func StreamText(ctx context.Context, model provider.LanguageModel, opts ...Optio
 	}
 
 	start := time.Now()
-	result, streamErr := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+	result, streamErr := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
 	if streamErr != nil {
@@ -1263,7 +1263,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		start := time.Now()
 		o.StateRef.set(StepLLMInFlight, step)
 		highestInflightStep = step
-		result, err := withRetry(ctx, o.MaxRetries, func() (*provider.GenerateResult, error) {
+		result, err := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.GenerateResult, error) {
 			return model.DoGenerate(ctx, params)
 		})
 

--- a/image.go
+++ b/image.go
@@ -40,7 +40,7 @@ func GenerateImage(ctx context.Context, model provider.ImageModel, opts ...Image
 		ProviderOptions: o.providerOptions,
 	}
 
-	result, err := withRetry(ctx, o.maxRetries, func() (*provider.ImageResult, error) {
+	result, err := withRetry(ctx, o.maxRetries, nil, func() (*provider.ImageResult, error) {
 		return model.DoGenerate(ctx, params)
 	})
 	if err != nil {

--- a/object.go
+++ b/object.go
@@ -464,7 +464,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 		}
 
 		start := time.Now()
-		result, err := withRetry(ctx, o.MaxRetries, func() (*provider.GenerateResult, error) {
+		result, err := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.GenerateResult, error) {
 			return model.DoGenerate(ctx, params)
 		})
 
@@ -643,7 +643,7 @@ func StreamObject[T any](ctx context.Context, model provider.LanguageModel, opts
 	}
 
 	start := time.Now()
-	result, streamErr := withRetry(ctx, o.MaxRetries, func() (*provider.StreamResult, error) {
+	result, streamErr := withRetry(ctx, o.MaxRetries, o.RetryObserver, func() (*provider.StreamResult, error) {
 		return model.DoStream(ctx, params)
 	})
 	if streamErr != nil {

--- a/options.go
+++ b/options.go
@@ -145,6 +145,9 @@ type options struct {
 	// StateRef, when non-nil, receives atomic state updates as the tool loop
 	// progresses. See WithStateRef / AgentState.
 	StateRef *AgentState
+
+	// RetryObserver is called before each retry attempt. See WithRetryObserver.
+	RetryObserver RetryObserver
 }
 
 // defaultOptions returns options with sensible defaults.
@@ -322,6 +325,14 @@ func WithEmbeddingProviderOptions(opts map[string]any) Option {
 	return func(o *options) {
 		o.EmbeddingProviderOptions = opts
 	}
+}
+
+// WithRetryObserver sets a callback that is invoked before each retry attempt.
+// The callback receives the 0-based retry attempt number, the error that triggered
+// the retry, and the delay before the next attempt. It is called before the sleep,
+// allowing callers to log or observe retry progress.
+func WithRetryObserver(fn RetryObserver) Option {
+	return func(o *options) { o.RetryObserver = fn }
 }
 
 // validateProviderOptions panics if any value in the map is not JSON-serializable.

--- a/retry.go
+++ b/retry.go
@@ -145,14 +145,21 @@ func parseRetryFromBody(msg string) time.Duration {
 	return time.Duration(v) * time.Second
 }
 
+// RetryObserver is called before each retry attempt, giving the caller a chance
+// to log or observe the retry step.
+type RetryObserver func(attempt int, err error, delay time.Duration)
+
 // withRetry executes fn up to maxRetries+1 times, retrying on retryable errors.
 // Respects Retry-After/Retry-After-ms headers when present; falls back to
 // exponential backoff otherwise.
-func withRetry[T any](ctx context.Context, maxRetries int, fn func() (T, error)) (T, error) {
+func withRetry[T any](ctx context.Context, maxRetries int, observer RetryObserver, fn func() (T, error)) (T, error) {
 	result, err := fn()
 	attempt := 0
 	for ; err != nil && retryable(err) && attempt < maxRetries; attempt++ {
 		delay := retryDelay(err, attempt)
+		if observer != nil {
+			observer(attempt, err, delay)
+		}
 		if sleepErr := sleep(ctx, delay); sleepErr != nil {
 			var zero T
 			return zero, sleepErr

--- a/retry_test.go
+++ b/retry_test.go
@@ -64,7 +64,7 @@ func TestBackoffDuration(t *testing.T) {
 
 func TestWithRetry_Success(t *testing.T) {
 	calls := 0
-	result, err := withRetry(t.Context(), 2, func() (string, error) {
+	result, err := withRetry(t.Context(), 2, nil, func() (string, error) {
 		calls++
 		return "ok", nil
 	})
@@ -81,7 +81,7 @@ func TestWithRetry_Success(t *testing.T) {
 
 func TestWithRetry_RetryThenSuccess(t *testing.T) {
 	calls := 0
-	result, err := withRetry(t.Context(), 2, func() (string, error) {
+	result, err := withRetry(t.Context(), 2, nil, func() (string, error) {
 		calls++
 		if calls < 3 {
 			return "", &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true, Message: "rate limited"}
@@ -101,7 +101,7 @@ func TestWithRetry_RetryThenSuccess(t *testing.T) {
 
 func TestWithRetry_AllFail(t *testing.T) {
 	calls := 0
-	_, err := withRetry(t.Context(), 2, func() (string, error) {
+	_, err := withRetry(t.Context(), 2, nil, func() (string, error) {
 		calls++
 		return "", &APIError{StatusCode: http.StatusServiceUnavailable, IsRetryable: true, Message: "unavailable"}
 	})
@@ -115,7 +115,7 @@ func TestWithRetry_AllFail(t *testing.T) {
 
 func TestWithRetry_NonRetryable(t *testing.T) {
 	calls := 0
-	_, err := withRetry(t.Context(), 2, func() (string, error) {
+	_, err := withRetry(t.Context(), 2, nil, func() (string, error) {
 		calls++
 		return "", &APIError{StatusCode: http.StatusBadRequest, IsRetryable: false, Message: "bad request"}
 	})
@@ -131,7 +131,7 @@ func TestWithRetry_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	calls := 0
 	cancel() // Cancel immediately.
-	_, err := withRetry(ctx, 5, func() (string, error) {
+	_, err := withRetry(ctx, 5, nil, func() (string, error) {
 		calls++
 		return "", &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true, Message: "rate limited"}
 	})
@@ -560,7 +560,7 @@ func TestStreamText_WithTimeout(t *testing.T) {
 
 func TestWithRetry_ZeroRetries(t *testing.T) {
 	calls := 0
-	_, err := withRetry(t.Context(), 0, func() (string, error) {
+	_, err := withRetry(t.Context(), 0, nil, func() (string, error) {
 		calls++
 		return "", &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true, Message: "rate limited"}
 	})
@@ -577,7 +577,7 @@ func TestWithRetry_ZeroRetries(t *testing.T) {
 // remains unwrappable via errors.As.
 func TestWithRetry_ExhaustionWraps(t *testing.T) {
 	inner := &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true, Message: "rate limited"}
-	_, err := withRetry(t.Context(), 2, func() (string, error) {
+	_, err := withRetry(t.Context(), 2, nil, func() (string, error) {
 		return "", inner
 	})
 	if err == nil {
@@ -593,4 +593,97 @@ func TestWithRetry_ExhaustionWraps(t *testing.T) {
 	if apiErr.StatusCode != http.StatusTooManyRequests {
 		t.Errorf("apiErr.StatusCode = %d, want %d", apiErr.StatusCode, http.StatusTooManyRequests)
 	}
+}
+
+func TestWithRetry_ObserverCalled(t *testing.T) {
+	calls := 0
+	var observerCalls []RetryInfo
+	observer := func(attempt int, err error, delay time.Duration) {
+		observerCalls = append(observerCalls, RetryInfo{Attempt: attempt, Err: err, Delay: delay})
+	}
+	result, err := withRetry(t.Context(), 3, observer, func() (string, error) {
+		calls++
+		if calls < 3 {
+			return "", &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true, Message: "rate limited"}
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "ok" {
+		t.Errorf("result = %q", result)
+	}
+	if len(observerCalls) != 2 {
+		t.Fatalf("observerCalls = %d, want 2", len(observerCalls))
+	}
+	if observerCalls[0].Attempt != 0 {
+		t.Errorf("first call attempt = %d, want 0", observerCalls[0].Attempt)
+	}
+	if observerCalls[1].Attempt != 1 {
+		t.Errorf("second call attempt = %d, want 1", observerCalls[1].Attempt)
+	}
+	if observerCalls[0].Delay <= 0 {
+		t.Error("delay should be > 0")
+	}
+	if observerCalls[0].Err == nil {
+		t.Error("err should not be nil")
+	}
+}
+
+func TestWithRetry_ObserverNotCalledOnSuccess(t *testing.T) {
+	calls := 0
+	observerCalled := false
+	withRetry(t.Context(), 2, func(attempt int, err error, delay time.Duration) {
+		observerCalled = true
+	}, func() (string, error) {
+		calls++
+		return "ok", nil
+	})
+	if observerCalled {
+		t.Error("observer should not be called when there are no retries")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+}
+
+func TestGenerateText_WithRetryObserver(t *testing.T) {
+	calls := 0
+	var observerCalls []RetryInfo
+	model := &mockModel{
+		id: "test",
+		generateFn: func(_ context.Context, _ provider.GenerateParams) (*provider.GenerateResult, error) {
+			calls++
+			if calls == 1 {
+				return nil, &APIError{StatusCode: http.StatusTooManyRequests, IsRetryable: true, Message: "rate limited"}
+			}
+			return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop}, nil
+		},
+	}
+
+	result, err := GenerateText(t.Context(), model, WithPrompt("hi"), WithMaxRetries(2), WithRetryObserver(func(attempt int, err error, delay time.Duration) {
+		observerCalls = append(observerCalls, RetryInfo{Attempt: attempt, Err: err, Delay: delay})
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "ok" {
+		t.Errorf("Text = %q", result.Text)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+	if len(observerCalls) != 1 {
+		t.Fatalf("observerCalls = %d, want 1", len(observerCalls))
+	}
+	if observerCalls[0].Attempt != 0 {
+		t.Errorf("attempt = %d, want 0", observerCalls[0].Attempt)
+	}
+}
+
+type RetryInfo struct {
+	Attempt int
+	Err     error
+	Delay   time.Duration
 }


### PR DESCRIPTION
Add `WithRetryObserver(fn RetryObserver)` callback that fires before each retry attempt, allowing callers to log or observe retry progress.

**Changes**
- New `RetryObserver` type: `func(attempt int, err error, delay time.Duration)`
- Observer invoked in `withRetry` loop before sleep
- All call sites (`generate.go`, `object.go`, `embed.go`) pass observer through
- `image.go` passes `nil` (uses separate `imageOptions`)
- 3 new tests: observer called on retry, not called on success, integration with `GenerateText`

**Usage**
```go
model := goai.NewModel(client, "gpt-5",
    goai.WithRetryObserver(func(attempt int, err error, delay time.Duration) {
        slog.Warn("retrying", "attempt", attempt, "delay", delay, "err", err)
    }),
)
```

Closes #95

**Coverage**
- Main package: 97.6% (unchanged)
- `retry.go`: 100%
- `options.go`: 100% (`WithRetryObserver` covered)
- All 1109 tests pass