### PR TITLE
fix(gemini): strip propertyNames/patternProperties/const/exclusiveMinMax/default from schemas

### DIFF
--- a/internal/gemini/schema.go
+++ b/internal/gemini/schema.go
@@ -227,9 +227,15 @@ func sanitizeImpl(obj any) any {
 		delete(result, "required")
 	}
 
-	// Gemini API does not support additionalProperties or format in JSON Schema.
+	// Gemini API does not support these JSON Schema keywords in function_declarations.
 	delete(result, "additionalProperties")
 	delete(result, "format")
+	delete(result, "propertyNames")
+	delete(result, "patternProperties")
+	delete(result, "const")
+	delete(result, "exclusiveMinimum")
+	delete(result, "exclusiveMaximum")
+	delete(result, "default")
 
 	return result
 }

--- a/internal/gemini/schema_test.go
+++ b/internal/gemini/schema_test.go
@@ -369,6 +369,60 @@ func TestSanitizeSchema_PointerToStructNullableType(t *testing.T) {
 	}
 }
 
+func TestSanitizeSchema_StripsUnsupportedKeywords(t *testing.T) {
+	// Gemini's function_declarations rejects propertyNames, patternProperties,
+	// const, exclusiveMinimum, exclusiveMaximum, and default.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":             "string",
+				"const":            "fixed",
+				"default":          "hello",
+				"exclusiveMinimum": 0,
+				"exclusiveMaximum": 100,
+			},
+			"meta": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"key": map[string]any{"type": "string"},
+				},
+				"propertyNames": map[string]any{
+					"pattern": "^[a-zA-Z]+$",
+				},
+				"patternProperties": map[string]any{
+					"^x-": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	result := SanitizeSchema(schema)
+
+	props := result["properties"].(map[string]any)
+
+	// name: const, default, exclusiveMinimum, exclusiveMaximum removed.
+	name := props["name"].(map[string]any)
+	for _, k := range []string{"const", "default", "exclusiveMinimum", "exclusiveMaximum"} {
+		if _, ok := name[k]; ok {
+			t.Errorf("name.%s should be removed", k)
+		}
+	}
+	if name["type"] != "string" {
+		t.Errorf("name.type = %v, want string", name["type"])
+	}
+
+	// meta: propertyNames, patternProperties removed.
+	meta := props["meta"].(map[string]any)
+	for _, k := range []string{"propertyNames", "patternProperties"} {
+		if _, ok := meta[k]; ok {
+			t.Errorf("meta.%s should be removed", k)
+		}
+	}
+	if meta["type"] != "object" {
+		t.Errorf("meta.type = %v, want object", meta["type"])
+	}
+}
+
 func TestSanitizeSchema_TimeDateTimeFormat(t *testing.T) {
 	// time.Time produces type: "string", format: "date-time".
 	// Gemini doesn't support format, so it should be stripped.


### PR DESCRIPTION


Gemini's function_declarations API rejects JSON Schema keywords like propertyNames, patternProperties, const, exclusiveMinimum, exclusiveMaximum, and default. MCP tool schemas (e.g. firecrawl) commonly carry these, causing 'Unknown name' errors.

Add all six to the existing strip list in sanitizeImpl alongside additionalProperties and format.

Fixes zendev-sh/zenflow#14

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List of changes -->
-

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes
- [ ] New tests added for new functionality
- [ ] Examples updated if public API changed

## Related issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
