### PR TITLE
Enhance error handling for OpenAI-compatible servers

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -129,45 +129,65 @@ func ParseStreamError(body []byte) *ParsedStreamError {
 	if err := json.Unmarshal(body, &obj); err != nil {
 		return nil
 	}
-	if obj.Type != "error" {
+
+	if obj.Type == "error" {
+		switch obj.Error.Code {
+		case "context_length_exceeded":
+			return &ParsedStreamError{
+				Type:         StreamErrorContextOverflow,
+				Message:      "Input exceeds context window of this model",
+				ResponseBody: string(body),
+			}
+		case "insufficient_quota":
+			return &ParsedStreamError{
+				Type:         StreamErrorAPI,
+				Message:      "Quota exceeded. Check your plan and billing details.",
+				IsRetryable:  false,
+				ResponseBody: string(body),
+			}
+		case "usage_not_included":
+			return &ParsedStreamError{
+				Type:         StreamErrorAPI,
+				Message:      "To use Codex with your ChatGPT plan, upgrade to Plus.",
+				IsRetryable:  false,
+				ResponseBody: string(body),
+			}
+		case "invalid_prompt":
+			msg := "Invalid prompt."
+			if obj.Error.Message != "" {
+				msg = obj.Error.Message
+			}
+			return &ParsedStreamError{
+				Type:         StreamErrorAPI,
+				Message:      msg,
+				IsRetryable:  false,
+				ResponseBody: string(body),
+			}
+		}
 		return nil
 	}
 
-	switch obj.Error.Code {
-	case "context_length_exceeded":
-		return &ParsedStreamError{
-			Type:         StreamErrorContextOverflow,
-			Message:      "Input exceeds context window of this model",
-			ResponseBody: string(body),
-		}
-	case "insufficient_quota":
-		return &ParsedStreamError{
-			Type:         StreamErrorAPI,
-			Message:      "Quota exceeded. Check your plan and billing details.",
-			IsRetryable:  false,
-			ResponseBody: string(body),
-		}
-	case "usage_not_included":
-		return &ParsedStreamError{
-			Type:         StreamErrorAPI,
-			Message:      "To use Codex with your ChatGPT plan, upgrade to Plus.",
-			IsRetryable:  false,
-			ResponseBody: string(body),
-		}
-	case "invalid_prompt":
-		msg := "Invalid prompt."
-		if obj.Error.Message != "" {
-			msg = obj.Error.Message
-		}
-		return &ParsedStreamError{
-			Type:         StreamErrorAPI,
-			Message:      msg,
-			IsRetryable:  false,
-			ResponseBody: string(body),
-		}
+	// Embedded error objects without type:"error" (LM Studio, llama.cpp server, etc.).
+	if obj.Error.Message != "" {
+		return streamErrorFromMessage(obj.Error.Message, body)
 	}
 
 	return nil
+}
+
+func streamErrorFromMessage(message string, body []byte) *ParsedStreamError {
+	if IsOverflow(message) {
+		return &ParsedStreamError{
+			Type:         StreamErrorContextOverflow,
+			Message:      message,
+			ResponseBody: string(body),
+		}
+	}
+	return &ParsedStreamError{
+		Type:         StreamErrorAPI,
+		Message:      message,
+		ResponseBody: string(body),
+	}
 }
 
 // ClassifyStreamError parses a stream error event and returns the appropriate

--- a/errors_test.go
+++ b/errors_test.go
@@ -170,6 +170,16 @@ func TestParseStreamError(t *testing.T) {
 			`{"type":"error","error":{"code":"unknown_code","message":"something"}}`,
 			nil,
 		},
+		{
+			"embedded error - LM Studio",
+			`{"error":{"message":"Compute error."},"message":"Compute error."}`,
+			&ParsedStreamError{Type: "api_error", Message: "Compute error."},
+		},
+		{
+			"embedded error - context overflow",
+			`{"error":{"message":"input length greater than the context length"}}`,
+			&ParsedStreamError{Type: "context_overflow", Message: "input length greater than the context length"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -396,6 +406,12 @@ func TestClassifyStreamError(t *testing.T) {
 			name:    "nil for unknown code",
 			body:    `{"type":"error","error":{"code":"unknown","message":"nope"}}`,
 			wantNil: true,
+		},
+		{
+			name:     "embedded error - LM Studio",
+			body:     `{"error":{"message":"Compute error."},"message":"Compute error."}`,
+			wantType: "api",
+			wantMsg:  "Compute error.",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/openaicompat/openaicompat_test.go
+++ b/internal/openaicompat/openaicompat_test.go
@@ -3,11 +3,13 @@ package openaicompat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"testing"
 
+	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/internal/sse"
 	"github.com/zendev-sh/goai/provider"
 )
@@ -630,6 +632,33 @@ data: [DONE]
 	for chunk := range out {
 		// Accept any chunk type - the key assertion is that the goroutine didn't leak.
 		_ = chunk
+	}
+}
+
+func TestParseStream_EmbeddedStreamError(t *testing.T) {
+	input := `data: {"error":{"message":"Compute error."},"message":"Compute error."}
+`
+	scanner := sse.NewScanner(strings.NewReader(input))
+	out := make(chan provider.StreamChunk, 10)
+	go ParseStream(t.Context(), scanner, out)
+
+	var chunks []provider.StreamChunk
+	for chunk := range out {
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	if chunks[0].Type != provider.ChunkError {
+		t.Errorf("type = %v, want error", chunks[0].Type)
+	}
+	var apiErr *goai.APIError
+	if !errors.As(chunks[0].Error, &apiErr) {
+		t.Fatalf("expected APIError, got %T", chunks[0].Error)
+	}
+	if apiErr.Message != "Compute error." {
+		t.Errorf("message = %q, want %q", apiErr.Message, "Compute error.")
 	}
 }
 


### PR DESCRIPTION
### Summary

LM Studio (and similar OpenAI-compatible servers) can return SSE errors as embedded error.message objects without type: "error", e.g. `{"error":{"message":"Compute error."},"message":"Compute error."}`. `ParseStreamError` only handled typed error events, so these were ignored during streaming and the stream ended without a useful error.

This PR extends `ParseStreamError` to detect embedded error objects and surface them as APIError or ContextOverflowError, fixing error handling for all openaicompat providers (compat, Ollama, vLLM, etc.).