### PR TITLE
fix: correct YAML indentation in zenflow-review workflow

### DIFF
--- a/.github/workflows/zenflow-review.yml
+++ b/.github/workflows/zenflow-review.yml
@@ -63,7 +63,7 @@ jobs:
           gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > .zenflow/diff.patch
           wc -l .zenflow/diff.patch
 
-       - name: Run zenflow review
+      - name: Run zenflow review
          env:
            ZENFLOW_MODEL: fptcloud/Qwen3.6-27B
            FPT_API_KEY: ${{ secrets.FPT_API_KEY }}


### PR DESCRIPTION
Fix extra space in step indentation at line 66 that caused YAML parse error.