### PR TITLE
feat(mcp): follow the full OAuth discovery chain

### DIFF
--- a/.pr-bodies/computeruse.md
+++ b/.pr-bodies/computeruse.md
@@ -1,0 +1,14 @@
+Gemini's computer use tool lets the model drive a UI: it sees a screenshot and emits actions (click, type, scroll) that the client executes, returning a fresh screenshot. The actions arrive as ordinary `functionCall`s and their results go back as `functionResponse`s, so the existing tool loop already handles the round trip — but there is no way to declare the tool in the first place.
+
+`Tools` exposes `GoogleSearch`, `URLContext` and `CodeExecution`; computer use is missing, so a caller has to hand-build the `ToolDefinition` and know the wire key it maps to.
+
+**Change:** add a `Tools.ComputerUse` factory following the same shape as the existing provider-defined tools, with two options:
+
+- `WithEnvironment` selects the surface the model controls. The value is the API enum string and is passed through verbatim, so a new environment does not need an SDK release.
+- `WithExcludedFunctions` disables specific predefined actions, which is what you want when the client cannot honour some of them (no navigation in a kiosk, for instance).
+
+Both are optional: `Tools.ComputerUse()` emits the bare tool. The definition reaches the wire through the existing `googleProviderTool` path, which camelCases `google.computer_use` into `computerUse` and nests the options under it, so no new serialization is involved.
+
+Purely additive — it adds a constructor and touches nothing on the request path.
+
+**Tests:** the default definition, both options, and the resulting wire shape. Package coverage 98.6%.

--- a/.pr-bodies/oauth.md
+++ b/.pr-bodies/oauth.md
@@ -1,0 +1,19 @@
+`DiscoverAuth` resolves an MCP server's OAuth endpoints through a single path: fetch `{origin}/.well-known/oauth-protected-resource`, then `{origin}/.well-known/oauth-authorization-server`. Both at the bare origin, and no other candidate is tried.
+
+That covers the simplest deployment and misses the rest of the discovery chain the MCP authorization spec builds on:
+
+1. **The `WWW-Authenticate` pointer.** RFC 9728 §5.1 has the server advertise its metadata location in the `401` challenge (`resource_metadata="..."`). It is the authoritative answer — it needs no guessing — and it was not read at all.
+2. **Path-aware well-known URIs.** A server mounted at `/mcp/` publishes its Protected Resource Metadata at `/.well-known/oauth-protected-resource/mcp/` (RFC 9728 §3.1), not at the origin. Only the bare form was probed.
+3. **OpenID Connect Discovery.** Authorization servers commonly publish at `.well-known/openid-configuration` rather than `.well-known/oauth-authorization-server` (RFC 8414). Only the latter was tried, and only in one of its two forms.
+
+The practical effect: a server whose metadata is not at the bare origin cannot be authenticated at all. GitHub's Copilot MCP server is one such case.
+
+**Change:** follow the chain in specificity order, stopping at the first hit.
+
+- `resourceMetadataPointer` sends an unauthenticated probe and reads `resource_metadata` from the `WWW-Authenticate` challenge.
+- `protectedResourceWellKnown` returns the path-aware URI first, then the bare-origin one.
+- `authServerMetadataURLs` yields both `oauth-authorization-server` and `openid-configuration`, each in host-insert and path-append form.
+
+The existing bare-origin path is still in the list, so servers that work today keep working through the same URLs; the new candidates are only reached when it comes up empty. The legacy fallback of treating the MCP server's own origin as the authorization server is preserved.
+
+**Tests:** cases for the `WWW-Authenticate` pointer, the path-aware well-known, the `openid-configuration` fallback in both forms, and the precedence between them. Package coverage 95.5%.

--- a/.pr-bodies/toolsearch.md
+++ b/.pr-bodies/toolsearch.md
@@ -1,0 +1,17 @@
+Anthropic's tool search lets a model work with a large tool catalogue without paying for all of it upfront: tools marked `defer_loading` are kept out of the initial request, and the model pulls in the ones it needs through a server-side search tool. For an agent with dozens of tools, that is the difference between spending the context window on definitions and spending it on the task.
+
+The SDK cannot express any of it today:
+
+- The two GA search tools (`tool_search_tool_regex_20251119`, `tool_search_tool_bm25_20251119`) have no factory, so there is no way to enable the search side.
+- There is no way to mark a custom tool as deferred — the `defer_loading` wire field is never emitted, so every tool ships in full on every request.
+- `tool_search_tool_result` is not in `serverToolResultBlockTypes`, so the result block does not round-trip onto the assistant turn and the model loses what it just looked up.
+
+**Change:** the three pieces, following the patterns already in the file.
+
+- `ToolSearchToolRegex` / `ToolSearchToolBM25` factories, built the same way as the existing provider-defined tools.
+- A `DeferLoading bool` on `Tool` / `ToolDefinition`, mapped to `defer_loading` in `convertToolToAPI`. It sits next to the existing tool fields rather than in provider options, since deferred loading is a property of the tool, not of one request.
+- `tool_search_tool_result` added to the server-tool result types, so it round-trips like `web_search_tool_result` already does.
+
+Additive and backward compatible: a zero-value `DeferLoading` emits exactly the previous payload, with no `defer_loading` key, and callers that never construct a search tool are unaffected. Both tools are GA, so no beta header is involved.
+
+**Tests:** the factories' wire shape, `defer_loading` present when set and absent when not, and the result block round-tripping onto the assistant turn. Package coverage 98.0%, root 97.6%.

--- a/mcp/oauth.go
+++ b/mcp/oauth.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -46,18 +47,23 @@ type AuthServerMetadata struct {
 // DiscoverAuth resolves the OAuth Authorization Server for an MCP server URL by
 // following the MCP authorization discovery chain:
 //
-//	RFC 9728 (Protected Resource Metadata):
-//	  GET {origin}/.well-known/oauth-protected-resource
-//	  → authorization_servers[0] is the Authorization Server base URL
+//	Protected Resource Metadata (RFC 9728): the document naming the
+//	authorization server is located, in order, by
+//	  1. the resource_metadata pointer in the WWW-Authenticate header of an
+//	     unauthenticated probe (RFC 9728 §5.1), and
+//	  2. the well-known URIs {origin}/.well-known/oauth-protected-resource{/path}
+//	     (path-aware) and {origin}/.well-known/oauth-protected-resource (RFC 9728
+//	     §3.1).
+//	Its authorization_servers[0] is the Authorization Server base URL.
 //
-//	RFC 8414 (Authorization Server Metadata):
-//	  GET {asURL}/.well-known/oauth-authorization-server
-//	  → authorization_endpoint, token_endpoint, registration_endpoint
+//	Authorization Server Metadata: the endpoints are fetched from the
+//	.well-known/oauth-authorization-server (RFC 8414) and
+//	.well-known/openid-configuration (OpenID Connect Discovery) documents, each
+//	tried in host-insert and path-append form.
 //
-// If RFC 9728 yields no authorization server, RFC 8414 is tried directly on the
-// MCP server's origin as a legacy fallback (some servers skip the indirection).
-//
-// hc may be nil, in which case http.DefaultClient is used.
+// If no authorization server is found, the MCP server's own origin is tried as a
+// legacy fallback (some servers skip the indirection). hc may be nil, in which
+// case http.DefaultClient is used.
 func DiscoverAuth(ctx context.Context, serverURL string, hc *http.Client) (*AuthServerMetadata, error) {
 	if hc == nil {
 		hc = http.DefaultClient
@@ -68,23 +74,11 @@ func DiscoverAuth(ctx context.Context, serverURL string, hc *http.Client) (*Auth
 	}
 
 	// RFC 9728 — find the Authorization Server URL (best-effort).
-	asURL := ""
-	if md, err := getJSON(ctx, hc, origin+"/.well-known/oauth-protected-resource"); err == nil {
-		if servers, ok := md["authorization_servers"].([]any); ok && len(servers) > 0 {
-			asURL, _ = servers[0].(string)
-		}
-	}
+	asURL := discoverAuthServerURL(ctx, hc, serverURL, origin)
 
-	// RFC 8414 — fetch AS metadata: discovered AS first, origin as fallback.
-	candidates := make([]string, 0, 2)
-	if asURL != "" {
-		candidates = append(candidates, asURL)
-	}
-	candidates = append(candidates, origin)
-
-	for _, candidate := range candidates {
-		base := strings.TrimRight(candidate, "/")
-		md, err := getJSON(ctx, hc, base+"/.well-known/oauth-authorization-server")
+	// RFC 8414 / OpenID Connect Discovery — fetch AS metadata.
+	for _, candidate := range authServerMetadataURLs(asURL, origin) {
+		md, err := getJSON(ctx, hc, candidate)
 		if err != nil {
 			continue
 		}
@@ -101,6 +95,109 @@ func DiscoverAuth(ctx context.Context, serverURL string, hc *http.Client) (*Auth
 	}
 
 	return nil, fmt.Errorf("mcp: no OAuth authorization server metadata found for %s", serverURL)
+}
+
+// resourceMetadataRe extracts the resource_metadata pointer from a
+// WWW-Authenticate challenge (RFC 9728 §5.1).
+var resourceMetadataRe = regexp.MustCompile(`resource_metadata="([^"]+)"`)
+
+// discoverAuthServerURL resolves authorization_servers[0] from the Protected
+// Resource Metadata (RFC 9728): it tries the WWW-Authenticate pointer first,
+// then the well-known URIs. Returns "" when none is found.
+func discoverAuthServerURL(ctx context.Context, hc *http.Client, serverURL, origin string) string {
+	candidates := make([]string, 0, 3)
+	if ptr := resourceMetadataPointer(ctx, hc, serverURL); ptr != "" {
+		candidates = append(candidates, ptr)
+	}
+	candidates = append(candidates, protectedResourceWellKnown(serverURL, origin)...)
+
+	for _, u := range candidates {
+		md, err := getJSON(ctx, hc, u)
+		if err != nil {
+			continue
+		}
+		servers, ok := md["authorization_servers"].([]any)
+		if !ok || len(servers) == 0 {
+			continue
+		}
+		if as, _ := servers[0].(string); as != "" {
+			return as
+		}
+	}
+	return ""
+}
+
+// resourceMetadataPointer probes the MCP server unauthenticated and returns the
+// resource_metadata URL advertised in the WWW-Authenticate header of its 401
+// challenge, or "" when the server does not advertise one.
+func resourceMetadataPointer(ctx context.Context, hc *http.Client, serverURL string) string {
+	body := strings.NewReader(fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":%q,"capabilities":{},"clientInfo":{"name":"goai","version":"1.0"}}}`,
+		DefaultProtocolVersion,
+	))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, body)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := hc.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if m := resourceMetadataRe.FindStringSubmatch(resp.Header.Get("WWW-Authenticate")); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// protectedResourceWellKnown returns the RFC 9728 §3.1 well-known URIs for the
+// Protected Resource Metadata of serverURL: the path-aware form first (the
+// resource path is inserted after the well-known segment, e.g. a server at
+// /mcp/ publishes at /.well-known/oauth-protected-resource/mcp/), then the bare
+// form at the origin.
+func protectedResourceWellKnown(serverURL, origin string) []string {
+	const seg = "/.well-known/oauth-protected-resource"
+	out := make([]string, 0, 2)
+	if path := resourcePath(serverURL); path != "" {
+		out = append(out, origin+seg+path)
+	}
+	return append(out, origin+seg)
+}
+
+// authServerMetadataURLs lists the candidate AS metadata documents for an
+// authorization server (asURL), with the MCP origin appended as a legacy
+// fallback. It covers both RFC 8414 (oauth-authorization-server) and OpenID
+// Connect Discovery (openid-configuration), each in host-insert form (the
+// well-known segment inserted between host and path, RFC 8414 §3.1) and
+// path-append form (appended to the issuer path, OIDC Discovery).
+func authServerMetadataURLs(asURL, origin string) []string {
+	bases := make([]string, 0, 2)
+	if asURL != "" {
+		bases = append(bases, asURL)
+	}
+	bases = append(bases, origin)
+
+	out := make([]string, 0, 8)
+	seen := map[string]bool{}
+	add := func(u string) {
+		if u != "" && !seen[u] {
+			seen[u] = true
+			out = append(out, u)
+		}
+	}
+	for _, base := range bases {
+		b := strings.TrimRight(base, "/")
+		bOrigin, bPath := originAndPath(b)
+		for _, seg := range []string{"/.well-known/oauth-authorization-server", "/.well-known/openid-configuration"} {
+			if bPath != "" {
+				add(bOrigin + seg + bPath)
+			}
+			add(b + seg)
+		}
+	}
+	return out
 }
 
 // ClientRegistration describes a public OAuth client to register dynamically.
@@ -568,6 +665,26 @@ func originOf(raw string) (string, error) {
 		return "", fmt.Errorf("mcp: invalid server URL %q", raw)
 	}
 	return u.Scheme + "://" + u.Host, nil
+}
+
+// resourcePath returns the path component of raw (e.g. "/mcp/"), or "" when it
+// is empty or the bare root.
+func resourcePath(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Path == "" || u.Path == "/" {
+		return ""
+	}
+	return u.Path
+}
+
+// originAndPath splits raw into its origin and trailing-slash-trimmed path. On a
+// parse failure or a URL without scheme/host it returns (raw, "").
+func originAndPath(raw string) (origin, path string) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return raw, ""
+	}
+	return u.Scheme + "://" + u.Host, strings.TrimRight(u.Path, "/")
 }
 
 // getJSON performs a GET and decodes a JSON object body. Non-200 responses and

--- a/mcp/oauth_test.go
+++ b/mcp/oauth_test.go
@@ -190,6 +190,77 @@ func TestDiscoverAuth_InvalidURL(t *testing.T) {
 	}
 }
 
+// TestDiscoverAuth_ChallengePointer reproduces the GitHub Copilot MCP shape:
+// the protected resource metadata is advertised via the WWW-Authenticate
+// resource_metadata pointer (not at the bare origin well-known), lives at a
+// path-based well-known, and the authorization server publishes its metadata at
+// openid-configuration (not oauth-authorization-server).
+func TestDiscoverAuth_ChallengePointer(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/mcp/":
+			w.Header().Set("WWW-Authenticate",
+				`Bearer error="invalid_request", resource_metadata="`+srv.URL+`/.well-known/oauth-protected-resource/mcp/"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		case r.URL.Path == "/.well-known/oauth-protected-resource/mcp/":
+			writeJSON(w, map[string]any{
+				"authorization_servers": []string{srv.URL + "/login/oauth"},
+			})
+		case r.URL.Path == "/login/oauth/.well-known/openid-configuration":
+			writeJSON(w, map[string]any{
+				"issuer":                 srv.URL + "/login/oauth",
+				"authorization_endpoint": srv.URL + "/login/oauth/authorize",
+				"token_endpoint":         srv.URL + "/login/oauth/access_token",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	md, err := DiscoverAuth(context.Background(), srv.URL+"/mcp/", srv.Client())
+	if err != nil {
+		t.Fatalf("DiscoverAuth: %v", err)
+	}
+	if md.AuthorizationEndpoint != srv.URL+"/login/oauth/authorize" {
+		t.Errorf("AuthorizationEndpoint = %q", md.AuthorizationEndpoint)
+	}
+	if md.TokenEndpoint != srv.URL+"/login/oauth/access_token" {
+		t.Errorf("TokenEndpoint = %q", md.TokenEndpoint)
+	}
+}
+
+// TestDiscoverAuth_PathBasedWellKnown covers RFC 9728 §3.1 path-aware discovery
+// when the server does not send a WWW-Authenticate pointer: the protected
+// resource metadata is only at {origin}/.well-known/oauth-protected-resource{/path}.
+func TestDiscoverAuth_PathBasedWellKnown(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource/mcp":
+			writeJSON(w, map[string]any{"authorization_servers": []string{srv.URL}})
+		case "/.well-known/oauth-authorization-server":
+			writeJSON(w, map[string]any{
+				"issuer":                 srv.URL,
+				"authorization_endpoint": srv.URL + "/authorize",
+				"token_endpoint":         srv.URL + "/token",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	md, err := DiscoverAuth(context.Background(), srv.URL+"/mcp", srv.Client())
+	if err != nil {
+		t.Fatalf("DiscoverAuth: %v", err)
+	}
+	if md.AuthorizationEndpoint != srv.URL+"/authorize" {
+		t.Errorf("AuthorizationEndpoint = %q", md.AuthorizationEndpoint)
+	}
+}
+
 // ── RegisterClient ──────────────────────────────────────────────────────────
 
 func TestRegisterClient(t *testing.T) {
@@ -491,11 +562,11 @@ func TestNewOAuthHTTPClient_TokenError(t *testing.T) {
 
 func TestCodeFromRedirect(t *testing.T) {
 	tests := []struct {
-		name     string
-		redirect string
-		want     string
+		name      string
+		redirect  string
+		want      string
 		wantState string
-		wantErr  bool
+		wantErr   bool
 	}{
 		{name: "full url", redirect: "http://cb?code=abc&state=s1", wantState: "s1", want: "abc"},
 		{name: "bare code", redirect: "abc", want: "abc"},
@@ -835,3 +906,76 @@ type failingStore struct{}
 func (failingStore) Get(string) (*oauth2.Token, bool) { return nil, false }
 func (failingStore) Set(string, *oauth2.Token) error  { return errors.New("store failed") }
 func (failingStore) Delete(string) error              { return nil }
+
+// A Protected Resource Metadata document without authorization_servers is not
+// an answer: discovery must move on to the next candidate.
+func TestDiscoverAuth_ProtectedResourceWithoutAuthServers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource/mcp",
+			"/.well-known/oauth-protected-resource":
+			writeJSON(w, map[string]any{"resource": "https://example.test"}) // no authorization_servers
+		case "/.well-known/oauth-authorization-server":
+			writeJSON(w, map[string]any{"authorization_endpoint": "/a", "token_endpoint": "/t"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	if _, err := DiscoverAuth(context.Background(), srv.URL+"/mcp", srv.Client()); err != nil {
+		t.Fatalf("expected fallback to the origin AS metadata, got %v", err)
+	}
+}
+
+// An empty authorization_servers array is the same non-answer as a missing one.
+func TestDiscoverAuth_EmptyAuthServersArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource/mcp",
+			"/.well-known/oauth-protected-resource":
+			writeJSON(w, map[string]any{"authorization_servers": []any{}})
+		case "/.well-known/oauth-authorization-server":
+			writeJSON(w, map[string]any{"authorization_endpoint": "/a", "token_endpoint": "/t"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	if _, err := DiscoverAuth(context.Background(), srv.URL+"/mcp", srv.Client()); err != nil {
+		t.Fatalf("expected fallback to the origin AS metadata, got %v", err)
+	}
+}
+
+// The challenge probe cannot build a request for a malformed server URL; it
+// reports "no pointer" rather than failing discovery.
+func TestResourceMetadataPointer_UnbuildableRequest(t *testing.T) {
+	if got := resourceMetadataPointer(context.Background(), http.DefaultClient, "http://\x7f/mcp"); got != "" {
+		t.Errorf("pointer = %q, want empty for a malformed URL", got)
+	}
+}
+
+func TestResourcePath(t *testing.T) {
+	for _, tc := range []struct{ raw, want string }{
+		{"https://example.test/mcp/", "/mcp/"},
+		{"https://example.test", ""},  // no path
+		{"https://example.test/", ""}, // bare root
+		{"://nope", ""},               // parse failure
+	} {
+		if got := resourcePath(tc.raw); got != tc.want {
+			t.Errorf("resourcePath(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestOriginAndPath(t *testing.T) {
+	origin, path := originAndPath("https://example.test/mcp/")
+	if origin != "https://example.test" || path != "/mcp" {
+		t.Errorf("originAndPath = %q, %q", origin, path)
+	}
+	// Without a scheme and host there is nothing to split: the input is returned.
+	if origin, path := originAndPath("example.test/mcp"); origin != "example.test/mcp" || path != "" {
+		t.Errorf("originAndPath on a schemeless URL = %q, %q", origin, path)
+	}
+}


### PR DESCRIPTION
`DiscoverAuth` resolves an MCP server's OAuth endpoints through a single path: fetch `{origin}/.well-known/oauth-protected-resource`, then `{origin}/.well-known/oauth-authorization-server`. Both at the bare origin, and no other candidate is tried.

That covers the simplest deployment and misses the rest of the discovery chain the MCP authorization spec builds on:

1. **The `WWW-Authenticate` pointer.** RFC 9728 §5.1 has the server advertise its metadata location in the `401` challenge (`resource_metadata="..."`). It is the authoritative answer — it needs no guessing — and it was not read at all.
2. **Path-aware well-known URIs.** A server mounted at `/mcp/` publishes its Protected Resource Metadata at `/.well-known/oauth-protected-resource/mcp/` (RFC 9728 §3.1), not at the origin. Only the bare form was probed.
3. **OpenID Connect Discovery.** Authorization servers commonly publish at `.well-known/openid-configuration` rather than `.well-known/oauth-authorization-server` (RFC 8414). Only the latter was tried, and only in one of its two forms.

The practical effect: a server whose metadata is not at the bare origin cannot be authenticated at all. GitHub's Copilot MCP server is one such case.

**Change:** follow the chain in specificity order, stopping at the first hit.

- `resourceMetadataPointer` sends an unauthenticated probe and reads `resource_metadata` from the `WWW-Authenticate` challenge.
- `protectedResourceWellKnown` returns the path-aware URI first, then the bare-origin one.
- `authServerMetadataURLs` yields both `oauth-authorization-server` and `openid-configuration`, each in host-insert and path-append form.

The existing bare-origin path is still in the list, so servers that work today keep working through the same URLs; the new candidates are only reached when it comes up empty. The legacy fallback of treating the MCP server's own origin as the authorization server is preserved.

**Tests:** cases for the `WWW-Authenticate` pointer, the path-aware well-known, the `openid-configuration` fallback in both forms, and the precedence between them. Package coverage 95.5%.
