### PR TITLE
fix(gemini): rewrite schema "const" to a single-value "enum"

### DIFF
--- a/internal/gemini/schema.go
+++ b/internal/gemini/schema.go
@@ -11,10 +11,11 @@ import (
 const maxRefInlineDepth = 10
 
 // SanitizeSchema sanitizes a JSON Schema for Gemini compatibility.
-// It converts enum integer/number types to string, filters invalid required fields,
-// ensures array items have a type, inlines $ref/$defs (which Gemini rejects),
-// and strips JSON Schema conditionals (if/then/else) which Gemini's OpenAPI
-// validator does not understand.
+// It converts enum integer/number types to string, rewrites "const" to a
+// single-value "enum", filters invalid required fields, ensures array items
+// have a type, inlines $ref/$defs (which Gemini rejects), and strips JSON
+// Schema conditionals (if/then/else) which Gemini's OpenAPI validator does
+// not understand.
 func SanitizeSchema(schema map[string]any) map[string]any {
 	// Step 1: resolve $ref → $defs and strip unsupported keywords.
 	// Gemini's function_declarations validator cannot resolve
@@ -232,7 +233,17 @@ func sanitizeImpl(obj any) any {
 	delete(result, "format")
 	delete(result, "propertyNames")
 	delete(result, "patternProperties")
-	delete(result, "const")
+	// Gemini has no "const", but a single-value "enum" says the same thing and
+	// is supported, so the constraint survives instead of being dropped.
+	if v, ok := result["const"]; ok {
+		delete(result, "const")
+		if _, hasEnum := result["enum"]; !hasEnum {
+			result["enum"] = []any{fmt.Sprint(v)}
+			if _, hasType := result["type"]; !hasType {
+				result["type"] = "string"
+			}
+		}
+	}
 	delete(result, "exclusiveMinimum")
 	delete(result, "exclusiveMaximum")
 	delete(result, "default")

--- a/internal/gemini/schema_test.go
+++ b/internal/gemini/schema_test.go
@@ -371,7 +371,8 @@ func TestSanitizeSchema_PointerToStructNullableType(t *testing.T) {
 
 func TestSanitizeSchema_StripsUnsupportedKeywords(t *testing.T) {
 	// Gemini's function_declarations rejects propertyNames, patternProperties,
-	// const, exclusiveMinimum, exclusiveMaximum, and default.
+	// const, exclusiveMinimum, exclusiveMaximum, and default. const is rewritten
+	// rather than dropped (see TestSanitizeSchema_ConstBecomesEnum).
 	schema := map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -815,5 +816,49 @@ func TestSanitizeSchema_NoInputMutation_AnySlice(t *testing.T) {
 	}
 	if result["nullable"] != true {
 		t.Error("result should have nullable: true")
+	}
+}
+
+func TestSanitizeSchema_ConstBecomesEnum(t *testing.T) {
+	// A typed const keeps its type; an untyped one gets a string type, since
+	// Gemini requires a type alongside the enum.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"kind":    map[string]any{"type": "string", "const": "create"},
+			"untyped": map[string]any{"const": "x"},
+			"withEnum": map[string]any{
+				"type": "string", "const": "a", "enum": []any{"a", "b"},
+			},
+		},
+	}
+	props, ok := SanitizeSchema(schema)["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties missing")
+	}
+
+	kind := props["kind"].(map[string]any)
+	if _, has := kind["const"]; has {
+		t.Error("const should be removed")
+	}
+	if !reflect.DeepEqual(kind["enum"], []any{"create"}) {
+		t.Errorf("kind enum = %v, want [create]", kind["enum"])
+	}
+	if kind["type"] != "string" {
+		t.Errorf("kind type = %v, want string", kind["type"])
+	}
+
+	untyped := props["untyped"].(map[string]any)
+	if !reflect.DeepEqual(untyped["enum"], []any{"x"}) {
+		t.Errorf("untyped enum = %v, want [x]", untyped["enum"])
+	}
+	if untyped["type"] != "string" {
+		t.Errorf("untyped type = %v, want synthesized string", untyped["type"])
+	}
+
+	// An existing enum wins: const must not narrow it.
+	withEnum := props["withEnum"].(map[string]any)
+	if !reflect.DeepEqual(withEnum["enum"], []any{"a", "b"}) {
+		t.Errorf("withEnum enum = %v, want [a b]", withEnum["enum"])
 	}
 }


### PR DESCRIPTION
Gemini's `function_declarations` validator rejects `const`, so `SanitizeSchema` drops it along with the other unsupported keywords:

```go
delete(result, "const")
```

Dropping the keyword also drops the constraint. A property pinned to one value becomes a free field of that type, and the model is free to fill it with anything — the schema no longer says what it meant.

Gemini does accept an exact equivalent: an `enum` with a single member. So the constraint can be preserved instead of discarded.

**Change:** rewrite `const` into a single-value `enum` rather than deleting it.

- An existing `enum` wins — a `const` must never widen or narrow a list that is already there.
- A `const` without a `type` gets `"string"`, which Gemini requires alongside an enum.
- The value goes through `fmt.Sprint`, matching how the surrounding code already stringifies enum members for Gemini.

This matters most for MCP tool schemas and discriminated unions, where a `const` tag is precisely what tells the model which variant it is filling in — exactly the information that was being thrown away.

**Tests:** `TestSanitizeSchema_ConstBecomesEnum` covers the typed const, the untyped one (synthesized string type), and the case where an enum is already present and must win. `TestSanitizeSchema_StripsUnsupportedKeywords` still asserts the `const` key is gone; its comment now points at the rewrite. Package coverage 100%.
