### PR TITLE
fix(google): count output tokens as candidatesTokenCount

### DIFF
--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -627,10 +627,10 @@ func parseSSE(ctx context.Context, body io.Reader, out chan<- provider.StreamChu
 				usage.InputTokens = 0
 			}
 			usage.ReasoningTokens = resp.UsageMetadata.ThoughtsTokenCount
-			usage.OutputTokens = resp.UsageMetadata.CandidatesTokenCount - resp.UsageMetadata.ThoughtsTokenCount
-			if usage.OutputTokens < 0 {
-				usage.OutputTokens = 0
-			}
+			// candidatesTokenCount is the visible output; thinking is reported
+			// separately in thoughtsTokenCount, so subtracting it zeroed the
+			// output whenever thoughts outgrew the answer.
+			usage.OutputTokens = resp.UsageMetadata.CandidatesTokenCount
 		}
 
 		if len(resp.Candidates) == 0 {
@@ -810,10 +810,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 			result.Usage.InputTokens = 0
 		}
 		result.Usage.ReasoningTokens = resp.UsageMetadata.ThoughtsTokenCount
-		result.Usage.OutputTokens = resp.UsageMetadata.CandidatesTokenCount - resp.UsageMetadata.ThoughtsTokenCount
-		if result.Usage.OutputTokens < 0 {
-			result.Usage.OutputTokens = 0
-		}
+		result.Usage.OutputTokens = resp.UsageMetadata.CandidatesTokenCount
 		result.Usage.TotalTokens = result.Usage.InputTokens + result.Usage.OutputTokens + result.Usage.ReasoningTokens
 	}
 

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -161,12 +161,12 @@ func TestChat_Stream_Reasoning(t *testing.T) {
 			gotText = true
 		}
 		if chunk.Type == provider.ChunkFinish {
-			// Thoughts should be separated from output.
+			// Thoughts are reported separately, so output keeps candidatesTokenCount.
 			if chunk.Usage.ReasoningTokens != 3 {
 				t.Errorf("ReasoningTokens = %d, want 3", chunk.Usage.ReasoningTokens)
 			}
-			if chunk.Usage.OutputTokens != 5 {
-				t.Errorf("OutputTokens = %d, want 5 (8-3)", chunk.Usage.OutputTokens)
+			if chunk.Usage.OutputTokens != 8 {
+				t.Errorf("OutputTokens = %d, want 8 (candidatesTokenCount)", chunk.Usage.OutputTokens)
 			}
 		}
 	}
@@ -1653,10 +1653,10 @@ func TestDoHTTP_ConnectionError(t *testing.T) {
 	}
 }
 
-func TestChat_Generate_NegativeOutputTokens(t *testing.T) {
+func TestChat_Generate_OutputExcludesThoughts(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		// ThoughtsTokenCount > CandidatesTokenCount would give negative output.
+		// thoughtsTokenCount outgrows candidatesTokenCount: subtracting zeroed the output.
 		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":3,"thoughtsTokenCount":5}}`)
 	}))
 	defer server.Close()
@@ -1670,8 +1670,11 @@ func TestChat_Generate_NegativeOutputTokens(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Usage.OutputTokens != 0 {
-		t.Errorf("OutputTokens = %d, want 0 (clamped)", result.Usage.OutputTokens)
+	if result.Usage.OutputTokens != 3 {
+		t.Errorf("OutputTokens = %d, want 3 (candidatesTokenCount)", result.Usage.OutputTokens)
+	}
+	if result.Usage.ReasoningTokens != 5 {
+		t.Errorf("ReasoningTokens = %d, want 5 (thoughtsTokenCount)", result.Usage.ReasoningTokens)
 	}
 }
 
@@ -1737,11 +1740,12 @@ func TestChat_Stream_NegativeTokens(t *testing.T) {
 
 	for chunk := range result.Stream {
 		if chunk.Type == provider.ChunkFinish {
+			// Input still clamps (prompt 5 - cache 10); output keeps candidatesTokenCount.
 			if chunk.Usage.InputTokens != 0 {
 				t.Errorf("InputTokens = %d, want 0", chunk.Usage.InputTokens)
 			}
-			if chunk.Usage.OutputTokens != 0 {
-				t.Errorf("OutputTokens = %d, want 0", chunk.Usage.OutputTokens)
+			if chunk.Usage.OutputTokens != 2 {
+				t.Errorf("OutputTokens = %d, want 2 (candidatesTokenCount)", chunk.Usage.OutputTokens)
 			}
 		}
 	}


### PR DESCRIPTION
Gemini reports thinking separately from the answer: `totalTokenCount` is `promptTokenCount + candidatesTokenCount + thoughtsTokenCount`, and `thoughtsTokenCount` is **not** part of `candidatesTokenCount`.

Both usage paths subtract it anyway:

```go
usage.OutputTokens = resp.UsageMetadata.CandidatesTokenCount - resp.UsageMetadata.ThoughtsTokenCount
if usage.OutputTokens < 0 {
    usage.OutputTokens = 0
}
```

So thinking tokens are counted twice — once as `ReasoningTokens`, once against the output — and on a reasoning-heavy turn, where thoughts routinely outgrow the answer, the subtraction goes negative and the clamp reports **zero output tokens** for a turn that produced text. Anything billing, budgeting or logging on `OutputTokens` sees nothing.

**Change:** map `OutputTokens` to `candidatesTokenCount` directly, in the streaming and non-streaming paths. `ReasoningTokens` already carries `thoughtsTokenCount`, so no information is lost — it just stops being subtracted from a field it was never part of.

The negative clamp goes away with it: `candidatesTokenCount` is never negative. The input clamp is untouched, since `promptTokenCount - cachedContentTokenCount` can legitimately go negative.

**Tests:** the three existing cases that encoded the subtraction now assert the reported counts — streaming (8 output / 3 thoughts), non-streaming with thoughts outgrowing the answer (renamed to `TestChat_Generate_OutputExcludesThoughts`, which is what it actually covers now), and the cached-input case where input still clamps while output does not. Package coverage unchanged.
