### PR TITLE
fix(openaicompat): let the caller decide max_completion_tokens

### DIFF
--- a/internal/openaicompat/factory.go
+++ b/internal/openaicompat/factory.go
@@ -70,6 +70,12 @@ type ChatModelConfig struct {
 	// WarnPromptCaching emits a one-line stderr warning when the caller sets
 	// GenerateParams.PromptCaching and the provider does not support it.
 	WarnPromptCaching bool
+
+	// UsesCompletionTokens forces the max_tokens / max_completion_tokens choice
+	// instead of deriving it from ModelID. Nil keeps the ModelID heuristic.
+	// Azure OpenAI needs it: its wire model id is the user-chosen deployment
+	// name, which says nothing about the model behind it.
+	UsesCompletionTokens *bool
 }
 
 // NewChatModel returns a provider.LanguageModel backed by the shared
@@ -152,7 +158,8 @@ func (m *chatModel) DoGenerate(ctx context.Context, params provider.GeneratePara
 		return nil, err
 	}
 	body := BuildRequest(params, m.cfg.ModelID, false, RequestConfig{
-		ExtraBody: m.cfg.ExtraBody,
+		ExtraBody:            m.cfg.ExtraBody,
+		UsesCompletionTokens: m.cfg.UsesCompletionTokens,
 	})
 
 	resp, err := m.doHTTP(ctx, m.cfg.BaseURL+"/chat/completions", body)
@@ -176,6 +183,7 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	body := BuildRequest(params, m.cfg.ModelID, true, RequestConfig{
 		IncludeStreamOptions: m.cfg.IncludeStreamOptions,
 		ExtraBody:            m.cfg.ExtraBody,
+		UsesCompletionTokens: m.cfg.UsesCompletionTokens,
 	})
 
 	resp, err := m.doHTTP(ctx, m.cfg.BaseURL+"/chat/completions", body)

--- a/internal/openaicompat/openaicompat.go
+++ b/internal/openaicompat/openaicompat.go
@@ -52,6 +52,10 @@ type RequestConfig struct {
 
 	// ExtraBody contains provider-specific fields to merge into the request body.
 	ExtraBody map[string]any
+
+	// UsesCompletionTokens forces the max_tokens / max_completion_tokens choice
+	// instead of deriving it from modelID. Nil keeps the modelID heuristic.
+	UsesCompletionTokens *bool
 }
 
 // BuildRequest creates a standard OpenAI chat/completions request body.
@@ -212,7 +216,13 @@ func BuildRequest(params provider.GenerateParams, modelID string, streaming bool
 	// reasoning model rejects max_tokens outright (Azure gpt-5 returns
 	// `Unsupported parameter: 'max_tokens'`) whether or not the caller
 	// passed a reasoning_effort.
-	if IsReasoningModel(modelID) {
+	// The caller may know what the model id cannot tell (Azure: the id is the
+	// deployment name); nil falls back to the id heuristic.
+	usesCompletionTokens := IsReasoningModel(modelID)
+	if cfg.UsesCompletionTokens != nil {
+		usesCompletionTokens = *cfg.UsesCompletionTokens
+	}
+	if usesCompletionTokens {
 		if v, ok := body["max_tokens"]; ok {
 			body["max_completion_tokens"] = v
 			delete(body, "max_tokens")

--- a/internal/openaicompat/openaicompat_test.go
+++ b/internal/openaicompat/openaicompat_test.go
@@ -1379,6 +1379,45 @@ func TestBuildRequest_MaxCompletionTokens_NoReasoningEffort(t *testing.T) {
 	}
 }
 
+// TestBuildRequest_UsesCompletionTokensOverridesModelID: the model id does not
+// always identify the model. On Azure OpenAI the wire id is the deployment name
+// the user picked, so the id heuristic misfires in both directions and the
+// caller must be able to state the answer.
+func TestBuildRequest_UsesCompletionTokensOverridesModelID(t *testing.T) {
+	yes, no := true, false
+	cases := []struct {
+		name    string
+		modelID string
+		flag    *bool
+		want    string
+	}{
+		{"nil keeps the heuristic (reasoning id)", "gpt-5", nil, "max_completion_tokens"},
+		{"nil keeps the heuristic (plain id)", "my-deployment", nil, "max_tokens"},
+		{"true forces the rename on an opaque id", "my-deployment", &yes, "max_completion_tokens"},
+		{"false suppresses it on a reasoning-looking id", "gpt-5-alias", &no, "max_tokens"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := provider.GenerateParams{
+				Messages:        []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+				MaxOutputTokens: 1500,
+			}
+			body := BuildRequest(params, tc.modelID, false, RequestConfig{UsesCompletionTokens: tc.flag})
+
+			if body[tc.want] != 1500 {
+				t.Errorf("%s = %v, want 1500", tc.want, body[tc.want])
+			}
+			other := "max_tokens"
+			if tc.want == "max_tokens" {
+				other = "max_completion_tokens"
+			}
+			if _, ok := body[other]; ok {
+				t.Errorf("%s must not be sent alongside %s", other, tc.want)
+			}
+		})
+	}
+}
+
 // TestBuildRequest_MaxTokensKeptForNonReasoning: a non-reasoning model
 // keeps the plain max_tokens parameter.
 func TestBuildRequest_MaxTokensKeptForNonReasoning(t *testing.T) {

--- a/provider/compat/compat.go
+++ b/provider/compat/compat.go
@@ -20,11 +20,23 @@ import (
 type Option func(*options)
 
 type options struct {
-	providerID  string
-	tokenSource provider.TokenSource
-	baseURL     string
-	headers     map[string]string
-	httpClient  *http.Client
+	providerID           string
+	tokenSource          provider.TokenSource
+	baseURL              string
+	headers              map[string]string
+	httpClient           *http.Client
+	usesCompletionTokens *bool
+}
+
+// WithCompletionTokens forces the max_tokens / max_completion_tokens choice
+// instead of deriving it from the model id. Use it when the id does not
+// identify the model: on Azure OpenAI the wire id is the deployment name the
+// user picked, so a GPT-5 deployment called "prod" would be sent max_tokens
+// and rejected with "Unsupported parameter: 'max_tokens'".
+func WithCompletionTokens(uses bool) Option {
+	return func(o *options) {
+		o.usesCompletionTokens = &uses
+	}
 }
 
 // WithProviderID overrides the provider name used in error messages.
@@ -83,6 +95,7 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 		Capabilities:         chatCaps,
 		IncludeStreamOptions: true,
 		WarnPromptCaching:    true,
+		UsesCompletionTokens: o.usesCompletionTokens,
 	})
 }
 

--- a/provider/compat/compat_test.go
+++ b/provider/compat/compat_test.go
@@ -732,3 +732,48 @@ func TestChat_PromptCachingIgnored(t *testing.T) {
 		t.Errorf("DoStream texts = %v, want [ok]", texts)
 	}
 }
+
+// TestChat_WithCompletionTokens: the option decides the output-token key
+// instead of the model id. Azure OpenAI needs it -- its wire id is the
+// deployment name the user picked, which says nothing about the model.
+func TestChat_WithCompletionTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []Option
+		want    string
+		notWant string
+	}{
+		{"default keeps the model-id heuristic", nil, "max_tokens", "max_completion_tokens"},
+		{"forced on an opaque id", []Option{WithCompletionTokens(true)}, "max_completion_tokens", "max_tokens"},
+		{"suppressed", []Option{WithCompletionTokens(false)}, "max_tokens", "max_completion_tokens"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decoding request: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"id":"1","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+			}))
+			defer server.Close()
+
+			opts := append([]Option{WithBaseURL(server.URL)}, tt.opts...)
+			model := Chat("my-deployment", opts...)
+			if _, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+				Messages:        []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+				MaxOutputTokens: 1500,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			if body[tt.want] != float64(1500) {
+				t.Errorf("%s = %v, want 1500", tt.want, body[tt.want])
+			}
+			if _, ok := body[tt.notWant]; ok {
+				t.Errorf("%s must not be sent alongside %s", tt.notWant, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `max_tokens` → `max_completion_tokens` rename is keyed on the model id via `IsReasoningModel` (`internal/openaicompat/openaicompat.go`). That works when the id names the model, but Azure OpenAI puts the **user-chosen deployment name** in the wire id.

So a GPT-5 deployment called `prod-gpt5` fails the `gpt-5` prefix check, gets `max_tokens`, and Azure rejects the request with the exact error the existing comment warns about:

```
Unsupported parameter: 'max_tokens'
```

The reverse also happens: a non-reasoning deployment named after a reasoning model gets `max_completion_tokens` and is rejected too. Renaming the deployment is the only workaround today, and both keys are in `openAIProtectedKeys`, so provider-option passthrough cannot fix it either.

**Change:** add `ChatModelConfig.UsesCompletionTokens *bool` (and the matching `RequestConfig` field) so a provider that knows the answer can state it. `nil` keeps the model-id heuristic, so every existing provider behaves exactly as before. `compat` exposes it as `WithCompletionTokens`.

Table test covers the four cases: nil with a reasoning id, nil with an opaque id, forced true on an opaque id, forced false on a reasoning-looking id.