### PR TITLE
Add Reasoning field to stepResult

### DIFF
--- a/object.go
+++ b/object.go
@@ -504,6 +504,7 @@ func GenerateObject[T any](ctx context.Context, model provider.LanguageModel, op
 			Response:         result.Response,
 			ProviderMetadata: result.ProviderMetadata,
 			Sources:          result.Sources,
+			Reasoning:        result.Reasoning,
 		}
 		steps = append(steps, stepResult)
 		totalUsage = addUsage(totalUsage, result.Usage)


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Changes

This pull request introduces a minor update to the `GenerateObject` function in `object.go` by including the `Reasoning` field in the generated step results. This ensures that any reasoning provided by the language model is now captured and stored as part of the step output.

- Functionality enhancement:
  * [`object.go`](diffhunk://#diff-12229ea844f42fd705168380fb7870bcd7d66f0c94b53ef0efe8b9ca50f05ec7R507): Added the `Reasoning` field to the `stepResult` structure in the `GenerateObject` function to capture reasoning from the language model.

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes
- [ ] New tests added for new functionality
- [ ] Examples updated if public API changed

## Related issues

#102 