### PR TITLE
feat(anthropic): tool search server tools and defer_loading

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -608,6 +608,7 @@ func buildParams(opts options) provider.GenerateParams {
 			InputSchema:            t.InputSchema,
 			ProviderDefinedType:    t.ProviderDefinedType,
 			ProviderDefinedOptions: t.ProviderDefinedOptions,
+			DeferLoading:           t.DeferLoading,
 		})
 	}
 

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -35,10 +35,10 @@ var (
 )
 
 const (
-	defaultBaseURL    = "https://api.anthropic.com"
-	apiVersion        = "2023-06-01"
-	betaFeatures      = "claude-code-20250219,interleaved-thinking-2025-05-14"
-	defaultMaxTokens  = 16384
+	defaultBaseURL   = "https://api.anthropic.com"
+	apiVersion       = "2023-06-01"
+	betaFeatures     = "claude-code-20250219,interleaved-thinking-2025-05-14"
+	defaultMaxTokens = 16384
 )
 
 // anthropicHandledKeys lists provider option keys that are explicitly handled
@@ -1271,12 +1271,13 @@ func mapFinishReason(reason string) provider.FinishReason {
 // assistant turn -- omitting them causes the API to reject re-sent transcripts
 // with "tool_use ids were found without `tool_result` blocks".
 var serverToolResultBlockTypes = map[string]bool{
-	"web_search_tool_result":                true,
-	"web_fetch_tool_result":                 true,
-	"code_execution_tool_result":            true,
-	"bash_code_execution_tool_result":       true,
+	"web_search_tool_result":                 true,
+	"web_fetch_tool_result":                  true,
+	"code_execution_tool_result":             true,
+	"bash_code_execution_tool_result":        true,
 	"text_editor_code_execution_tool_result": true,
-	"mcp_tool_result":                       true,
+	"mcp_tool_result":                        true,
+	"tool_search_tool_result":                true,
 }
 
 func isServerToolResultBlock(t string) bool {
@@ -1296,7 +1297,7 @@ func parseResponse(body []byte) (*provider.GenerateResult, error) {
 			Input     json.RawMessage `json:"input,omitempty"`
 			Thinking  string          `json:"thinking,omitempty"`
 			Signature string          `json:"signature,omitempty"`
-			Data      string          `json:"data,omitempty"` // redacted_thinking
+			Data      string          `json:"data,omitempty"`        // redacted_thinking
 			ToolUseID string          `json:"tool_use_id,omitempty"` // for server tool result blocks
 			Citations []struct {
 				Type            string  `json:"type"`

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -3613,6 +3613,58 @@ func TestChat_Generate_ServerToolResultRoundTrip(t *testing.T) {
 	}
 }
 
+// TestChat_Generate_ToolSearchResultRoundTrip verifies that the built-in tool
+// search server tool (server_tool_use + tool_search_tool_result) is captured
+// into the matching ToolCall.Metadata so it survives a multi-turn round-trip,
+// like web_search and the other server-executed tool results. Unlike those,
+// the tool_search_tool_result content is an object (not an array), which the
+// verbatim round-trip must preserve unchanged.
+func TestChat_Generate_ToolSearchResultRoundTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{
+			"id": "msg_ts1",
+			"model": "sonnet-test-model",
+			"type": "message",
+			"content": [
+				{"type": "server_tool_use", "id": "srvtoolu_ts", "name": "tool_search_tool_regex", "input": {"query": "weather"}},
+				{"type": "tool_search_tool_result", "tool_use_id": "srvtoolu_ts", "content": {"type": "tool_search_tool_search_result", "tool_references": [{"type": "tool_reference", "tool_name": "get_weather"}]}}
+			],
+			"stop_reason": "tool_use",
+			"usage": {"input_tokens": 20, "output_tokens": 15}
+		}`)
+	}))
+	defer server.Close()
+
+	model := Chat("sonnet-test-model", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "weather in SF?"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	tc := result.ToolCalls[0]
+	if tc.ID != "srvtoolu_ts" || tc.Name != "tool_search_tool_regex" {
+		t.Errorf("ToolCall = %+v, want srvtoolu_ts/tool_search_tool_regex", tc)
+	}
+	rb, ok := tc.Metadata["resultBlock"].(map[string]any)
+	if !ok {
+		t.Fatalf("ToolCall.Metadata[resultBlock] missing or wrong type: %T", tc.Metadata["resultBlock"])
+	}
+	if rb["type"] != "tool_search_tool_result" {
+		t.Errorf("resultBlock type = %v, want tool_search_tool_result", rb["type"])
+	}
+	if rb["tool_use_id"] != "srvtoolu_ts" {
+		t.Errorf("resultBlock tool_use_id = %v, want srvtoolu_ts", rb["tool_use_id"])
+	}
+}
+
 // TestChat_Stream_ServerToolResultRoundTrip is the streaming counterpart to
 // TestChat_Generate_ServerToolResultRoundTrip.
 func TestChat_Stream_ServerToolResultRoundTrip(t *testing.T) {

--- a/provider/anthropic/tools.go
+++ b/provider/anthropic/tools.go
@@ -52,6 +52,16 @@ var Tools = struct {
 	// CodeExecution_20250825 creates a code execution tool (version 20250825).
 	// Requires beta header: code-execution-2025-08-25.
 	CodeExecution_20250825 func() provider.ToolDefinition
+
+	// ToolSearchToolRegex creates the regex tool search tool (version 20251119).
+	// Claude searches the deferred tool catalog with Python re.search() patterns.
+	// Pair it with defer_loading:true on the tools that should load on demand.
+	ToolSearchToolRegex func() provider.ToolDefinition
+
+	// ToolSearchToolBM25 creates the BM25 tool search tool (version 20251119).
+	// Claude searches the deferred tool catalog with natural-language queries.
+	// Pair it with defer_loading:true on the tools that should load on demand.
+	ToolSearchToolBM25 func() provider.ToolDefinition
 }{
 	Computer: func(opts ComputerToolOptions) provider.ToolDefinition {
 		return computerTool(opts, "computer_20250124")
@@ -72,6 +82,12 @@ var Tools = struct {
 	},
 	CodeExecution_20250825: func() provider.ToolDefinition {
 		return codeExecutionTool("code_execution_20250825")
+	},
+	ToolSearchToolRegex: func() provider.ToolDefinition {
+		return toolSearchTool("tool_search_tool_regex", "tool_search_tool_regex_20251119")
+	},
+	ToolSearchToolBM25: func() provider.ToolDefinition {
+		return toolSearchTool("tool_search_tool_bm25", "tool_search_tool_bm25_20251119")
 	},
 }
 
@@ -194,10 +210,10 @@ func textEditor20250728Tool(opts ...TextEditorOption) provider.ToolDefinition {
 type WebSearchOption func(*webSearchConfig)
 
 type webSearchConfig struct {
-	MaxUses        int                 // max number of searches per turn
-	AllowedDomains []string            // restrict search to these domains
-	BlockedDomains []string            // exclude these domains from search
-	UserLocation   *WebSearchLocation  // optional user location
+	MaxUses        int                // max number of searches per turn
+	AllowedDomains []string           // restrict search to these domains
+	BlockedDomains []string           // exclude these domains from search
+	UserLocation   *WebSearchLocation // optional user location
 }
 
 // WebSearchLocation provides geographically relevant search results.
@@ -372,6 +388,20 @@ func codeExecutionTool(version string) provider.ToolDefinition {
 }
 
 // ---------------------------------------------------------------------------
+// ToolSearch
+// ---------------------------------------------------------------------------
+
+// toolSearchTool builds a tool search server tool (regex or bm25). The search
+// tool itself must never be deferred; pair it with defer_loading:true on the
+// custom tools that should be discovered on demand.
+func toolSearchTool(name, version string) provider.ToolDefinition {
+	return provider.ToolDefinition{
+		Name:                name,
+		ProviderDefinedType: version,
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Beta header helpers
 // ---------------------------------------------------------------------------
 
@@ -443,6 +473,11 @@ func convertToolToAPI(t provider.ToolDefinition) map[string]any {
 		if err := json.Unmarshal(t.InputSchema, &schema); err == nil {
 			tool["input_schema"] = schema
 		}
+	}
+	// Deferred tools are omitted from the initial tool set and surfaced only
+	// when the model discovers them through a tool search tool.
+	if t.DeferLoading {
+		tool["defer_loading"] = true
 	}
 	return tool
 }

--- a/provider/anthropic/tools_test.go
+++ b/provider/anthropic/tools_test.go
@@ -206,6 +206,26 @@ func TestTools_CodeExecution20250825(t *testing.T) {
 	}
 }
 
+func TestTools_ToolSearchToolRegex(t *testing.T) {
+	tool := Tools.ToolSearchToolRegex()
+	if tool.Name != "tool_search_tool_regex" {
+		t.Errorf("Name = %q, want tool_search_tool_regex", tool.Name)
+	}
+	if tool.ProviderDefinedType != "tool_search_tool_regex_20251119" {
+		t.Errorf("ProviderDefinedType = %q, want tool_search_tool_regex_20251119", tool.ProviderDefinedType)
+	}
+}
+
+func TestTools_ToolSearchToolBM25(t *testing.T) {
+	tool := Tools.ToolSearchToolBM25()
+	if tool.Name != "tool_search_tool_bm25" {
+		t.Errorf("Name = %q, want tool_search_tool_bm25", tool.Name)
+	}
+	if tool.ProviderDefinedType != "tool_search_tool_bm25_20251119" {
+		t.Errorf("ProviderDefinedType = %q, want tool_search_tool_bm25_20251119", tool.ProviderDefinedType)
+	}
+}
+
 func TestBetaForTool(t *testing.T) {
 	tests := []struct {
 		toolType string
@@ -224,6 +244,8 @@ func TestBetaForTool(t *testing.T) {
 		{"code_execution_20260120", ""},
 		{"web_search_20260209", "code-execution-web-tools-2026-02-09"},
 		{"web_fetch_20260209", "code-execution-web-tools-2026-02-09"},
+		{"tool_search_tool_regex_20251119", ""}, // GA, no beta header
+		{"tool_search_tool_bm25_20251119", ""},  // GA, no beta header
 		{"unknown_tool", ""},
 		{"", ""},
 	}
@@ -265,8 +287,8 @@ func TestCollectToolBetas_Mixed(t *testing.T) {
 
 func TestCollectToolBetas_CodeExecution(t *testing.T) {
 	tools := []provider.ToolDefinition{
-		Tools.CodeExecution(),           // 20260120 → no beta
-		Tools.CodeExecution_20250825(),  // 20250825 → beta
+		Tools.CodeExecution(),          // 20260120 → no beta
+		Tools.CodeExecution_20250825(), // 20250825 → beta
 	}
 
 	betas := collectToolBetas(tools)
@@ -346,6 +368,38 @@ func TestConvertToolToAPI_Regular(t *testing.T) {
 	}
 	if api["input_schema"] == nil {
 		t.Error("regular tool should have input_schema")
+	}
+}
+
+func TestConvertToolToAPI_DeferLoading(t *testing.T) {
+	tool := provider.ToolDefinition{
+		Name:         "get_weather",
+		Description:  "Get the weather",
+		InputSchema:  json.RawMessage(`{"type":"object"}`),
+		DeferLoading: true,
+	}
+
+	api := convertToolToAPI(tool)
+
+	if api["defer_loading"] != true {
+		t.Errorf("defer_loading = %v, want true", api["defer_loading"])
+	}
+	if api["name"] != "get_weather" {
+		t.Errorf("name = %v, want get_weather", api["name"])
+	}
+}
+
+func TestConvertToolToAPI_NoDeferLoadingByDefault(t *testing.T) {
+	tool := provider.ToolDefinition{
+		Name:        "get_weather",
+		Description: "Get the weather",
+	}
+
+	api := convertToolToAPI(tool)
+
+	// Backward-compatible: absent unless explicitly deferred.
+	if _, ok := api["defer_loading"]; ok {
+		t.Error("defer_loading should be absent when DeferLoading is false")
 	}
 }
 

--- a/provider/types.go
+++ b/provider/types.go
@@ -449,6 +449,13 @@ type ToolDefinition struct {
 	// ProviderDefinedOptions holds provider-specific tool configuration
 	// (e.g. displayWidthPx for computer use). Providers interpret these as needed.
 	ProviderDefinedOptions map[string]any
+
+	// DeferLoading marks a tool for on-demand loading: it is omitted from the
+	// initial tool set and surfaced only once the model discovers it through a
+	// tool search tool. Providers that support deferred tool loading (Anthropic)
+	// translate it to their wire flag; others ignore it. Has no effect unless a
+	// tool search tool is also present in the request.
+	DeferLoading bool
 }
 
 // ToolCall represents the model's request to invoke a tool.

--- a/types.go
+++ b/types.go
@@ -28,6 +28,11 @@ type Tool struct {
 	// (e.g. displayWidthPx for computer use).
 	ProviderDefinedOptions map[string]any
 
+	// DeferLoading marks this tool for on-demand loading via a tool search tool
+	// (see provider.ToolDefinition.DeferLoading). The zero value keeps the tool
+	// loaded upfront.
+	DeferLoading bool
+
 	// Execute runs the tool with the given JSON input and returns the result text.
 	// Both the return value and error string are forwarded to the model as a tool
 	// result message. Do not include sensitive data (credentials, internal paths)


### PR DESCRIPTION
Anthropic's tool search lets a model work with a large tool catalogue without paying for all of it upfront: tools marked `defer_loading` are kept out of the initial request, and the model pulls in the ones it needs through a server-side search tool. For an agent with dozens of tools, that is the difference between spending the context window on definitions and spending it on the task.

The SDK cannot express any of it today:

- The two GA search tools (`tool_search_tool_regex_20251119`, `tool_search_tool_bm25_20251119`) have no factory, so there is no way to enable the search side.
- There is no way to mark a custom tool as deferred — the `defer_loading` wire field is never emitted, so every tool ships in full on every request.
- `tool_search_tool_result` is not in `serverToolResultBlockTypes`, so the result block does not round-trip onto the assistant turn and the model loses what it just looked up.

**Change:** the three pieces, following the patterns already in the file.

- `ToolSearchToolRegex` / `ToolSearchToolBM25` factories, built the same way as the existing provider-defined tools.
- A `DeferLoading bool` on `Tool` / `ToolDefinition`, mapped to `defer_loading` in `convertToolToAPI`. It sits next to the existing tool fields rather than in provider options, since deferred loading is a property of the tool, not of one request.
- `tool_search_tool_result` added to the server-tool result types, so it round-trips like `web_search_tool_result` already does.

Additive and backward compatible: a zero-value `DeferLoading` emits exactly the previous payload, with no `defer_loading` key, and callers that never construct a search tool are unaffected. Both tools are GA, so no beta header is involved.

**Tests:** the factories' wire shape, `defer_loading` present when set and absent when not, and the result block round-tripping onto the assistant turn. Package coverage 98.0%, root 97.6%.
