### PR TITLE
fix(anthropic): send native structured output as output_config.format

### DIFF
--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -44,7 +44,7 @@ const (
 // in buildRequest and must not be passed through verbatim.
 // Allocated once at package init to avoid per-request map allocation.
 var anthropicHandledKeys = map[string]bool{
-	"thinking": true, "_headers": true,
+	"thinking": true, "_headers": true, "output_format": true,
 	"disableParallelToolUse": true, "effort": true, "speed": true,
 	"container": true, "contextManagement": true,
 }
@@ -407,6 +407,22 @@ func (m *chatModel) buildRequest(params provider.GenerateParams, streaming bool)
 		}
 	}
 
+	// output_format -- native structured-output schema set by
+	// injectNativeOutputFormat. Anthropic nests it under output_config.format
+	// (the top-level output_format field is deprecated). Merge into
+	// output_config so it coexists with effort.
+	// https://platform.claude.com/docs/en/build-with-claude/structured-outputs
+	if of, ok := params.ProviderOptions["output_format"]; ok {
+		if ofm, ok := of.(map[string]any); ok {
+			oc, _ := body["output_config"].(map[string]any)
+			if oc == nil {
+				oc = map[string]any{}
+			}
+			oc["format"] = ofm
+			body["output_config"] = oc
+		}
+	}
+
 	// speed -- fast/standard inference speed.
 	if speed, ok := params.ProviderOptions["speed"]; ok {
 		if s, ok := speed.(string); ok && s != "" {
@@ -721,7 +737,9 @@ func (m *chatModel) supportsNativeOutputFormat() bool {
 		strings.Contains(id, "claude-opus-4-1")
 }
 
-// injectNativeOutputFormat adds output_format to ProviderOptions for passthrough to the API body.
+// injectNativeOutputFormat stores the structured-output schema in
+// ProviderOptions["output_format"]; buildRequest nests it under
+// output_config.format on the wire.
 func injectNativeOutputFormat(params provider.GenerateParams) provider.GenerateParams {
 	p := params
 	// Copy the map to avoid mutating the caller's ProviderOptions.

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -643,6 +643,60 @@ func TestBuildRequest_ToolChoice(t *testing.T) {
 	}
 }
 
+// Native structured output must be sent as output_config.format; the top-level
+// output_format field is deprecated and rejected by the API. This exercises the
+// full native path (injectNativeOutputFormat -> buildRequest).
+func TestBuildRequest_NativeOutputFormat(t *testing.T) {
+	m := &chatModel{id: "claude-sonnet-4-6", opts: options{baseURL: defaultBaseURL}}
+
+	schema := json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}`)
+	params := provider.GenerateParams{
+		Messages:       []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		ResponseFormat: &provider.ResponseFormat{Schema: schema},
+		ProviderOptions: map[string]any{
+			"structuredOutputMode": "outputFormat",
+			"effort":               "high",
+		},
+	}
+
+	if !m.useNativeOutputFormat(params) {
+		t.Fatal("useNativeOutputFormat = false, want true for structuredOutputMode=outputFormat")
+	}
+	params = injectNativeOutputFormat(params)
+	body := m.buildRequest(params, false)
+
+	// The deprecated top-level field must not be present.
+	if _, ok := body["output_format"]; ok {
+		t.Errorf("body has top-level output_format = %v, want it nested under output_config.format", body["output_format"])
+	}
+
+	oc, ok := body["output_config"].(map[string]any)
+	if !ok {
+		t.Fatalf("output_config = %v, want map", body["output_config"])
+	}
+
+	// effort and format coexist in the same output_config object.
+	if oc["effort"] != "high" {
+		t.Errorf("output_config.effort = %v, want high", oc["effort"])
+	}
+
+	format, ok := oc["format"].(map[string]any)
+	if !ok {
+		t.Fatalf("output_config.format = %v, want map", oc["format"])
+	}
+	if format["type"] != "json_schema" {
+		t.Errorf("output_config.format.type = %v, want json_schema", format["type"])
+	}
+	got, _ := json.Marshal(format["schema"])
+	var want, gotNorm any
+	_ = json.Unmarshal(schema, &want)
+	_ = json.Unmarshal(got, &gotNorm)
+	wantJSON, _ := json.Marshal(want)
+	if string(got) != string(wantJSON) {
+		t.Errorf("output_config.format.schema = %s, want %s", got, wantJSON)
+	}
+}
+
 // --- Message conversion tests ---
 
 func TestConvertMessages_Text(t *testing.T) {
@@ -1931,14 +1985,21 @@ func TestDoStream_NativeOutputFormat(t *testing.T) {
 		var req map[string]any
 		_ = json.Unmarshal(body, &req)
 
-		// Verify output_format is passed through (via ProviderOptions injection).
-		if of, ok := req["output_format"]; !ok {
-			t.Errorf("expected output_format in request, got none")
-		} else {
-			ofm := of.(map[string]any)
-			if ofm["type"] != "json_schema" {
-				t.Errorf("output_format.type = %v, want json_schema", ofm["type"])
-			}
+		// Verify the schema is sent as output_config.format, not the deprecated
+		// top-level output_format. Non-fatal assertions only: t.Fatal/panic in
+		// this handler goroutine would reset the connection (client EOF).
+		if _, ok := req["output_format"]; ok {
+			t.Error("deprecated top-level output_format present in request")
+		}
+		oc, _ := req["output_config"].(map[string]any)
+		if oc == nil {
+			t.Error("output_config not present in request")
+		}
+		of, _ := oc["format"].(map[string]any)
+		if of == nil {
+			t.Error("output_config.format not present in request")
+		} else if of["type"] != "json_schema" {
+			t.Errorf("output_config.format.type = %v, want json_schema", of["type"])
 		}
 
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/provider/anthropic/bf14_parity_test.go
+++ b/provider/anthropic/bf14_parity_test.go
@@ -321,13 +321,20 @@ func TestDoGenerate_NativeOutputFormat(t *testing.T) {
 		var req map[string]any
 		_ = json.Unmarshal(body, &req)
 
-		// Verify output_format is set and no synthetic tool trick.
-		if _, ok := req["output_format"]; !ok {
-			t.Error("output_format not present in request")
+		// Verify the schema is sent as output_config.format (not the
+		// deprecated top-level output_format).
+		if _, ok := req["output_format"]; ok {
+			t.Error("deprecated top-level output_format present in request")
 		}
-		of := req["output_format"].(map[string]any)
-		if of["type"] != "json_schema" {
-			t.Errorf("output_format.type = %v, want json_schema", of["type"])
+		oc, _ := req["output_config"].(map[string]any)
+		if oc == nil {
+			t.Error("output_config not present in request")
+		}
+		of, _ := oc["format"].(map[string]any)
+		if of == nil {
+			t.Error("output_config.format not present in request")
+		} else if of["type"] != "json_schema" {
+			t.Errorf("output_config.format.type = %v, want json_schema", of["type"])
 		}
 		// Should NOT have the json_response synthetic tool.
 		if tools, ok := req["tools"]; ok {


### PR DESCRIPTION
## Summary

Native structured-output mode (`structuredOutputMode: "outputFormat"`, or `"auto"` with a supported model) sent the JSON schema as the **top-level `output_format`** request field. The Anthropic Messages API has deprecated that field, so every native-output-format request now fails with `400: output_format: This field is deprecated. Use 'output_config.format' instead.` This nests the schema under `output_config.format` instead.

## Changes

- `buildRequest` (`provider/anthropic/anthropic.go`): nest the native structured-output schema under `output_config.format`, merging into the same `output_config` object that `effort` writes so the two coexist. (The merge lives here, not in `injectNativeOutputFormat`, because `buildRequest` runs after the wire body exists and is the only place `output_config` is assembled.)
- Add `output_format` to `anthropicHandledKeys` so the provider-options passthrough loop no longer copies it to the top level of the body.
- Update the doc comment on `injectNativeOutputFormat` to describe the nesting.
- Update `TestDoGenerate_NativeOutputFormat` and `TestDoStream_NativeOutputFormat` to assert the `output_config.format` wire shape; their httptest handlers now use only non-fatal assertions so a missing field can no longer panic the handler goroutine into a client-side `EOF`.
- Add `TestBuildRequest_NativeOutputFormat`: asserts the body carries `output_config.format` (type `json_schema`, correct schema), carries no top-level `output_format`, and that `format` coexists with `effort`. Verified failing before the fix.

No exported API change. The `structuredOutputMode` option name and semantics are unchanged; only the emitted wire shape moves to the current location.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` passes — emits 9 **pre-existing** issues (8 errcheck, 1 unused); none in the files this PR changes (`anthropic.go` and `bf14_parity_test.go` are clean; the 3 `anthropic_test.go` findings predate this PR — commit `21f46200a`)
- [x] New tests added for new functionality
- [x] Examples updated if public API changed — n/a (no public API change)

## Related issues

Fixes #104
