### PR TITLE
fix(openaicompat): emit reasoning before text within a combined delta

### DIFF
--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -436,14 +436,9 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 		choice := resp.Choices[0]
 		delta := choice.Delta
 
-		// Text content -- handle both string and array [{type:"text",text:"..."}] formats.
-		if text := extractTextContent(delta.Content); text != "" {
-			if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkText, Text: text}) {
-				return
-			}
-		}
-
-		// Reasoning content -- prefer reasoning_content (DeepSeek native),
+		// Reasoning content -- emitted before text: a delta can carry both
+		// fields at the reasoning→answer transition, and reasoning always
+		// precedes the answer. Prefer reasoning_content (DeepSeek native),
 		// fall back to reasoning (OpenRouter).
 		if delta.ReasoningContent != "" {
 			if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkReasoning, Text: delta.ReasoningContent}) {
@@ -451,6 +446,13 @@ func ParseStream(ctx context.Context, scanner *sse.Scanner, out chan<- provider.
 			}
 		} else if delta.Reasoning != "" {
 			if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkReasoning, Text: delta.Reasoning}) {
+				return
+			}
+		}
+
+		// Text content -- handle both string and array [{type:"text",text:"..."}] formats.
+		if text := extractTextContent(delta.Content); text != "" {
+			if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkText, Text: text}) {
 				return
 			}
 		}

--- a/internal/openaicompat/reasoning_order_test.go
+++ b/internal/openaicompat/reasoning_order_test.go
@@ -1,0 +1,46 @@
+package openaicompat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zendev-sh/goai/internal/sse"
+	"github.com/zendev-sh/goai/provider"
+)
+
+// A single SSE delta can carry both reasoning_content and content at the
+// reasoning→answer transition (seen with GLM via NVIDIA NIM). Within one
+// delta, reasoning always precedes the answer, so the reasoning chunk must
+// be emitted before the text chunk.
+func TestParseStream_ReasoningBeforeTextInCombinedDelta(t *testing.T) {
+	input := `data: {"choices":[{"delta":{"reasoning_content":"existing aesthetic"},"index":0}]}
+data: {"choices":[{"delta":{"reasoning_content":".","content":"V"},"index":0}]}
+data: {"choices":[{"delta":{"content":"oy a explorar"},"index":0}]}
+data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}]}
+data: [DONE]
+`
+	scanner := sse.NewScanner(strings.NewReader(input))
+	out := make(chan provider.StreamChunk, 10)
+
+	go ParseStream(t.Context(), scanner, out)
+
+	var order []string
+	for chunk := range out {
+		switch chunk.Type {
+		case provider.ChunkText:
+			order = append(order, "text:"+chunk.Text)
+		case provider.ChunkReasoning:
+			order = append(order, "reasoning:"+chunk.Text)
+		}
+	}
+
+	want := []string{"reasoning:existing aesthetic", "reasoning:.", "text:V", "text:oy a explorar"}
+	if len(order) != len(want) {
+		t.Fatalf("got %d text/reasoning chunks %v, want %d", len(order), order, len(want))
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Errorf("chunk[%d] = %q, want %q (full order: %v)", i, order[i], want[i], order)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A single SSE delta can carry **both** a reasoning field and a content field at the reasoning-to-answer transition. `ParseStream` processed `content` first, which inverts the logical order — reasoning always precedes the answer it produces.

The visible symptom is a corrupted chunk order that splits the answer around a stray trailing reasoning chunk. Observed with GLM via NVIDIA NIM, but the shape is provider-agnostic — any OpenAI-compatible backend that flushes the tail of its reasoning together with the head of the answer hits it.

Given a delta carrying both fields, consumers rendering the live stream saw:

```
reasoning:"existing aesthetic"  text:"V"  reasoning:"."  text:"oy a explorar"
```

instead of:

```
reasoning:"existing aesthetic"  reasoning:"."  text:"V"  text:"oy a explorar"
```

Note how the answer `"Voy a explorar"` is broken in two by a reasoning chunk that logically belonged to the previous phase.

## Fix

Move the reasoning block — including the OpenRouter `reasoning` fallback added in #111 — above the text block, so both fields of a combined delta are emitted in their logical order.

The change is ordering-only:

- Deltas carrying just one of the two fields (the common case) are unaffected.
- The `reasoning_content` → `reasoning` precedence from #111 is preserved verbatim.
- No wire format, struct, or public API change.

## Test

Adds `TestParseStream_ReasoningBeforeTextInCombinedDelta`, which feeds a delta carrying both fields and asserts the emitted chunk order. It **fails on the previous ordering** and passes with this change:

```
--- FAIL: TestParseStream_ReasoningBeforeTextInCombinedDelta
    reasoning_order_test.go:43: chunk[1] = "text:V", want "reasoning:."
    reasoning_order_test.go:43: chunk[2] = "reasoning:.", want "text:V"
```

**Patch coverage: 100%** (7/7 added statement lines). Project coverage unchanged vs. base at 97.9%.

`go build ./...` and `go test ./...` pass (34 packages, 0 failures).
