### PR TITLE
fix(openai): emit a Responses tool call once, not per valid buffer

### DIFF
--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -21,12 +21,14 @@ import (
 type errorReader struct{}
 
 func (e *errorReader) Read(_ []byte) (int, error) { return 0, fmt.Errorf("read error") }
-func (e *errorReader) Close() error                { return nil }
+func (e *errorReader) Close() error               { return nil }
 
 // failTokenSource is a provider.TokenSource that always returns an error.
 type failTokenSource struct{}
 
-func (f failTokenSource) Token(_ context.Context) (string, error) { return "", fmt.Errorf("token error") }
+func (f failTokenSource) Token(_ context.Context) (string, error) {
+	return "", fmt.Errorf("token error")
+}
 
 // chatCompletionsOpts forces the Chat Completions API path (not Responses API).
 var chatCompletionsOpts = map[string]any{"useResponsesAPI": false}
@@ -672,8 +674,8 @@ func TestIsReasoningModel(t *testing.T) {
 		{"gpt-5.2", true},
 		{"codex-mini-latest", true},
 		{"codex-mini", true},
-		{"O3", true},        // case insensitive
-		{"GPT-5.1", true},   // case insensitive
+		{"O3", true},      // case insensitive
+		{"GPT-5.1", true}, // case insensitive
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
@@ -1101,7 +1103,7 @@ func TestChat_Responses_ProviderOptions(t *testing.T) {
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
 		},
 		ProviderOptions: map[string]any{
-			"serviceTier":     "default",
+			"serviceTier":      "default",
 			"reasoning_effort": "medium",
 		},
 	})
@@ -1139,7 +1141,7 @@ func TestChat_Responses_ProviderOptions_All(t *testing.T) {
 			"parallelToolCalls": true,
 			"truncation":        "auto",
 			"include":           []string{"reasoning.encrypted_content"},
-			"reasoning_summary":  "auto",
+			"reasoning_summary": "auto",
 		},
 	})
 
@@ -4431,3 +4433,82 @@ func TestConvertToResponsesInput_ServerToolItem(t *testing.T) {
 	}
 }
 
+func TestStreamResponses_ToolCallEmittedOnceAfterTrailingDelta(t *testing.T) {
+	// A delta arriving after the arguments already parse must not become a
+	// second call: the buffer is resolved on function_call_arguments.done.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.output_item.added\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0,"item":{"type":"function_call","call_id":"tc1","name":"read"}}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.function_call_arguments.delta\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0,"delta":"{\"path\":\"a.go\"}"}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.function_call_arguments.delta\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0,"delta":"\n"}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.function_call_arguments.done\n")
+		_, _ = fmt.Fprint(w, `data: {"output_index":0}`+"\n\n")
+		_, _ = fmt.Fprint(w, "event: response.completed\n")
+		_, _ = fmt.Fprint(w, `data: {"response":{"usage":{"input_tokens":1,"output_tokens":1}}}`+"\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []provider.StreamChunk
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkToolCall {
+			calls = append(calls, chunk)
+		}
+	}
+	if len(calls) != 1 {
+		t.Fatalf("emitted %d tool calls, want 1", len(calls))
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(calls[0].ToolInput), &args); err != nil {
+		t.Fatalf("ToolInput = %q, does not parse: %v", calls[0].ToolInput, err)
+	}
+	if args["path"] != "a.go" {
+		t.Errorf("args = %v, want path a.go", args)
+	}
+	if calls[0].ToolCallID != "tc1" || calls[0].ToolName != "read" {
+		t.Errorf("call = %q/%q, want tc1/read", calls[0].ToolCallID, calls[0].ToolName)
+	}
+}
+
+// The flush in output_item.done is the one TrySend path that cannot be reached
+// with an already-cancelled context: the events leading up to it send first and
+// bail out earlier. Cancel once the arguments are buffered instead.
+func TestStreamResponses_ContextCancel_OutputItemDoneFlush(t *testing.T) {
+	line := func(event, data string) string {
+		return "event: " + event + "\ndata: " + data + "\n\n"
+	}
+	input := line("response.output_item.added",
+		`{"output_index":0,"item":{"type":"function_call","id":"fc1","call_id":"c1","name":"fn"}}`) +
+		line("response.function_call_arguments.delta", `{"output_index":0,"delta":"{\"a\":1}"}`) +
+		// No arguments.done: the item is closed directly, so the flush runs.
+		line("response.output_item.done", `{"output_index":0,"item":{"type":"function_call"}}`)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	out := make(chan provider.StreamChunk) // unbuffered: the flush blocks on send
+	done := make(chan struct{})
+	go func() {
+		streamResponses(ctx, io.NopCloser(strings.NewReader(input)), out)
+		close(done)
+	}()
+
+	for chunk := range out {
+		if chunk.Type == provider.ChunkToolCallDelta {
+			break // stop consuming: the flush is now the pending send
+		}
+	}
+	cancel()
+
+	<-done
+	for range out { //nolint:revive // drain whatever was buffered
+	}
+}

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -593,17 +593,9 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 					return
 				}
 
-				if accumulated := active.args.String(); json.Valid([]byte(accumulated)) {
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:       provider.ChunkToolCall,
-						ToolCallID: active.id,
-						ToolName:   active.name,
-						ToolInput:  accumulated,
-					}) {
-						return
-					}
-					active.args.Reset()
-				}
+				// The call is resolved on function_call_arguments.done. Finalizing
+				// as soon as the buffer parses assumes no further delta arrives,
+				// and any that does becomes a second, bogus call.
 			}
 
 		case "response.function_call_arguments.done":
@@ -665,6 +657,20 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 							}) {
 								return
 							}
+						}
+					} else if active := activeTools[ev.OutputIndex]; active != nil {
+						// Safety net for an item closed without its arguments.done.
+						// The normal path resets the buffer, so this stays empty.
+						if remaining := active.args.String(); remaining != "" {
+							if !provider.TrySend(ctx, out, provider.StreamChunk{
+								Type:       provider.ChunkToolCall,
+								ToolCallID: active.id,
+								ToolName:   active.name,
+								ToolInput:  remaining,
+							}) {
+								return
+							}
+							active.args.Reset()
 						}
 					}
 					delete(activeTools, ev.OutputIndex)


### PR DESCRIPTION
`response.function_call_arguments.delta` finalizes the tool call as soon as the accumulated buffer parses as JSON, then resets the buffer:

```go
if accumulated := active.args.String(); json.Valid([]byte(accumulated)) {
    // emit ChunkToolCall
    active.args.Reset()
}
```

That assumes the delta completing the object is the last one for that call. Usually it is, but nothing in the protocol guarantees it — and when it isn't, whatever follows stays in the buffer and `response.function_call_arguments.done` emits it as a **second tool call**, carrying garbage arguments under the same call id. A client that executes tool calls runs the same call twice, the second time with a payload that does not parse.

A single trailing newline is enough to trigger it. Streaming these events:

```
response.output_item.added          {"type":"function_call","call_id":"tc1","name":"read"}
response.function_call_arguments.delta   {"path":"a.go"}
response.function_call_arguments.delta   "\n"
response.function_call_arguments.done
```

emits two `ChunkToolCall`s — `{"path":"a.go"}` and `"\n"` — where one is correct.

**Change:** resolve the call on the explicit `done` signal only. This is what the Anthropic provider in this repo already does — it waits for `content_block_stop` rather than validating mid-stream — so the two providers now agree on when a tool call is final.

`response.output_item.done` keeps a flush for the case where `done` never arrives and the item is closed directly, so an item closed early still emits its call instead of being dropped. Since the normal path resets the buffer after emitting, that branch finds it empty and cannot double-emit.

**Tests:** `TestStreamResponses_ToolCallEmittedOnceAfterTrailingDelta` drives the sequence above and asserts one call, with arguments that parse and the right id/name. It emitted two calls before this change. The existing `TestStreamResponses_FunctionCallOutputItemDone` covers the flush path and still passes. Package coverage 98.6%.
