### PR TITLE
feat(anthropic): configurable ephemeral cache TTL (5m/1h)

### DIFF
--- a/caching.go
+++ b/caching.go
@@ -11,7 +11,8 @@ const cacheControlEphemeral = "ephemeral"
 // applyCaching applies cache control markers to system messages only.
 // Per arxiv 2601.06007v2: caching system prompts (not conversation messages or
 // tool results) saves 41-80% cost and 13-31% latency for agentic workloads.
-func applyCaching(msgs []provider.Message) []provider.Message {
+// ttl ("5m"/"1h") is attached to each marker; empty preserves the provider default.
+func applyCaching(msgs []provider.Message, ttl string) []provider.Message {
 	result := slices.Clone(msgs)
 	for i := range result {
 		if result[i].Role != provider.RoleSystem {
@@ -24,6 +25,7 @@ func applyCaching(msgs []provider.Message) []provider.Message {
 		content := slices.Clone(result[i].Content)
 		lastIdx := len(content) - 1
 		content[lastIdx].CacheControl = cacheControlEphemeral
+		content[lastIdx].CacheControlTTL = ttl
 		result[i].Content = content
 	}
 	return result

--- a/caching_test.go
+++ b/caching_test.go
@@ -21,7 +21,7 @@ func TestApplyCaching_SystemMessages(t *testing.T) {
 		},
 	}
 
-	result := applyCaching(msgs)
+	result := applyCaching(msgs, "")
 
 	// First system part should not be marked.
 	if result[0].Content[0].CacheControl != "" {
@@ -45,7 +45,7 @@ func TestApplyCaching_NoSystemMessages(t *testing.T) {
 		},
 	}
 
-	result := applyCaching(msgs)
+	result := applyCaching(msgs, "")
 
 	if result[0].Content[0].CacheControl != "" {
 		t.Errorf("CacheControl = %q, want empty", result[0].Content[0].CacheControl)
@@ -58,7 +58,7 @@ func TestApplyCaching_EmptyContent(t *testing.T) {
 	}
 
 	// Should not panic.
-	result := applyCaching(msgs)
+	result := applyCaching(msgs, "")
 	if len(result[0].Content) != 0 {
 		t.Error("expected empty content")
 	}
@@ -76,12 +76,42 @@ func TestApplyCaching_MultipleSystemMessages(t *testing.T) {
 		},
 	}
 
-	result := applyCaching(msgs)
+	result := applyCaching(msgs, "")
 
 	if result[0].Content[0].CacheControl != cacheControlEphemeral {
 		t.Errorf("first system CacheControl = %q", result[0].Content[0].CacheControl)
 	}
 	if result[1].Content[0].CacheControl != cacheControlEphemeral {
 		t.Errorf("second system CacheControl = %q", result[1].Content[0].CacheControl)
+	}
+}
+
+func TestApplyCaching_TTLPropagatedToMarker(t *testing.T) {
+	msgs := []provider.Message{
+		{
+			Role: provider.RoleSystem,
+			Content: []provider.Part{
+				{Type: provider.PartText, Text: "You are helpful."},
+				{Type: provider.PartText, Text: "Be concise."},
+			},
+		},
+	}
+
+	result := applyCaching(msgs, "1h")
+
+	last := result[0].Content[1]
+	if last.CacheControl != cacheControlEphemeral {
+		t.Errorf("CacheControl = %q, want %q", last.CacheControl, cacheControlEphemeral)
+	}
+	if last.CacheControlTTL != "1h" {
+		t.Errorf("CacheControlTTL = %q, want 1h", last.CacheControlTTL)
+	}
+	// Unmarked parts stay untouched.
+	if result[0].Content[0].CacheControlTTL != "" {
+		t.Errorf("non-breakpoint part gained a TTL: %q", result[0].Content[0].CacheControlTTL)
+	}
+	// The caller's slice must not be mutated.
+	if msgs[0].Content[1].CacheControlTTL != "" {
+		t.Error("applyCaching mutated the caller's messages")
 	}
 }

--- a/generate.go
+++ b/generate.go
@@ -620,7 +620,7 @@ func buildParams(opts options) provider.GenerateParams {
 	}
 
 	if opts.PromptCaching {
-		msgs = applyCaching(msgs)
+		msgs = applyCaching(msgs, opts.CacheTTL)
 	}
 
 	return provider.GenerateParams{
@@ -638,6 +638,7 @@ func buildParams(opts options) provider.GenerateParams {
 		Headers:          maps.Clone(opts.Headers),
 		ProviderOptions:  maps.Clone(opts.ProviderOptions),
 		PromptCaching:    opts.PromptCaching,
+		CacheTTL:         opts.CacheTTL,
 		ToolChoice:       opts.ToolChoice,
 	}
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -6343,3 +6343,41 @@ func TestBuildToolMap_DuplicateAcrossExecutable(t *testing.T) {
 		t.Errorf("error = %q, want it to contain %q", err.Error(), "duplicate tool name")
 	}
 }
+
+// WithCacheTTL must reach GenerateParams and every ephemeral breakpoint the
+// request emits, and must stay inert when prompt caching is off.
+func TestBuildParams_CacheTTL(t *testing.T) {
+	opts := applyOptions(
+		WithMessages(SystemMessage("You are helpful."), UserMessage("hi")),
+		WithPromptCaching(true),
+		WithCacheTTL("1h"),
+	)
+	params := buildParams(opts)
+
+	if params.CacheTTL != "1h" {
+		t.Errorf("CacheTTL = %q, want 1h", params.CacheTTL)
+	}
+
+	var marked int
+	for _, msg := range params.Messages {
+		for _, part := range msg.Content {
+			if part.CacheControl == "" {
+				continue
+			}
+			marked++
+			if part.CacheControlTTL != "1h" {
+				t.Errorf("breakpoint TTL = %q, want 1h", part.CacheControlTTL)
+			}
+		}
+	}
+	if marked == 0 {
+		t.Fatal("no cache breakpoint was marked")
+	}
+}
+
+func TestBuildParams_CacheTTLDefaultsEmpty(t *testing.T) {
+	params := buildParams(applyOptions(WithPrompt("hi"), WithPromptCaching(true)))
+	if params.CacheTTL != "" {
+		t.Errorf("CacheTTL = %q, want empty (provider default)", params.CacheTTL)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -84,6 +84,9 @@ type options struct {
 	// PromptCaching enables provider-specific prompt caching.
 	PromptCaching bool
 
+	// CacheTTL sets the ephemeral cache lifetime ("5m" or "1h"); empty = default 5m.
+	CacheTTL string
+
 	// ToolChoice controls tool selection: "auto", "none", "required", or a specific tool name.
 	ToolChoice string
 
@@ -284,6 +287,13 @@ func WithProviderOptions(opts map[string]any) Option {
 // this option is set.
 func WithPromptCaching(b bool) Option {
 	return func(o *options) { o.PromptCaching = b }
+}
+
+// WithCacheTTL sets the ephemeral prompt-cache lifetime for Anthropic: "5m" or
+// "1h". Empty preserves the provider default (5m). Only Anthropic-family models
+// honor it; other providers ignore it. The 1h TTL needs no beta header (GA).
+func WithCacheTTL(ttl string) Option {
+	return func(o *options) { o.CacheTTL = ttl }
 }
 
 // Tool choice constants for use with WithToolChoice.

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -331,7 +331,7 @@ func (m *chatModel) buildRequest(params provider.GenerateParams, streaming bool)
 	if params.System != "" {
 		systemPart := map[string]any{"type": "text", "text": params.System}
 		if params.PromptCaching {
-			systemPart["cache_control"] = map[string]any{"type": "ephemeral"}
+			systemPart["cache_control"] = ephemeralCacheControl(params.CacheTTL)
 		}
 		body["system"] = []map[string]any{systemPart}
 	}
@@ -594,7 +594,7 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 					continue
 				}
 				p := map[string]any{"type": "text", "text": part.Text}
-				applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+				applyCacheControl(p, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 				content = append(content, p)
 
 			case provider.PartReasoning:
@@ -609,7 +609,7 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 						continue
 					}
 					p := map[string]any{"type": "thinking", "thinking": part.Text, "signature": sig}
-					applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+					applyCacheControl(p, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 					content = append(content, p)
 				} else if part.ProviderOptions != nil {
 					// Redacted thinking (no text, just encrypted data).
@@ -635,7 +635,7 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 						"data":       data,
 					},
 				}
-				applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+				applyCacheControl(p, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 				content = append(content, p)
 
 			case provider.PartFile:
@@ -647,7 +647,7 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 							"file_id": part.RemoteRef.ID,
 						},
 					}
-					applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+					applyCacheControl(p, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 					content = append(content, p)
 				} else if part.URL != "" {
 					mediaType, data, ok := httpc.ParseDataURL(part.URL)
@@ -662,7 +662,7 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 							"data":       data,
 						},
 					}
-					applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+					applyCacheControl(p, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 					content = append(content, p)
 				}
 
@@ -692,11 +692,11 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 					"input": input,
 				}
 				if resultBlock == nil {
-					applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+					applyCacheControl(p, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 				}
 				content = append(content, p)
 				if resultBlock != nil {
-					applyCacheControl(resultBlock, part.CacheControl, msgCacheControl, isLast)
+					applyCacheControl(resultBlock, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 					content = append(content, resultBlock)
 				}
 
@@ -706,7 +706,7 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 					"tool_use_id": part.ToolCallID,
 					"content":     part.ToolOutput,
 				}
-				applyCacheControl(p, part.CacheControl, msgCacheControl, isLast)
+				applyCacheControl(p, part.CacheControl, part.CacheControlTTL, msgCacheControl, isLast)
 				content = append(content, p)
 			}
 		}
@@ -733,11 +733,27 @@ func convertMessages(msgs []provider.Message) []map[string]any {
 	return result
 }
 
+// ephemeralCacheControl builds an ephemeral cache_control marker, attaching the
+// TTL ("5m"/"1h") when non-empty. Empty TTL preserves the Anthropic default (5m).
+// The 1h TTL needs no beta header (GA).
+func ephemeralCacheControl(ttl string) map[string]any {
+	cc := map[string]any{"type": "ephemeral"}
+	if ttl != "" {
+		cc["ttl"] = ttl
+	}
+	return cc
+}
+
 // applyCacheControl adds cache_control to a content part.
 // Part-level CacheControl takes precedence; message-level only applies to the last part.
-func applyCacheControl(p map[string]any, partCC string, msgCC map[string]any, isLast bool) {
+// partTTL ("5m"/"1h") is attached to the part-level marker; empty = provider default (5m).
+func applyCacheControl(p map[string]any, partCC, partTTL string, msgCC map[string]any, isLast bool) {
 	if partCC != "" {
-		p["cache_control"] = map[string]any{"type": partCC}
+		cc := map[string]any{"type": partCC}
+		if partTTL != "" {
+			cc["ttl"] = partTTL
+		}
+		p["cache_control"] = cc
 	} else if msgCC != nil && isLast {
 		p["cache_control"] = msgCC
 	}

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -563,6 +563,115 @@ func TestBuildRequest_SystemCacheControl(t *testing.T) {
 	if cc["type"] != "ephemeral" {
 		t.Errorf("cache_control = %v, want ephemeral", cc)
 	}
+	if _, hasTTL := cc["ttl"]; hasTTL {
+		t.Errorf("cache_control should omit ttl by default, got %v", cc)
+	}
+}
+
+func TestBuildRequest_SystemCacheControlTTL(t *testing.T) {
+	m := &chatModel{id: "claude-sonnet-4-20250514", opts: options{baseURL: defaultBaseURL}}
+	body := m.buildRequest(provider.GenerateParams{
+		System: "You are helpful.",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+		PromptCaching: true,
+		CacheTTL:      "1h",
+	}, true)
+
+	system := body["system"].([]map[string]any)
+	cc, _ := system[0]["cache_control"].(map[string]any)
+	if cc["type"] != "ephemeral" {
+		t.Errorf("cache_control.type = %v, want ephemeral", cc["type"])
+	}
+	if cc["ttl"] != "1h" {
+		t.Errorf("cache_control.ttl = %v, want 1h", cc["ttl"])
+	}
+}
+
+// CacheTTL must not leak into the request when caching is off.
+func TestBuildRequest_CacheTTLWithoutPromptCaching(t *testing.T) {
+	m := &chatModel{id: "claude-sonnet-4-20250514", opts: options{baseURL: defaultBaseURL}}
+	body := m.buildRequest(provider.GenerateParams{
+		System: "You are helpful.",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+		CacheTTL: "1h",
+	}, true)
+
+	system := body["system"].([]map[string]any)
+	if _, has := system[0]["cache_control"]; has {
+		t.Errorf("cache_control set without PromptCaching: %v", system[0])
+	}
+}
+
+func TestConvertMessages_PartLevelCacheTTL(t *testing.T) {
+	msgs := convertMessages([]provider.Message{
+		{
+			Role:    provider.RoleUser,
+			Content: []provider.Part{{Type: provider.PartText, Text: "hi", CacheControl: "ephemeral", CacheControlTTL: "1h"}},
+		},
+	})
+
+	content := msgs[0]["content"].([]map[string]any)
+	cc := content[0]["cache_control"].(map[string]any)
+	if cc["type"] != "ephemeral" {
+		t.Errorf("cache_control.type = %v, want ephemeral", cc["type"])
+	}
+	if cc["ttl"] != "1h" {
+		t.Errorf("cache_control.ttl = %v, want 1h", cc["ttl"])
+	}
+
+	// Empty TTL must omit the ttl key (default 5m behavior preserved).
+	msgs = convertMessages([]provider.Message{
+		{
+			Role:    provider.RoleUser,
+			Content: []provider.Part{{Type: provider.PartText, Text: "hi", CacheControl: "ephemeral"}},
+		},
+	})
+	cc = msgs[0]["content"].([]map[string]any)[0]["cache_control"].(map[string]any)
+	if _, hasTTL := cc["ttl"]; hasTTL {
+		t.Errorf("empty TTL should omit ttl key, got %v", cc)
+	}
+}
+
+// A message-level breakpoint carries its own marker, so a part-level TTL on a
+// part that has no part-level CacheControl must not alter it.
+func TestConvertMessages_MessageLevelCacheControlIgnoresPartTTL(t *testing.T) {
+	msgs := convertMessages([]provider.Message{
+		{
+			Role: provider.RoleUser,
+			Content: []provider.Part{
+				{Type: provider.PartText, Text: "hi", CacheControlTTL: "1h"},
+			},
+			ProviderOptions: map[string]any{
+				"anthropic": map[string]any{
+					"cacheControl": map[string]any{"type": "ephemeral"},
+				},
+			},
+		},
+	})
+
+	cc := msgs[0]["content"].([]map[string]any)[0]["cache_control"].(map[string]any)
+	if cc["type"] != "ephemeral" {
+		t.Errorf("cache_control.type = %v, want ephemeral", cc["type"])
+	}
+	if _, hasTTL := cc["ttl"]; hasTTL {
+		t.Errorf("message-level marker must not gain a part TTL, got %v", cc)
+	}
+}
+
+func TestEphemeralCacheControl(t *testing.T) {
+	if cc := ephemeralCacheControl(""); cc["type"] != "ephemeral" || len(cc) != 1 {
+		t.Errorf("ephemeralCacheControl(\"\") = %v, want {type:ephemeral} only", cc)
+	}
+	for _, ttl := range []string{"5m", "1h"} {
+		cc := ephemeralCacheControl(ttl)
+		if cc["type"] != "ephemeral" || cc["ttl"] != ttl {
+			t.Errorf("ephemeralCacheControl(%q) = %v", ttl, cc)
+		}
+	}
 }
 
 func TestBuildRequest_Tools(t *testing.T) {
@@ -3629,5 +3738,51 @@ func TestConvertMessages_ServerToolResultBlock(t *testing.T) {
 				t.Errorf("orphan tool_result injected for server tool srvtoolu_abc in msg[%d]: %+v", i, p)
 			}
 		}
+	}
+}
+
+// End-to-end: the configured TTL must reach the wire on both the system block
+// and the message breakpoint, and the 1h TTL must not require a beta header.
+func TestDoGenerate_CacheTTLOnWire(t *testing.T) {
+	var req map[string]any
+	var betaHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		betaHeader = r.Header.Get("anthropic-beta")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg_1","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("claude-sonnet-4-20250514", WithAPIKey("k"), WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		System: "You are helpful.",
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{
+				{Type: provider.PartText, Text: "hi", CacheControl: "ephemeral", CacheControlTTL: "1h"},
+			}},
+		},
+		PromptCaching: true,
+		CacheTTL:      "1h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	system := req["system"].([]any)[0].(map[string]any)
+	if cc := system["cache_control"].(map[string]any); cc["ttl"] != "1h" {
+		t.Errorf("system cache_control = %v, want ttl 1h", cc)
+	}
+
+	msg := req["messages"].([]any)[0].(map[string]any)
+	part := msg["content"].([]any)[0].(map[string]any)
+	if cc := part["cache_control"].(map[string]any); cc["ttl"] != "1h" {
+		t.Errorf("part cache_control = %v, want ttl 1h", cc)
+	}
+
+	// 1h is GA -- it must not add a beta opt-in.
+	if betaHeader != betaFeatures {
+		t.Errorf("anthropic-beta = %q, want %q (1h TTL is GA)", betaHeader, betaFeatures)
 	}
 }

--- a/provider/types.go
+++ b/provider/types.go
@@ -164,6 +164,11 @@ type GenerateParams struct {
 	// PromptCaching enables provider-specific prompt caching.
 	PromptCaching bool
 
+	// CacheTTL sets the ephemeral cache lifetime for Anthropic prompt caching:
+	// "5m" or "1h". Empty preserves the provider default (5m). Applies to every
+	// ephemeral cache_control marker the request emits (system and breakpoints).
+	CacheTTL string
+
 	// ToolChoice controls tool selection: "auto", "none", "required", or a specific tool name.
 	ToolChoice string
 
@@ -403,6 +408,10 @@ type Part struct {
 
 	// CacheControl directive (e.g. "ephemeral") for prompt caching.
 	CacheControl string
+
+	// CacheControlTTL is the ephemeral cache lifetime ("5m"/"1h") attached to
+	// CacheControl. Empty preserves the provider default (5m). Anthropic only.
+	CacheControlTTL string
 
 	// Detail level for image parts ("low", "high", "auto").
 	Detail string


### PR DESCRIPTION
## Motivation

Anthropic's prompt caching accepts a `ttl` on the ephemeral `cache_control` marker, selecting a **5-minute** or **1-hour** cache lifetime. The SDK always emitted the bare marker:

```json
{"type": "ephemeral"}
```

so callers were pinned to the 5m default with no way to opt into 1h — the better trade for long-lived system prompts and agentic loops whose turns outlive a 5-minute window.

## API

```go
result, err := goai.GenerateText(ctx, model,
    goai.WithSystem(bigSystemPrompt),
    goai.WithPromptCaching(true),
    goai.WithCacheTTL("1h"),   // "5m" | "1h"; empty = provider default (5m)
)
```

Surfaced on the provider layer as:

- `GenerateParams.CacheTTL` — request-wide, applied to every ephemeral marker the request emits.
- `Part.CacheControlTTL` — per-breakpoint, for callers building parts directly.

Both the system block and message breakpoints honour it, including the file/document parts added in #115 — uploaded documents inherit the configured TTL rather than silently falling back to 5m.

## Backward compatibility

Additive and non-breaking. An empty TTL emits **exactly** the previous payload — `{"type":"ephemeral"}` with no `ttl` key — so existing behaviour is preserved byte-for-byte. `TestBuildRequest_SystemCacheControl` asserts the key is absent by default.

Two internal signatures gain a parameter (`applyCacheControl`, `applyCaching`); both are unexported.

The 1h TTL is GA and requires no beta opt-in — the wire test asserts the `anthropic-beta` header is unchanged.

## Tests

| Test | Covers |
|---|---|
| `TestBuildRequest_SystemCacheControlTTL` | TTL on the system block |
| `TestBuildRequest_SystemCacheControl` | default omits `ttl` (no behaviour change) |
| `TestBuildRequest_CacheTTLWithoutPromptCaching` | TTL inert when caching is off |
| `TestConvertMessages_PartLevelCacheTTL` | per-part breakpoint, set and empty |
| `TestConvertMessages_MessageLevelCacheControlIgnoresPartTTL` | message-level marker must not absorb a part TTL |
| `TestEphemeralCacheControl` | helper, both branches |
| `TestApplyCaching_TTLPropagatedToMarker` | propagation + no caller mutation |
| `TestBuildParams_CacheTTL` / `...DefaultsEmpty` | option → params plumbing |
| `TestDoGenerate_CacheTTLOnWire` | end-to-end mock server: TTL on wire, beta header unchanged |

**Patch coverage: 100%** (27/27 added statement lines). Package coverage unchanged vs. base — root 97.6%, `provider/anthropic` 98.0%, project total 97.9%.

`go build ./...` and `go test ./...` pass (34 packages, 0 failures).
