### PR TITLE
feat: add Requesty provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 ## Features
 
 - **7 core functions**: `GenerateText`, `StreamText`, `GenerateObject[T]`, `StreamObject[T]`, `Embed`, `EmbedMany`, `GenerateImage`
-- **25+ providers**: OpenAI, Anthropic, Google, Bedrock, Azure, Vertex, Mistral, xAI, Groq, Cohere, DeepSeek, MiniMax, Fireworks, Together, DeepInfra, OpenRouter, Perplexity, Cerebras, Ollama, vLLM, RunPod, Cloudflare Workers AI, FPT Smart Cloud, NVIDIA NIM, + generic OpenAI-compatible
+- **25+ providers**: OpenAI, Anthropic, Google, Bedrock, Azure, Vertex, Mistral, xAI, Groq, Cohere, DeepSeek, MiniMax, Fireworks, Together, DeepInfra, OpenRouter, Requesty, Perplexity, Cerebras, Ollama, vLLM, RunPod, Cloudflare Workers AI, FPT Smart Cloud, NVIDIA NIM, + generic OpenAI-compatible
 - **Auto tool loop**: Define tools with `Execute` handlers, set `MaxSteps` for `GenerateText` and `StreamText`
 - **Structured output**: `GenerateObject[T]` auto-generates JSON Schema from Go types via reflection
 - **Streaming**: Real-time text and partial object streaming via channels

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -162,6 +162,7 @@ export default defineConfig({
                 { text: 'Together', link: '/providers/together' },
                 { text: 'DeepInfra', link: '/providers/deepinfra' },
                 { text: 'OpenRouter', link: '/providers/openrouter' },
+                { text: 'Requesty', link: '/providers/requesty' },
                 { text: 'Perplexity', link: '/providers/perplexity' },
                 { text: 'Cerebras', link: '/providers/cerebras' },
                 { text: 'NVIDIA NIM', link: '/providers/nvidia' },

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -43,6 +43,7 @@ Most use the shared `internal/openaicompat` codec (some wrappers delegate via `p
 | [Together](together.md)     | `api.together.xyz`  | `TOGETHER_AI_API_KEY` (or `TOGETHER_API_KEY`) |
 | [DeepInfra](deepinfra.md)   | `api.deepinfra.com` | `DEEPINFRA_API_KEY`                           |
 | [OpenRouter](openrouter.md) | `openrouter.ai`     | `OPENROUTER_API_KEY`                          |
+| [Requesty](requesty.md)     | `router.requesty.ai` | `REQUESTY_API_KEY`                           |
 | [Perplexity](perplexity.md) | `api.perplexity.ai` | `PERPLEXITY_API_KEY`                          |
 | [Cerebras](cerebras.md)     | `api.cerebras.ai`   | `CEREBRAS_API_KEY`                            |
 | [RunPod](runpod.md)         | `api.runpod.ai`     | `RUNPOD_API_KEY`                              |

--- a/docs/providers/requesty.md
+++ b/docs/providers/requesty.md
@@ -1,0 +1,66 @@
+---
+title: Requesty Provider
+description: "Access models from multiple AI providers through Requesty's OpenAI-compatible gateway in Go with GoAI. One API key for OpenAI, Anthropic, Google, and more, with caching, failover, and cost controls."
+---
+
+# Requesty
+
+[Requesty](https://requesty.ai/) is a unified, OpenAI-compatible LLM gateway. Access models from multiple providers through a single API key, with caching, failover, and cost optimization.
+
+## Setup
+
+```bash
+go get github.com/zendev-sh/goai@latest
+```
+
+```go
+import "github.com/zendev-sh/goai/provider/requesty"
+```
+
+Set the `REQUESTY_API_KEY` environment variable, or pass `WithAPIKey()` directly.
+
+## Models
+
+Models use a `provider/model` prefix format:
+
+- `openai/gpt-4o-mini`
+- `anthropic/claude-sonnet-4-5`
+- `google/gemini-2.5-flash`
+- `deepseek/deepseek-chat`
+
+See [app.requesty.ai/router/list](https://app.requesty.ai/router/list) for the full catalog.
+
+## Tested Models
+
+**Unit tested** (mock HTTP server): `anthropic/claude-sonnet-4`
+
+**Live tested** against `https://router.requesty.ai/v1`: `openai/gpt-4o-mini`, `google/gemini-2.5-flash`
+
+## Usage
+
+```go
+model := requesty.Chat("openai/gpt-4o-mini")
+
+result, err := goai.GenerateText(ctx, model, goai.WithPrompt("Hello"))
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(result.Text)
+```
+
+## Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `WithAPIKey(key)` | `string` | Set a static API key |
+| `WithTokenSource(ts)` | `provider.TokenSource` | Set a dynamic token source |
+| `WithBaseURL(url)` | `string` | Override the default `https://router.requesty.ai/v1` endpoint |
+| `WithHeaders(h)` | `map[string]string` | Set additional HTTP headers |
+| `WithHTTPClient(c)` | `*http.Client` | Set a custom `*http.Client` |
+
+## Notes
+
+- Supports image inputs (depends on the underlying model).
+- Sends optional `HTTP-Referer` and `X-Title` analytics headers, as documented by Requesty.
+- Usage reporting is enabled by default (`usage: {include: true}` in request body).
+- Environment variable `REQUESTY_BASE_URL` can override the default endpoint (for example, the EU endpoint `https://router.eu.requesty.ai/v1`).

--- a/provider/requesty/requesty.go
+++ b/provider/requesty/requesty.go
@@ -1,0 +1,105 @@
+// Package requesty provides a Requesty language model implementation for GoAI.
+//
+// Requesty is a unified, OpenAI-compatible LLM gateway that routes to multiple
+// providers through a single endpoint, with caching, failover, and cost
+// optimization. See https://requesty.ai and https://docs.requesty.ai.
+package requesty
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/zendev-sh/goai/internal/openaicompat"
+	"github.com/zendev-sh/goai/provider"
+)
+
+const defaultBaseURL = "https://router.requesty.ai/v1"
+
+// Option configures the Requesty provider.
+type Option func(*options)
+
+type options struct {
+	tokenSource provider.TokenSource
+	baseURL     string
+	headers     map[string]string
+	httpClient  *http.Client
+}
+
+// WithAPIKey sets a static API key for authentication.
+func WithAPIKey(key string) Option {
+	return func(o *options) { o.tokenSource = provider.StaticToken(key) }
+}
+
+// WithTokenSource sets a dynamic token source for authentication.
+func WithTokenSource(ts provider.TokenSource) Option {
+	return func(o *options) { o.tokenSource = ts }
+}
+
+// WithBaseURL overrides the default API base URL.
+func WithBaseURL(url string) Option {
+	return func(o *options) { o.baseURL = url }
+}
+
+// WithHeaders sets additional HTTP headers sent with every request.
+func WithHeaders(h map[string]string) Option {
+	return func(o *options) { o.headers = h }
+}
+
+// WithHTTPClient sets a custom HTTP client for all requests.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *options) { o.httpClient = c }
+}
+
+// Chat creates a Requesty language model for the given model ID.
+//
+// Model IDs use the provider/model naming convention, e.g.
+// "openai/gpt-4o-mini" or "anthropic/claude-sonnet-4-5".
+func Chat(modelID string, opts ...Option) provider.LanguageModel {
+	o := options{baseURL: defaultBaseURL}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.tokenSource == nil {
+		if key := os.Getenv("REQUESTY_API_KEY"); key != "" {
+			o.tokenSource = provider.StaticToken(key)
+		}
+	}
+	if o.baseURL == defaultBaseURL {
+		if base := os.Getenv("REQUESTY_BASE_URL"); base != "" {
+			o.baseURL = base
+		}
+	}
+	return openaicompat.NewChatModel(openaicompat.ChatModelConfig{
+		ProviderID:           "requesty",
+		ModelID:              modelID,
+		BaseURL:              o.baseURL,
+		TokenSource:          o.tokenSource,
+		TokenRequired:        true,
+		Headers:              mergeHeaders(o.headers),
+		HTTPClient:           o.httpClient,
+		Capabilities:         chatCaps,
+		IncludeStreamOptions: true,
+		WarnPromptCaching:    true,
+		ExtraBody:            map[string]any{"usage": map[string]any{"include": true}},
+	})
+}
+
+// mergeHeaders returns user-provided headers with Requesty-specific headers added.
+// These optional analytics headers are documented at https://docs.requesty.ai.
+func mergeHeaders(user map[string]string) map[string]string {
+	merged := map[string]string{
+		"HTTP-Referer": "https://github.com/zendev-sh/goai",
+		"X-Title":      "goai",
+	}
+	for k, v := range user {
+		merged[k] = v
+	}
+	return merged
+}
+
+var chatCaps = provider.ModelCapabilities{
+	Temperature:      true,
+	ToolCall:         true,
+	InputModalities:  provider.ModalitySet{Text: true},
+	OutputModalities: provider.ModalitySet{Text: true},
+}

--- a/provider/requesty/requesty_test.go
+++ b/provider/requesty/requesty_test.go
@@ -1,0 +1,359 @@
+package requesty
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestChat_Stream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("auth = %s", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("HTTP-Referer") != "https://github.com/zendev-sh/goai" {
+			t.Errorf("referer = %s", r.Header.Get("HTTP-Referer"))
+		}
+		if r.Header.Get("X-Title") != "goai" {
+			t.Errorf("x-title = %s", r.Header.Get("X-Title"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		// Check usage include.
+		usage, _ := req["usage"].(map[string]any)
+		if usage["include"] != true {
+			t.Errorf("usage.include = %v, want true", usage)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{},\"index\":0,\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("anthropic/claude-sonnet-4", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var texts []string
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkText {
+			texts = append(texts, chunk.Text)
+		}
+	}
+	if len(texts) != 1 || texts[0] != "Hello" {
+		t.Errorf("texts = %v, want [Hello]", texts)
+	}
+}
+
+func TestChat_Generate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"chatcmpl-123","model":"anthropic/claude-sonnet-4","choices":[{"message":{"role":"assistant","content":"Hello world"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("anthropic/claude-sonnet-4", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "Hello world" {
+		t.Errorf("Text = %q, want 'Hello world'", result.Text)
+	}
+}
+
+func TestChat_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"Rate limited"}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("model", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNoTokenSource(t *testing.T) {
+	model := Chat("model")
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func okResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)),
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	called := false
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return okResponse(), nil
+	})
+	m := Chat("model", WithAPIKey("key"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("custom HTTP client transport was not invoked")
+	}
+}
+
+func TestWithHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "val" {
+			t.Error("missing custom header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithAPIKey("k"), WithBaseURL(server.URL), WithHeaders(map[string]string{"X-Custom": "val"}))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWithTokenSource(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer dynamic" {
+			t.Errorf("auth = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithTokenSource(provider.StaticToken("dynamic")), WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	model := Chat("m", WithAPIKey("k"))
+	caps := provider.ModelCapabilitiesOf(model)
+	if !caps.Temperature || !caps.ToolCall {
+		t.Error("unexpected capabilities")
+	}
+}
+
+func TestModelID(t *testing.T) {
+	model := Chat("anthropic/claude-sonnet-4", WithAPIKey("k"))
+	if model.ModelID() != "anthropic/claude-sonnet-4" {
+		t.Errorf("ModelID() = %q", model.ModelID())
+	}
+}
+
+func TestConnectionError(t *testing.T) {
+	model := Chat("m", WithAPIKey("k"), WithBaseURL("http://127.0.0.1:1"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "sending request") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestPerRequestHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Per-Request") != "val" {
+			t.Error("missing per-request header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"x","model":"m","choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithAPIKey("k"), WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+		Headers: map[string]string{"X-Per-Request": "val"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"id"`)
+	}))
+	defer server.Close()
+
+	model := Chat("m", WithAPIKey("k"), WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestChat_EnvVarResolution(t *testing.T) {
+	var gotAuth string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	})
+	t.Setenv("REQUESTY_API_KEY", "env-key")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "Bearer env-key" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+}
+
+func TestChat_EnvVarBaseURL(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("REQUESTY_API_KEY", "k")
+	t.Setenv("REQUESTY_BASE_URL", "https://custom.example.com/v1")
+	m := Chat("m", WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://custom.example.com/v1/") {
+		t.Errorf("URL = %q", gotURL)
+	}
+}
+
+func TestChat_EnvVarNotOverrideExplicit(t *testing.T) {
+	var gotURL string
+	tr := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return okResponse(), nil
+	})
+	t.Setenv("REQUESTY_API_KEY", "env-key")
+	t.Setenv("REQUESTY_BASE_URL", "https://env.url")
+	m := Chat("m", WithAPIKey("explicit"), WithBaseURL("https://explicit.url"), WithHTTPClient(&http.Client{Transport: tr}))
+	_, err := m.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(gotURL, "https://explicit.url/") {
+		t.Errorf("URL = %q", gotURL)
+	}
+}
+
+func TestChat_PromptCachingIgnored(t *testing.T) {
+	// DoGenerate with JSON server
+	genServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"chatcmpl-test","model":"openai/gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`)
+	}))
+	defer genServer.Close()
+
+	genModel := Chat("openai/gpt-4o", WithAPIKey("test-key"), WithBaseURL(genServer.URL))
+	genResult, err := genModel.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages:      []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		PromptCaching: true,
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate unexpected error: %v", err)
+	}
+	if genResult.Text != "ok" {
+		t.Errorf("DoGenerate Text = %q, want ok", genResult.Text)
+	}
+
+	// DoStream with SSE server
+	streamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"index\":0}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{},\"index\":0,\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2}}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer streamServer.Close()
+
+	streamModel := Chat("openai/gpt-4o", WithAPIKey("test-key"), WithBaseURL(streamServer.URL))
+	streamResult, err := streamModel.DoStream(t.Context(), provider.GenerateParams{
+		Messages:      []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		PromptCaching: true,
+	})
+	if err != nil {
+		t.Fatalf("DoStream unexpected error: %v", err)
+	}
+	for range streamResult.Stream {
+	}
+}


### PR DESCRIPTION
## What

Adds a native [Requesty](https://requesty.ai) provider, mirroring the existing `openrouter` provider. Requesty is an OpenAI-compatible LLM gateway, so the package is built on `internal/openaicompat` — a `/chat/completions` endpoint at `https://router.requesty.ai/v1`, `provider/model` model naming, and the same optional `HTTP-Referer` / `X-Title` analytics headers OpenRouter uses.

- `provider/requesty/requesty.go` — `Chat()` + the standard options (`WithAPIKey`, `WithTokenSource`, `WithBaseURL`, `WithHeaders`, `WithHTTPClient`); resolves `REQUESTY_API_KEY` / `REQUESTY_BASE_URL` from the environment.
- `provider/requesty/requesty_test.go` — full test suite ported from the openrouter tests.
- `docs/providers/requesty.md`, `docs/providers/index.md`, `docs/.vitepress/config.ts` nav, and the README `25+ providers` list.

## Tested (per AGENTS.md / CONTRIBUTING.md)

- `go build ./...` — OK
- `go test ./...` — all pass; `go test -cover ./provider/requesty/` → **100.0% of statements** (exceeds the 90% target)
- `go vet ./provider/requesty/` — clean
- `golangci-lint run ./provider/requesty/` — **0 issues**
- `gofmt` — clean
- **Live**: ran `goai.GenerateText` through `requesty.Chat("openai/gpt-4o-mini")` against the real `https://router.requesty.ai/v1` endpoint — returns correctly.

One feature, one PR, with tests and docs, as per CONTRIBUTING.md.

## Disclosure

I work at Requesty. This follows the exact pattern of the existing `openrouter` provider. Happy to adjust naming, capabilities, or docs — or close it if it's not a fit.