### PR TITLE
fix: docs drift audit — file upload docs, homepage, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ testdata/
 .zenflow/diff.patch
 .zenflow/events.ndjson
 .zenflow/review.md
+
+.vibeflow
+*.out
+docs/drift-report

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 
 ## What's New
 
+> **v0.9.0** - Provider-neutral file upload and remote file references. `FileUploader` interface + `RemoteFileRef` for OpenAI (Files API), Anthropic (Files API), and Google Gemini (Files API). Compat providers fall back to inline base64 automatically. [Changelog →](https://github.com/zendev-sh/goai/releases)
+>
 > **v0.8.5** - New provider: [Requesty](https://goai.sh/providers/requesty) (OpenAI-compatible LLM gateway). Plus Anthropic native structured output, per-step `Reasoning`, and Gemini schema sanitization fixes. [Changelog →](https://github.com/zendev-sh/goai/releases)
 >
 > **v0.8.4** - `WithRetryObserver` callback for observing retry attempts, split tool-call stream metadata fix, and Anthropic `redacted_thinking` capture in streaming. [Changelog →](https://github.com/zendev-sh/goai/releases)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # GoAI Roadmap
 
-> Last updated: 2026-06-21
+> Last updated: 2026-07-20
 
 ## v0.4.4
 
@@ -142,7 +142,13 @@
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **MCP HTTPTransport: POST-only Streamable HTTP** | `mcp.HTTPTransport.Start` now treats `405` (or `404`) on the optional GET-for-SSE channel as "no server-initiated stream" per the MCP Streamable HTTP spec (2025-03-26), so POST-only servers (Zoho MCP and others) work instead of failing with `mcp: SSE connection failed: HTTP 405`. Inline JSON-RPC and `text/event-stream` POST responses are still dispatched as before. (#76) |
 
-## v0.8.5 - Current release
+## v0.9.0 - Current release
+
+| Feature                                  | Description                                                                                                                                                                                                                     |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **File upload & remote file references** | New `FileUploader` interface with `UploadFile`/`DeleteFile` for OpenAI (Files API), Anthropic (Files API), and Google Gemini (Files API). New `RemoteFileRef` type with `Part.RemoteRef` field. Compat providers fall back to inline base64 via `RemoteFileRef.Data`. `ModelCapabilities.FileUpload` capability flag. |
+
+## v0.8.5
 
 | Feature                             | Description                                                                                                                                                                                                                                                                            |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/.vitepress/theme/HomeRaw.vue
+++ b/docs/.vitepress/theme/HomeRaw.vue
@@ -136,17 +136,34 @@ onMounted(() => {
         <p class="rh-section-label">What's new</p>
         <div class="rh-release-list">
           <a
-            href="https://github.com/zendev-sh/goai/releases/tag/v0.7.2"
+            href="https://github.com/zendev-sh/goai/releases/tag/v0.9.0"
             class="rh-release"
           >
-            <span class="rh-release-tag">v0.7.2</span>
+            <span class="rh-release-tag">v0.9.0</span>
             <span class="rh-release-text"
-              ><strong>NVIDIA NIM provider</strong> — New provider.
-              OpenAI-compatible chat + embeddings. E2E tested with meta/llama-3.3-70b-instruct.</span
+              ><strong>File upload &amp; remote file refs</strong> — Provider-neutral file upload for OpenAI, Anthropic, and Google Gemini. Compat providers fall back to inline base64.</span
             >
           </a>
           <a
-            href="https://github.com/zendev-sh/goai/releases/tag/v0.7.0"
+            href="https://github.com/zendev-sh/goai/releases/tag/v0.8.5"
+            class="rh-release"
+          >
+            <span class="rh-release-tag">v0.8.5</span>
+            <span class="rh-release-text"
+              ><strong>Requesty provider</strong> — New OpenAI-compatible LLM gateway provider. Anthropic native structured output, per-step Reasoning.</span
+            >
+          </a>
+          <a
+            href="https://github.com/zendev-sh/goai/releases/tag/v0.8.0"
+            class="rh-release"
+          >
+            <span class="rh-release-tag">v0.8.0</span>
+            <span class="rh-release-text"
+              ><strong>MCP OAuth 2.1 + PKCE</strong> — Native OAuth for remote MCP servers. NewTool typed constructor. Hook panics surfaced as PanicError.</span
+            >
+          </a>
+          <a
+            href="https://github.com/zendev-sh/goai/releases"
             class="rh-release"
           >
             <span class="rh-release-tag">v0.7.0</span>
@@ -155,26 +172,6 @@ onMounted(() => {
               <strong>FPT Smart Cloud</strong> — New providers.
               OpenAI-compatible chat + embeddings. FPT supports Global and
               Japan regions.</span
-            >
-          </a>
-          <a
-            href="https://github.com/zendev-sh/goai/releases"
-            class="rh-release"
-          >
-            <span class="rh-release-tag">v0.6.0</span>
-            <span class="rh-release-text"
-              ><strong>OpenTelemetry integration</strong> — Tracing, metrics,
-              GenAI semantic conventions.</span
-            >
-          </a>
-          <a
-            href="https://github.com/zendev-sh/goai/releases"
-            class="rh-release"
-          >
-            <span class="rh-release-tag">v0.5.8</span>
-            <span class="rh-release-text"
-              ><strong>RunPod provider</strong> — Serverless vLLM support.
-              Bedrock embeddings. Docs accuracy improvements.</span
             >
           </a>
         </div>

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -561,6 +561,7 @@ type Part struct {
     Detail          string          // Image detail level ("low", "high", "auto").
     MediaType       string          // Content type (for PartImage, PartFile).
     Filename        string          // For PartFile.
+    RemoteRef       *RemoteFileRef  // Reference to an uploaded remote file (for PartFile, PartImage).
     ProviderOptions map[string]any  // Provider-specific part parameters.
 }
 ```
@@ -691,6 +692,7 @@ type ModelCapabilities struct {
     Reasoning        bool        // Supports extended thinking/reasoning.
     Attachment       bool        // Supports file attachments.
     ToolCall         bool        // Supports tool/function calling.
+    FileUpload       bool        // Supports remote file upload.
     InputModalities  ModalitySet // Supported input types.
     OutputModalities ModalitySet // Supported output types.
 }
@@ -869,4 +871,62 @@ Utility for provider implementors. Sends a chunk to a stream channel, returning 
 
 ```go
 func TrySend(ctx context.Context, out chan<- StreamChunk, chunk StreamChunk) bool
+```
+
+### FileUpload
+
+Describes a file to upload to a provider's remote storage.
+
+```go
+type FileUpload struct {
+    Reader    io.Reader // File content to upload.
+    Filename  string    // Name of the file.
+    MediaType string    // MIME type (e.g. "application/pdf").
+    Purpose   string    // Intended use (e.g. "assistants", "vision").
+}
+```
+
+### RemoteFileRef
+
+A reference to an uploaded remote file. Carries raw bytes for fallback on providers without native file APIs.
+
+```go
+type RemoteFileRef struct {
+    Provider  string    // Provider that owns this file.
+    ID        string    // Provider-specific file identifier.
+    URI       string    // Provider-specific file URI (e.g. for Gemini).
+    Filename  string    // Original file name.
+    MediaType string    // MIME type.
+    ExpiresAt time.Time // When the remote file expires (zero if unknown).
+    Data      []byte    // Raw file bytes for compat fallback.
+}
+```
+
+### FileUploader
+
+Interface for uploading and deleting remote files. Providers that support file upload implement `FileUploadCapableModel`.
+
+```go
+type FileUploader interface {
+    UploadFile(ctx context.Context, upload *FileUpload) (*RemoteFileRef, error)
+    DeleteFile(ctx context.Context, ref *RemoteFileRef) error
+}
+```
+
+### FileUploadCapableModel
+
+Optional interface that `LanguageModel` implementations can satisfy to indicate they support remote file upload. Use `FileUploader()` to get the uploader.
+
+```go
+type FileUploadCapableModel interface {
+    FileUploader() FileUploader
+}
+```
+
+### ErrFileUploadUnsupported
+
+Sentinel error returned by providers that do not support remote file upload. Callers can check for this error to fall back to inline data URIs.
+
+```go
+var ErrFileUploadUnsupported = errors.New("provider: file upload not supported by this provider")
 ```

--- a/docs/concepts/providers-and-models.md
+++ b/docs/concepts/providers-and-models.md
@@ -92,6 +92,7 @@ The `ModelCapabilities` struct includes:
 | `Reasoning`        | `bool`        | Extended thinking / chain-of-thought      |
 | `Attachment`       | `bool`        | File attachment support                   |
 | `ToolCall`         | `bool`        | Tool / function calling                   |
+| `FileUpload`       | `bool`        | Remote file upload support                |
 | `InputModalities`  | `ModalitySet` | Supported input types (text, image, etc.) |
 | `OutputModalities` | `ModalitySet` | Supported output types                    |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,13 +9,13 @@ description: "Open-source Go SDK for AI applications. One unified API for OpenAI
 
 ## What's New
 
-> **v0.7.2** — New provider: [NVIDIA NIM](/providers/nvidia) (OpenAI-compatible, chat + embeddings). E2E tested with `meta/llama-3.3-70b-instruct`. [Changelog →](https://github.com/zendev-sh/goai/releases)
+> **v0.9.0** — Provider-neutral file upload and remote file references. `FileUploader` interface + `RemoteFileRef` for OpenAI, Anthropic, and Google Gemini. Compat providers fall back to inline base64. [Changelog →](https://github.com/zendev-sh/goai/releases)
 >
-> **v0.7.0** — New providers: [Cloudflare Workers AI](/providers/cloudflare) and [FPT Smart Cloud](/providers/fptcloud) (both OpenAI-compatible, chat + embeddings). [Changelog →](https://github.com/zendev-sh/goai/releases)
+> **v0.8.5** — New provider: [Requesty](/providers/requesty) (OpenAI-compatible LLM gateway). Anthropic native structured output, per-step `Reasoning`, Gemini schema sanitization. [Changelog →](https://github.com/zendev-sh/goai/releases)
 >
-> **v0.6.0** — OpenTelemetry tracing + metrics, context propagation via RequestInfo.Ctx, Langfuse data race fix. [Changelog →](https://github.com/zendev-sh/goai/releases)
+> **v0.8.0** — MCP OAuth 2.1 + PKCE, `NewTool[In]` typed constructor, lifecycle hook panics surfaced as `*PanicError`. [Changelog →](https://github.com/zendev-sh/goai/releases)
 >
-> **v0.5.8** — RunPod provider (serverless vLLM), Bedrock embeddings, and docs accuracy improvements. [Changelog →](https://github.com/zendev-sh/goai/releases)
+> **v0.7.0** — New providers: [Cloudflare Workers AI](/providers/cloudflare) and [FPT Smart Cloud](/providers/fptcloud). [Changelog →](https://github.com/zendev-sh/goai/releases)
 
 ## What is GoAI SDK?
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -279,3 +279,4 @@ result, err := goai.GenerateText(ctx, model,
 - **Default max tokens**: 16384 when not explicitly set via `goai.WithMaxOutputTokens()`.
 - **Auth header**: Uses `x-api-key` (not `Authorization: Bearer`), matching Anthropic's API convention.
 - **Input modalities**: Supports text, images (base64), and PDF documents (base64).
+- **File upload**: Anthropic supports remote file upload via the Files API. Use `model.FileUploader()` to get a `provider.FileUploader` for uploading and deleting files. Uploaded files are referenced via `Part.RemoteRef` in messages. Compat providers fall back to inline base64 automatically.

--- a/docs/providers/compat.md
+++ b/docs/providers/compat.md
@@ -92,3 +92,4 @@ model := compat.Chat("my-model",
 - When no API key or token source is configured, the Authorization header is omitted entirely. This is useful for local servers that do not require authentication.
 - Max embedding batch size: 2048 values per call.
 - The `compat` provider is used internally by the `ollama` and `vllm` providers.
+- **File upload**: The `compat` provider does not support native file upload. When a `Part.RemoteRef` is provided, it falls back to inline base64 encoding using the file data stored in `RemoteFileRef.Data`. This ensures the same code path works across all providers.

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -272,3 +272,4 @@ No configuration options. The model generates Python code, executes it server-si
 - **Role mapping**: `assistant` is mapped to `model`, and `tool` is mapped to `user` for function responses.
 - **Embedding batch limit**: 100 values per call via `batchEmbedContents`. `goai.EmbedMany` auto-chunks larger batches.
 - **Difference from Vertex**: This provider uses Google AI (`generativelanguage.googleapis.com`) with API key auth. The Vertex provider uses Vertex AI endpoints with OAuth/ADC auth and supports additional features like enterprise web search and RAG stores.
+- **File upload**: Google Gemini supports remote file upload via the Files API. Use `model.FileUploader()` to get a `provider.FileUploader` for uploading and deleting files. Uploaded files are referenced via `Part.RemoteRef` in messages. Compat providers fall back to inline base64 automatically.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -316,3 +316,4 @@ This pattern supports Copilot (URL rewrite + OAuth token swap) and Codex (URL re
 - Image models `gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5` default to `b64_json` response format and reject an explicit `response_format` parameter. For older models like `dall-e-3`, the provider automatically sets `response_format` to `b64_json`.
 - Structured output uses `response_format` with `json_schema` for both APIs. The Responses API places it under `text.format`.
 - Per-request headers can be injected via `goai.WithHeaders(map[string]string{...})` for features like Codex session tracking.
+- **File upload**: OpenAI supports remote file upload via the Files API. Use `model.FileUploader()` to get a `provider.FileUploader` for uploading and deleting files. Uploaded files are referenced via `Part.RemoteRef` in messages. Compat providers fall back to inline base64 automatically.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -1,8 +1,8 @@
 # GoAI SDK
 
-> Go SDK for building AI applications. One unified API across 22+ LLM providers.
+> Go SDK for building AI applications. One unified API across 25+ LLM providers.
 
-GoAI SDK is an open-source Go library inspired by the Vercel AI SDK, designed idiomatically for Go with generics, interfaces, and channels. It provides a single API surface for text generation, streaming, structured output, embeddings, image generation, and tool calling across 22+ providers.
+GoAI SDK is an open-source Go library inspired by the Vercel AI SDK, designed idiomatically for Go with generics, interfaces, and channels. It provides a single API surface for text generation, streaming, structured output, embeddings, image generation, and tool calling across 25+ providers.
 
 - Website: https://goai.sh
 - GitHub: https://github.com/zendev-sh/goai

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,8 +1,8 @@
 # GoAI SDK
 
-> Go SDK for building AI applications. One unified API across 22+ LLM providers.
+> Go SDK for building AI applications. One unified API across 25+ LLM providers.
 
-GoAI SDK is an open-source Go library inspired by the Vercel AI SDK, designed idiomatically for Go with generics, interfaces, and channels. It provides a single API surface for text generation, streaming, structured output, embeddings, image generation, and tool calling across 22+ providers including OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, and more.
+GoAI SDK is an open-source Go library inspired by the Vercel AI SDK, designed idiomatically for Go with generics, interfaces, and channels. It provides a single API surface for text generation, streaming, structured output, embeddings, image generation, and tool calling across 25+ providers including OpenAI, Anthropic, Google Gemini, AWS Bedrock, Azure, and more.
 
 - Website: https://goai.sh
 - GitHub: https://github.com/zendev-sh/goai


### PR DESCRIPTION
## Summary

Docs drift audit (full) — 14 fixes across 13 files.

### What's fixed
- **What's New** — README, docs/index, homepage (HomeRaw.vue), ROADMAP: added v0.9.0 file upload entry
- **API types** — added FileUpload to ModelCapabilities, RemoteRef to Part, and 5 new type entries
- **Provider docs** — added file upload notes to OpenAI, Anthropic, Google, Compat
- **Capabilities table** — added FileUpload row in providers-and-models.md
- **LLM context** — fixed 22+ to 25+ providers in llms.txt and llms-full.txt
- **.gitignore** — added .vibeflow, *.out, docs/drift-report