### PR TITLE
fix: ensure CallTool sends arguments as {} instead of omitting it (#107)

### DIFF
--- a/agent_state_test.go
+++ b/agent_state_test.go
@@ -2524,114 +2524,105 @@ func TestAgentState_StreamText_ErrorAfterLLMInFlight_MonotonicStep(t *testing.T)
 		}
 	})
 
-	// FIX 50: the single-shot (MaxSteps=1) race subtest above is tautological
-	// for the load-bearing monotonicity path - a single-shot failure has
-	// highestInflightStep == len(steps) (both effectively 1), so the
-	// `highestInflightStep > finalStep` branch in the StepIdle defer is
-	// never exercised. This subtest exercises the genuine mid-loop case:
-	// step 1 succeeds with a tool call (steps gets length 1), then step 2's
-	// DoStream errors BEFORE a StepResult is appended (len(steps) stays 1,
-	// highestInflightStep reaches 2). Pollers must observe step monotonically
-	// advance from 1 → 2 at Idle, never regressing.
-	t.Run("race/mid-loop-error-monotonic-step", func(t *testing.T) {
-		for trial := 0; trial < 50; trial++ {
-			var callCount atomic.Int32
-			model := &mockModel{
-				id: "t",
-				streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
-					n := callCount.Add(1)
-					if n == 1 {
-						// Step 1: success with one tool call → tool executes,
-						// loop proceeds to step 2.
-						return streamFromChunks(
-							provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "ping", ToolInput: `{}`},
-							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
-						), nil
-					}
-					// Step 2+: DoStream itself fails (error before any StepResult).
-					return nil, errors.New("step2 upstream refused")
-				},
-			}
-			var state AgentState
-			var pollerWG sync.WaitGroup
-			stop := make(chan struct{})
-			var violated atomic.Bool
-			var maxObserved atomic.Int32
-			for i := 0; i < 8; i++ {
-				pollerWG.Add(1)
-				go func() {
-					defer pollerWG.Done()
-					var lastStep int
-					for {
-						select {
-						case <-stop:
-							return
-						default:
+		// FIX 50: the single-shot (MaxSteps=1) race subtest above is tautological
+		// for the load-bearing monotonicity path - a single-shot failure has
+		// highestInflightStep == len(steps) (both effectively 1), so the
+		// `highestInflightStep > finalStep` branch in the StepIdle defer is
+		// never exercised. This subtest exercises the genuine mid-loop case:
+		// step 1 succeeds with a tool call (steps gets length 1), then step 2's
+		// DoStream errors BEFORE a StepResult is appended (len(steps) stays 1,
+		// highestInflightStep reaches 2). Pollers must observe step monotonically
+		// advance from 1 → 2 at Idle, never regressing.
+		t.Run("race/mid-loop-error-monotonic-step", func(t *testing.T) {
+			for trial := 0; trial < 50; trial++ {
+				var callCount atomic.Int32
+				model := &mockModel{
+					id: "t",
+					streamFn: func(_ context.Context, _ provider.GenerateParams) (*provider.StreamResult, error) {
+						n := callCount.Add(1)
+						if n == 1 {
+							// Step 1: success with one tool call → tool executes,
+							// loop proceeds to step 2.
+							return streamFromChunks(
+								provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "tc1", ToolName: "ping", ToolInput: `{}`},
+								provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls},
+							), nil
 						}
-						_, s := state.Observe()
-						if s < lastStep {
-							violated.Store(true)
-							return
-						}
-						if int32(s) > maxObserved.Load() {
-							maxObserved.Store(int32(s))
-						}
-						lastStep = s
-					}
-				}()
-			}
-			stream, err := StreamText(t.Context(), model,
-				WithPrompt("go"),
-				WithMaxSteps(3),
-				WithTools(Tool{
-					Name:        "ping",
-					Description: "ping",
-					InputSchema: json.RawMessage(`{"type":"object"}`),
-					Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
-						return "pong", nil
+						// Step 2+: DoStream itself fails (error before any StepResult).
+						return nil, errors.New("step2 upstream refused")
 					},
-				}),
-				WithStateRef(&state),
-			)
-			// StreamText returns (stream, nil) even if a subsequent step
-			// errors - the error surfaces via ChunkError inside the stream.
-			if err != nil {
-				// Unexpected: step 1 succeeded so StreamText should have
-				// returned a live stream.
+				}
+				var state AgentState
+				var pollerWG sync.WaitGroup
+				stop := make(chan struct{})
+				var violated atomic.Bool
+				for i := 0; i < 8; i++ {
+					pollerWG.Add(1)
+					go func() {
+						defer pollerWG.Done()
+						var lastStep int
+						for {
+							select {
+							case <-stop:
+								return
+							default:
+							}
+							_, s := state.Observe()
+							if s < lastStep {
+								violated.Store(true)
+								return
+							}
+							lastStep = s
+						}
+					}()
+				}
+				stream, err := StreamText(t.Context(), model,
+					WithPrompt("go"),
+					WithMaxSteps(3),
+					WithTools(Tool{
+						Name:        "ping",
+						Description: "ping",
+						InputSchema: json.RawMessage(`{"type":"object"}`),
+						Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+							return "pong", nil
+						},
+					}),
+					WithStateRef(&state),
+				)
+				// StreamText returns (stream, nil) even if a subsequent step
+				// errors - the error surfaces via ChunkError inside the stream.
+				if err != nil {
+					// Unexpected: step 1 succeeded so StreamText should have
+					// returned a live stream.
+					close(stop)
+					pollerWG.Wait()
+					t.Fatalf("trial %d: unexpected initial StreamText error: %v", trial, err)
+				}
+				// Drain the stream so the background goroutine completes and
+				// publishes StepIdle. Without this, the tool-loop goroutine is
+				// still running when we check final state below.
+				for range stream.Stream() {
+				}
+				// Additionally wait for the done signal - raw channel close
+				// fires BEFORE StepIdle store (documented in WithStateRef godoc).
+				_ = stream.Err()
 				close(stop)
 				pollerWG.Wait()
-				t.Fatalf("trial %d: unexpected initial StreamText error: %v", trial, err)
+				if violated.Load() {
+					t.Fatalf("trial %d: poller observed step regression across LLMInFlight→Idle transition", trial)
+				}
+				kind, finalStep := state.Observe()
+				if kind != StepIdle {
+					t.Errorf("trial %d: final kind=%v; want StepIdle", trial, kind)
+				}
+				// FIX 47 invariant: finalStep must reflect the highest
+				// announced in-flight step (2), NOT len(steps) (which is 1
+				// because step 2 erred before a StepResult was appended).
+				if finalStep < 2 {
+					t.Errorf("trial %d: finalStep=%d; want >= 2 (highestInflightStep tracked step-2 announcement)", trial, finalStep)
+				}
 			}
-			// Drain the stream so the background goroutine completes and
-			// publishes StepIdle. Without this, the tool-loop goroutine is
-			// still running when we check final state below.
-			for range stream.Stream() {
-			}
-			// Additionally wait for the done signal - raw channel close
-			// fires BEFORE StepIdle store (documented in WithStateRef godoc).
-			_ = stream.Err()
-			close(stop)
-			pollerWG.Wait()
-			if violated.Load() {
-				t.Fatalf("trial %d: poller observed step regression across LLMInFlight→Idle transition", trial)
-			}
-			kind, finalStep := state.Observe()
-			if kind != StepIdle {
-				t.Errorf("trial %d: final kind=%v; want StepIdle", trial, kind)
-			}
-			// FIX 47 invariant: finalStep must reflect the highest
-			// announced in-flight step (2), NOT len(steps) (which is 1
-			// because step 2 erred before a StepResult was appended).
-			if finalStep < 2 {
-				t.Errorf("trial %d: finalStep=%d; want >= 2 (highestInflightStep tracked step-2 announcement)", trial, finalStep)
-			}
-			// Sanity: pollers must have seen the advance to step 2 at
-			// some point (not merely read it once at exit).
-			if maxObserved.Load() < 2 {
-				t.Errorf("trial %d: maxObserved=%d; pollers never saw step 2 advancing", trial, maxObserved.Load())
-			}
-		}
-	})
+		})
 }
 
 // TestAgentState_TerminalCAS verifies that SetTerminal:

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -186,9 +186,12 @@ func (c *Client) CallTool(ctx context.Context, name string, args map[string]any)
 	if err := c.assertCapability("tools"); err != nil {
 		return nil, err
 	}
+	if args == nil {
+		args = make(map[string]any)
+	}
 	params := struct {
 		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
+		Arguments map[string]any `json:"arguments"`
 	}{
 		Name:      name,
 		Arguments: args,

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -1081,6 +1081,50 @@ func TestSendRequest_ClosedChannel(t *testing.T) {
 	}
 }
 
+func TestCallTool_NilArgs(t *testing.T) {
+	mt := newMockTransport()
+	c := NewClient("test", "1.0", WithTransport(mt))
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	mt.sendFunc = func(_ context.Context, msg JSONRPCMessage) error {
+		if msg.Method == "tools/call" {
+			// Verify arguments is always present as an object, never omitted
+			var p struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			}
+			if err := json.Unmarshal(msg.Params, &p); err != nil {
+				t.Fatalf("unmarshal params: %v", err)
+			}
+			if p.Name != "noop" {
+				t.Errorf("tool name = %q, want %q", p.Name, "noop")
+			}
+			if p.Arguments == nil {
+				t.Error("arguments should not be nil when args is nil")
+			}
+
+			result, _ := json.Marshal(CallToolResult{
+				Content: []ContentBlock{
+					json.RawMessage(`{"type":"text","text":"ok"}`),
+				},
+			})
+			mt.inject(JSONRPCMessage{JSONRPC: "2.0", ID: msg.ID, Result: result})
+		}
+		return nil
+	}
+
+	result, err := c.CallTool(context.Background(), "noop", nil)
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("len(content) = %d, want 1", len(result.Content))
+	}
+}
+
 func TestCallTool_NoCapability(t *testing.T) {
 	mt := newMockTransport()
 	mt.serverCaps = ServerCapabilities{}


### PR DESCRIPTION
Buffer.com MCP server rejects tools/call when the arguments field is absent. CallTool now initializes nil args to an empty map and always serializes arguments as an object.

Also fixes a flaky test (race/mid-loop-error-monotonic-step) that asserted pollers must observe every intermediate step value, which is not guaranteed when the error path completes synchronously.

Fix #107

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List of changes -->
-

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes
- [ ] New tests added for new functionality
- [ ] Examples updated if public API changed

## Related issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
