### PR TITLE
fix: preserve Responses reasoning state and continuation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ testdata/
 .vibeflow
 *.out
 docs/drift-report
+docs/issue-fixes-review/
 .pr-bodies/

--- a/generate.go
+++ b/generate.go
@@ -80,10 +80,8 @@ type TextResult struct {
 	// For StreamText, check Err() before using , on stream errors, ResponseMessages
 	// may be partial (intermediate tool round-trips lost) or reflect only completed
 	// steps. Do not use ResponseMessages for conversation continuation when Err() != nil.
-	// Reasoning parts (PartReasoning) are included for StreamText (both single-step
-	// and multi-step) but not for GenerateText (which does not expose reasoning).
-	// Reasoning chunks are consolidated into a single PartReasoning part with merged
-	// metadata (e.g. Anthropic/Bedrock signatures).
+	// Reasoning parts (PartReasoning) are included for both GenerateText and
+	// StreamText. Provider-native metadata is preserved for replay when available.
 	ResponseMessages []provider.Message
 }
 
@@ -150,6 +148,89 @@ type StepResult struct {
 	Sources []provider.Source
 }
 
+type reasoningAccumulator struct {
+	parts   []provider.Part
+	current *provider.Part
+	key     string
+}
+
+func (a *reasoningAccumulator) add(chunk provider.StreamChunk) {
+	key, hasKey := reasoningBoundaryKey(chunk.Metadata)
+	if a.current != nil && reasoningBoundaryChanged(a.current, a.key, key, hasKey, chunk) {
+		a.flush()
+	}
+	if a.current == nil {
+		a.current = &provider.Part{Type: provider.PartReasoning, ProviderOptions: map[string]any{}}
+		a.key = key
+	}
+	a.current.Text += chunk.Text
+	for k, v := range chunk.Metadata {
+		if k != "source" {
+			a.current.ProviderOptions[k] = v
+		}
+	}
+}
+
+func reasoningBoundaryChanged(current *provider.Part, currentKey, incomingKey string, incomingHasKey bool, chunk provider.StreamChunk) bool {
+	if currentKey != "" && incomingHasKey && currentKey != incomingKey {
+		return true
+	}
+	if chunk.Text == "" {
+		return false
+	}
+	if (currentKey == "" && incomingHasKey) || (currentKey != "" && !incomingHasKey) {
+		return current.Text != ""
+	}
+	return reasoningSignatureChanged(current.ProviderOptions, chunk.Metadata) || reasoningSignaturePresenceChanged(current.ProviderOptions, chunk.Metadata)
+}
+
+func reasoningBoundaryKey(metadata map[string]any) (string, bool) {
+	for _, name := range []string{"reasoningId", "blockId", "itemId"} {
+		if value, ok := metadata[name].(string); ok && value != "" {
+			return name + ":" + value, true
+		}
+	}
+	return "", false
+}
+
+func (a *reasoningAccumulator) flush() {
+	if a.current == nil {
+		return
+	}
+	if a.current.Text != "" || len(a.current.ProviderOptions) > 0 {
+		a.parts = append(a.parts, *a.current)
+	}
+	a.current = nil
+	a.key = ""
+}
+
+func (a *reasoningAccumulator) finish() []provider.Part {
+	a.flush()
+	parts := a.parts
+	a.parts = nil
+	return parts
+}
+
+func reasoningSignatureChanged(existing, incoming map[string]any) bool {
+	oldSig, oldOK := existing["signature"].(string)
+	newSig, newOK := incoming["signature"].(string)
+	return oldOK && newOK && oldSig != "" && newSig != "" && oldSig != newSig
+}
+
+func reasoningSignaturePresenceChanged(existing, incoming map[string]any) bool {
+	_, oldOK := existing["signature"].(string)
+	_, newOK := incoming["signature"].(string)
+	return oldOK != newOK
+}
+
+func reasoningText(parts []provider.Part) string {
+	var text strings.Builder
+	for _, part := range parts {
+		text.WriteString(part.Text)
+	}
+	return text.String()
+}
+
 // TextStream is a streaming text generation response.
 //
 // Callers must consume the stream (via Stream, TextStream, or Result) or cancel
@@ -196,13 +277,13 @@ type TextStream struct {
 	streamErr        error
 
 	// Multi-step accumulation (written by consume goroutine).
-	steps         []StepResult
-	currentStep   int
-	stepText      strings.Builder
-	stepToolCalls []provider.ToolCall
-	stepSources   []provider.Source
-	reasoningBuf  strings.Builder // consolidated reasoning text (matches drainStep)
-	reasoningMeta map[string]any  // merged reasoning metadata (e.g. Anthropic signature)
+	steps          []StepResult
+	currentStep    int
+	stepText       strings.Builder
+	stepToolCalls  []provider.ToolCall
+	stepSources    []provider.Source
+	reasoning      reasoningAccumulator
+	reasoningParts []provider.Part
 
 	// responseMessages is set by the streamWithToolLoop goroutine before doneCh closes.
 	responseMessages []provider.Message
@@ -377,19 +458,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 
 		case provider.ChunkReasoning:
 			ts.text.WriteString(chunk.Text) // global accumulator (existing, includes reasoning)
-			// Consolidate reasoning fragments into one Part (matching drainStep behavior).
-			// Text is accumulated; metadata is merged (last chunk carries the signature).
-			if chunk.Text != "" {
-				ts.reasoningBuf.WriteString(chunk.Text)
-			}
-			if chunk.Metadata != nil {
-				if ts.reasoningMeta == nil {
-					ts.reasoningMeta = make(map[string]any)
-				}
-				for k, v := range chunk.Metadata {
-					ts.reasoningMeta[k] = v
-				}
-			}
+			ts.reasoning.add(chunk)
 			if s, ok := chunk.Metadata["source"].(provider.Source); ok {
 				ts.sources = append(ts.sources, s)         // global (preserve existing behavior)
 				ts.stepSources = append(ts.stepSources, s) // per-step
@@ -413,6 +482,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 			}
 			// GoAI-emitted step boundaries: build per-step StepResult.
 			if stepSource, _ := chunk.Metadata["stepSource"].(string); stepSource == "goai" {
+				stepReasoning := ts.reasoning.finish()
 				ts.currentStep++
 				// Response is set directly on the chunk by the step loop.
 				// ProviderMetadata is embedded in Metadata (no dedicated StreamChunk field).
@@ -423,7 +493,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				ts.steps = append(ts.steps, StepResult{
 					Number:           ts.currentStep,
 					Text:             ts.stepText.String(),
-					Reasoning:        ts.reasoningBuf.String(),
+					Reasoning:        reasoningText(stepReasoning),
 					ToolCalls:        ts.stepToolCalls,
 					FinishReason:     chunk.FinishReason,
 					Usage:            chunk.Usage,
@@ -444,10 +514,9 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 				ts.stepText.Reset()
 				ts.stepToolCalls = nil
 				ts.stepSources = nil
-				ts.reasoningBuf.Reset()
-				ts.reasoningMeta = nil
 			} else {
 				// Provider-internal step boundary (e.g., Anthropic extended thinking).
+				ts.reasoning.flush()
 				// Preserve existing behavior: extract response, metadata, sources.
 				// This ensures single-step streaming continues to work correctly.
 				// NOTE: Do NOT accumulate usage here with addUsage. Provider-internal
@@ -531,6 +600,7 @@ func (ts *TextStream) consume(rawOut chan<- provider.StreamChunk, textOut chan<-
 			}
 		}
 	}
+	ts.reasoningParts = ts.reasoning.finish()
 }
 
 func (ts *TextStream) buildResult() *TextResult {
@@ -557,7 +627,7 @@ func (ts *TextStream) buildResult() *TextResult {
 		result.Reasoning = reasoningAll.String()
 	} else if text != "" || len(ts.toolCalls) > 0 || ts.finishReason != "" {
 		// Single-step fallback (no multi-step ChunkStepFinish received, but data exists).
-		stepReasoning := ts.reasoningBuf.String()
+		stepReasoning := reasoningText(ts.reasoningParts)
 		result.Steps = []StepResult{{
 			Number:           1,
 			Text:             ts.stepText.String(),
@@ -582,18 +652,7 @@ func (ts *TextStream) buildResult() *TextResult {
 		result.ResponseMessages = ts.responseMessages
 	} else if text != "" || len(result.ToolCalls) > 0 {
 		// Single-step: build a simple assistant message from the result.
-		// Use stepText (text-only, excludes reasoning) for ResponseMessages so reasoning
-		// doesn't get baked into PartText. Pass consolidated reasoning part separately
-		// (matching drainStep: one Part with merged metadata including signatures).
-		var reasoning []provider.Part
-		if ts.reasoningBuf.Len() > 0 || len(ts.reasoningMeta) > 0 {
-			reasoning = []provider.Part{{
-				Type:            provider.PartReasoning,
-				Text:            ts.reasoningBuf.String(),
-				ProviderOptions: ts.reasoningMeta,
-			}}
-		}
-		result.ResponseMessages = buildFinalAssistantMessages(ts.stepText.String(), result.ToolCalls, reasoning)
+		result.ResponseMessages = buildFinalAssistantMessages(ts.stepText.String(), result.ToolCalls, ts.reasoningParts)
 	}
 	return result
 }
@@ -641,6 +700,26 @@ func buildParams(opts options) provider.GenerateParams {
 		CacheTTL:         opts.CacheTTL,
 		ToolChoice:       opts.ToolChoice,
 	}
+}
+
+func setPreviousResponseID(params *provider.GenerateParams, response provider.ResponseMetadata) {
+	if !strings.HasPrefix(response.ID, "resp_") {
+		return
+	}
+	if params.ProviderOptions == nil {
+		params.ProviderOptions = make(map[string]any)
+	}
+	if store, ok := params.ProviderOptions["store"].(bool); ok && !store {
+		return
+	}
+	if _, ok := params.ProviderOptions["previousResponseId"]; ok {
+		return
+	}
+	if _, ok := params.ProviderOptions["previous_response_id"]; ok {
+		return
+	}
+	params.ProviderOptions["previousResponseId"] = response.ID
+	params.ProviderOptions["goaiAutoPreviousResponseID"] = true
 }
 
 func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o options, toolMap map[string]Tool) (_ *TextStream, err error) {
@@ -926,6 +1005,7 @@ func streamWithToolLoop(ctx context.Context, model provider.LanguageModel, o opt
 			totalUsage = addUsage(totalUsage, ds.usage)
 			lastResponse = ds.response
 			lastReasoning = ds.reasoning
+			setPreviousResponseID(&params, ds.response)
 
 			// AgentState: the step's stream has fully drained; tool exec and
 			// stop-predicate evaluation have not started yet. Pollers observing
@@ -1240,6 +1320,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	}
 
 	var totalUsage provider.Usage
+	var lastReasoning []provider.Part
 	var hookStopped bool             // true iff WithStopWhen or OnBeforeStep.Stop broke the loop
 	var stopCause provider.StopCause // classifies how the loop exited (FIX 5)
 
@@ -1330,6 +1411,10 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		}
 		steps = append(steps, stepResult)
 		totalUsage = addUsage(totalUsage, result.Usage)
+		lastReasoning = result.ReasoningParts
+		if len(lastReasoning) == 0 && result.Reasoning != "" {
+			lastReasoning = []provider.Part{{Type: provider.PartReasoning, Text: result.Reasoning}}
+		}
 
 		// AgentState: LLM call for this step is complete; tool exec and
 		// stop-predicate evaluation have not started yet. Pollers observing
@@ -1353,7 +1438,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 
 		if result.FinishReason != provider.FinishToolCalls || (len(result.ToolCalls) == 0 && !hasProviderDefinedTools(params.Tools)) || (len(result.ToolCalls) > 0 && len(toolMap) == 0) {
 			tr := buildTextResult(steps, totalUsage)
-			tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
+			tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, lastReasoning)
 			// Distinguish "model stopped on its own" from "model wants more
 			// tool calls but no tool has Execute" (FIX 11). Both exit cleanly
 			// but mean very different things to consumers.
@@ -1399,11 +1484,8 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 		// Append assistant message with tool calls + tool result messages.
 		// For server-executed tools (no client tool calls), pass reasoning
 		// so the model's thinking is preserved in the continuation.
-		var reasoningParts []provider.Part
-		if result.Reasoning != "" {
-			reasoningParts = []provider.Part{{Type: provider.PartReasoning, Text: result.Reasoning}}
-		}
-		params.Messages = appendToolRoundTrip(params.Messages, result.Text, reasoningParts, result.ToolCalls, toolMessages)
+		params.Messages = appendToolRoundTrip(params.Messages, result.Text, lastReasoning, result.ToolCalls, toolMessages)
+		setPreviousResponseID(&params, result.Response)
 
 		// WithStopWhen (Vercel parity): evaluated AFTER this step's LLM call
 		// AND its tool executions complete. The tool-result messages are
@@ -1436,7 +1518,7 @@ func GenerateText(ctx context.Context, model provider.LanguageModel, opts ...Opt
 	var stepsExhausted bool
 	stopCause, stepsExhausted = finalizeStopCause(hookStopped, stopCause, steps, o.MaxSteps)
 	tr.StepsExhausted = stepsExhausted
-	tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, nil)
+	tr.ResponseMessages = buildResponseMessages(params.Messages[originalLen:], steps, lastReasoning)
 	fireOnFinish(o.OnPanic, o.OnFinish, FinishInfo{
 		StepsExhausted: tr.StepsExhausted,
 		TotalSteps:     len(steps),
@@ -2002,7 +2084,7 @@ func buildTextResult(steps []StepResult, totalUsage provider.Usage) *TextResult 
 // across multiple messages).
 //
 // The reasoning parameter provides thinking/reasoning parts for the final
-// assistant message (streaming path only; GenerateText passes nil). It is
+// assistant message for both synchronous and streaming generation. It is
 // only applied when the delta is empty or the last step had no tool calls
 // (i.e. when we are actually building the final assistant message here).
 func buildResponseMessages(roundTripDelta []provider.Message, steps []StepResult, reasoning []provider.Part) []provider.Message {
@@ -2091,10 +2173,9 @@ func drainStep(
 	out chan<- provider.StreamChunk,
 ) drainResult {
 	var (
-		textBuf       strings.Builder // ChunkText only (reasoning excluded)
-		reasoningBuf  strings.Builder // accumulated reasoning text
-		reasoningMeta map[string]any  // last metadata (contains signature)
-		dr            drainResult
+		textBuf   strings.Builder // ChunkText only (reasoning excluded)
+		reasoning reasoningAccumulator
+		dr        drainResult
 	)
 
 	for chunk := range source {
@@ -2125,20 +2206,7 @@ func drainStep(
 				dr.sources = append(dr.sources, s)
 			}
 		case provider.ChunkReasoning:
-			// Accumulate into a single buffer. The final chunk carries the
-			// signature (text="", metadata={"signature":"..."}); earlier chunks
-			// carry text fragments. Consolidating produces one complete part.
-			if chunk.Text != "" {
-				reasoningBuf.WriteString(chunk.Text)
-			}
-			if chunk.Metadata != nil {
-				if reasoningMeta == nil {
-					reasoningMeta = make(map[string]any)
-				}
-				for k, v := range chunk.Metadata {
-					reasoningMeta[k] = v
-				}
-			}
+			reasoning.add(chunk)
 			if s, ok := chunk.Metadata["source"].(provider.Source); ok {
 				dr.sources = append(dr.sources, s)
 			}
@@ -2150,6 +2218,7 @@ func drainStep(
 				Metadata: chunk.Metadata,
 			})
 		case provider.ChunkStepFinish:
+			reasoning.flush()
 			// Provider-internal step boundary (e.g., Anthropic extended thinking).
 			// Use direct assignment (last value wins), matching ChunkFinish below.
 			// This is correct for both zero-usage providers (Anthropic: 0 overwrites 0)
@@ -2173,6 +2242,7 @@ func drainStep(
 				dr.response.ProviderMetadata[k] = v
 			}
 		case provider.ChunkFinish:
+			reasoning.flush()
 			// Terminal chunk. Use direct assignment for usage (not addUsage) to avoid
 			// double-counting when providers emit both ChunkStepFinish and ChunkFinish
 			// with the same accumulated usage (e.g., Google).
@@ -2209,17 +2279,8 @@ func drainStep(
 	}
 
 	dr.text = textBuf.String()
-	dr.reasoningText = reasoningBuf.String()
-
-	// Consolidate reasoning fragments into one Part (text + signature metadata)
-	// so the codec serializes a single complete block.
-	if reasoningBuf.Len() > 0 || len(reasoningMeta) > 0 {
-		dr.reasoning = []provider.Part{{
-			Type:            provider.PartReasoning,
-			Text:            reasoningBuf.String(),
-			ProviderOptions: reasoningMeta,
-		}}
-	}
+	dr.reasoning = reasoning.finish()
+	dr.reasoningText = reasoningText(dr.reasoning)
 
 	return dr
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -43,6 +43,228 @@ func streamFromChunks(chunks ...provider.StreamChunk) *provider.StreamResult {
 	return &provider.StreamResult{Stream: ch}
 }
 
+func TestDrainStep_PreservesDistinctReasoningBlocks(t *testing.T) {
+	source := make(chan provider.StreamChunk, 8)
+	source <- provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first", Metadata: map[string]any{"reasoningId": "r1:0"}}
+	source <- provider.StreamChunk{Type: provider.ChunkReasoning, Metadata: map[string]any{"reasoningId": "r1:0", "signature": "sig-1"}}
+	source <- provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second", Metadata: map[string]any{"reasoningId": "r2:0", "signature": "sig-2"}}
+	source <- provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop}
+	close(source)
+	out := make(chan provider.StreamChunk, 8)
+
+	result := drainStep(context.Background(), source, out)
+	if len(result.reasoning) != 2 {
+		t.Fatalf("reasoning blocks = %d, want 2", len(result.reasoning))
+	}
+	if result.reasoning[0].Text != "first" || result.reasoning[1].Text != "second" {
+		t.Errorf("reasoning text = %#v", result.reasoning)
+	}
+	if result.reasoning[0].ProviderOptions["signature"] != "sig-1" || result.reasoning[1].ProviderOptions["signature"] != "sig-2" {
+		t.Errorf("reasoning metadata = %#v", result.reasoning)
+	}
+}
+
+func TestReasoningAccumulator_FlushesOnSignatureChange(t *testing.T) {
+	var acc reasoningAccumulator
+	acc.add(provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first", Metadata: map[string]any{"signature": "sig-1"}})
+	acc.add(provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second", Metadata: map[string]any{"signature": "sig-2"}})
+	parts := acc.finish()
+	if len(parts) != 2 || parts[0].Text != "first" || parts[1].Text != "second" {
+		t.Fatalf("parts = %#v, want two signature-bound blocks", parts)
+	}
+}
+
+func TestReasoningAccumulator_UsesExplicitBlockID(t *testing.T) {
+	var acc reasoningAccumulator
+	acc.add(provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first", Metadata: map[string]any{"blockId": "a"}})
+	acc.add(provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second", Metadata: map[string]any{"blockId": "b"}})
+	parts := acc.finish()
+	if len(parts) != 2 {
+		t.Fatalf("parts = %#v, want two explicit blocks", parts)
+	}
+}
+
+func TestReasoningAccumulator_KeyAndSignaturePresenceTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  provider.StreamChunk
+		second provider.StreamChunk
+	}{
+		{
+			name:   "unkeyed to keyed",
+			first:  provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first"},
+			second: provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second", Metadata: map[string]any{"blockId": "b"}},
+		},
+		{
+			name:   "keyed to unkeyed",
+			first:  provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first", Metadata: map[string]any{"blockId": "a"}},
+			second: provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second"},
+		},
+		{
+			name:   "signed to unsigned",
+			first:  provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first", Metadata: map[string]any{"signature": "sig"}},
+			second: provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second"},
+		},
+		{
+			name:   "unsigned to signed",
+			first:  provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first"},
+			second: provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second", Metadata: map[string]any{"signature": "sig"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var acc reasoningAccumulator
+			acc.add(tt.first)
+			acc.add(tt.second)
+			parts := acc.finish()
+			if len(parts) != 2 || parts[0].Text != "first" || parts[1].Text != "second" {
+				t.Fatalf("parts = %#v, want two blocks", parts)
+			}
+		})
+	}
+}
+
+func TestSetPreviousResponseID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		opts map[string]any
+		want any
+	}{
+		{name: "responses id", id: "resp_123", want: "resp_123"},
+		{name: "non responses id", id: "msg_123", want: nil},
+		{name: "store false", id: "resp_123", opts: map[string]any{"store": false}, want: nil},
+		{name: "explicit camel case", id: "resp_123", opts: map[string]any{"previousResponseId": "manual"}, want: "manual"},
+		{name: "explicit wire key", id: "resp_123", opts: map[string]any{"previous_response_id": "manual"}, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := provider.GenerateParams{ProviderOptions: tt.opts}
+			setPreviousResponseID(&params, provider.ResponseMetadata{ID: tt.id})
+			if got := params.ProviderOptions["previousResponseId"]; got != tt.want {
+				t.Errorf("previousResponseId = %v, want %v", got, tt.want)
+			}
+			if tt.name == "explicit wire key" && params.ProviderOptions["previous_response_id"] != "manual" {
+				t.Errorf("explicit wire option was changed: %#v", params.ProviderOptions)
+			}
+		})
+	}
+}
+
+func TestGenerateText_ToolLoopPropagatesPreviousResponseID(t *testing.T) {
+	var calls int
+	var secondOptions map[string]any
+	model := &mockModel{id: "responses", generateFn: func(_ context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
+		calls++
+		if calls == 2 {
+			secondOptions = params.ProviderOptions
+			return &provider.GenerateResult{Text: "done", FinishReason: provider.FinishStop, Response: provider.ResponseMetadata{ID: "resp_456"}}, nil
+		}
+		return &provider.GenerateResult{
+			ToolCalls:    []provider.ToolCall{{ID: "call-1", Name: "lookup", Input: json.RawMessage(`{}`)}},
+			FinishReason: provider.FinishToolCalls,
+			Response:     provider.ResponseMetadata{ID: "resp_123"},
+		}, nil
+	}}
+
+	_, err := GenerateText(t.Context(), model,
+		WithPrompt("lookup"), WithMaxSteps(3),
+		WithTools(Tool{Name: "lookup", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondOptions["previousResponseId"] != "resp_123" {
+		t.Fatalf("second request options = %#v", secondOptions)
+	}
+}
+
+func TestStreamText_ToolLoopPropagatesPreviousResponseID(t *testing.T) {
+	var calls int
+	var secondOptions map[string]any
+	model := &mockModel{id: "responses", streamFn: func(_ context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+		calls++
+		if calls == 2 {
+			secondOptions = params.ProviderOptions
+			return streamFromChunks(
+				provider.StreamChunk{Type: provider.ChunkText, Text: "done"},
+				provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop, Response: provider.ResponseMetadata{ID: "resp_456"}},
+			), nil
+		}
+		return streamFromChunks(
+			provider.StreamChunk{Type: provider.ChunkToolCall, ToolCallID: "call-1", ToolName: "lookup", ToolInput: `{}`},
+			provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishToolCalls, Response: provider.ResponseMetadata{ID: "resp_123"}},
+		), nil
+	}}
+
+	stream, err := StreamText(t.Context(), model,
+		WithPrompt("lookup"), WithMaxSteps(3),
+		WithTools(Tool{Name: "lookup", Execute: func(context.Context, json.RawMessage) (string, error) { return "ok", nil }}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.Stream() {
+	}
+	if err := stream.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if secondOptions["previousResponseId"] != "resp_123" {
+		t.Fatalf("second request options = %#v", secondOptions)
+	}
+}
+
+func TestGenerateText_ResponseMessagesPreserveReasoningParts(t *testing.T) {
+	model := &mockModel{id: "responses", generateFn: func(context.Context, provider.GenerateParams) (*provider.GenerateResult, error) {
+		return &provider.GenerateResult{
+			Text:      "answer",
+			Reasoning: "think",
+			ReasoningParts: []provider.Part{{
+				Type: provider.PartReasoning,
+				Text: "think",
+				ProviderOptions: map[string]any{
+					"openai": map[string]any{"itemId": "rs-1", "encryptedContent": "opaque"},
+				},
+			}},
+			FinishReason: provider.FinishStop,
+		}, nil
+	}}
+	result, err := GenerateText(t.Context(), model, WithPrompt("answer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.ResponseMessages) != 1 || len(result.ResponseMessages[0].Content) != 2 {
+		t.Fatalf("ResponseMessages = %#v", result.ResponseMessages)
+	}
+	if result.ResponseMessages[0].Content[0].ProviderOptions["openai"].(map[string]any)["encryptedContent"] != "opaque" {
+		t.Fatalf("reasoning part lost metadata: %#v", result.ResponseMessages[0].Content[0])
+	}
+}
+
+func TestStreamText_ResponseMessagesPreserveReasoningBlocks(t *testing.T) {
+	model := &mockModel{id: "responses", streamFn: func(context.Context, provider.GenerateParams) (*provider.StreamResult, error) {
+		return streamFromChunks(
+			provider.StreamChunk{Type: provider.ChunkReasoning, Text: "first", Metadata: map[string]any{"reasoningId": "r1:0"}},
+			provider.StreamChunk{Type: provider.ChunkReasoning, Text: "second", Metadata: map[string]any{"reasoningId": "r2:0"}},
+			provider.StreamChunk{Type: provider.ChunkText, Text: "answer"},
+			provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},
+		), nil
+	}}
+	stream, err := StreamText(t.Context(), model, WithPrompt("answer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range stream.Stream() {
+	}
+	result := stream.Result()
+	if len(result.ResponseMessages) != 1 || len(result.ResponseMessages[0].Content) != 3 {
+		t.Fatalf("ResponseMessages = %#v", result.ResponseMessages)
+	}
+	if result.ResponseMessages[0].Content[0].Text != "first" || result.ResponseMessages[0].Content[1].Text != "second" {
+		t.Fatalf("reasoning blocks = %#v", result.ResponseMessages[0].Content)
+	}
+}
+
 // --- StreamText tests ---
 
 func TestStreamText_Stream(t *testing.T) {
@@ -1117,8 +1339,8 @@ func TestGenerateText_ToolLoop_ServerTool(t *testing.T) {
 		WithPrompt("weather in Singapore?"),
 		WithMaxSteps(3),
 		WithTools(Tool{
-			Name:               "web_search",
-			Description:        "Search the web",
+			Name:                "web_search",
+			Description:         "Search the web",
 			ProviderDefinedType: "openrouter:web_search",
 		}),
 	)
@@ -2506,8 +2728,8 @@ func TestStreamText_ToolLoop_ServerTool(t *testing.T) {
 		WithPrompt("weather?"),
 		WithMaxSteps(3),
 		WithTools(Tool{
-			Name:               "web_search",
-			Description:        "Search the web",
+			Name:                "web_search",
+			Description:         "Search the web",
 			ProviderDefinedType: "openrouter:web_search",
 		}),
 	)

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -2183,6 +2183,165 @@ func TestParseResponsesResult_ReasoningSummary(t *testing.T) {
 	}
 }
 
+func TestParseResponsesResult_ReasoningEncryptedContent(t *testing.T) {
+	body := `{
+		"id": "resp-1",
+		"model": "o3",
+		"status": "completed",
+		"output": [{"type": "reasoning", "id": "rs-1", "encrypted_content": "opaque-state", "summary": [{"type": "summary_text", "text": "think"}]}]
+	}`
+
+	result, err := parseResponsesResult([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts = %d, want 1", len(result.ReasoningParts))
+	}
+	openAI, ok := result.ReasoningParts[0].ProviderOptions["openai"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing openai reasoning metadata: %#v", result.ReasoningParts[0].ProviderOptions)
+	}
+	if openAI["itemId"] != "rs-1" || openAI["encryptedContent"] != "opaque-state" {
+		t.Errorf("reasoning metadata = %#v", openAI)
+	}
+}
+
+func TestConvertToResponsesInput_ReasoningEncryptedContent(t *testing.T) {
+	input := convertToResponsesInput([]provider.Message{{
+		Role:    provider.RoleAssistant,
+		Content: []provider.Part{openAIReasoningPart("rs-1", "think", "opaque-state")},
+	}})
+	if len(input) != 1 {
+		t.Fatalf("input length = %d, want 1", len(input))
+	}
+	if input[0]["type"] != "reasoning" || input[0]["id"] != "rs-1" || input[0]["encrypted_content"] != "opaque-state" {
+		t.Errorf("reasoning input = %#v", input[0])
+	}
+	if got := input[0]["summary"].([]map[string]any)[0]["text"]; got != "think" {
+		t.Errorf("summary text = %v, want think", got)
+	}
+}
+
+func TestReasoningInputItem_RequiresOpenAIState(t *testing.T) {
+	for name, part := range map[string]provider.Part{
+		"missing provider metadata": {Type: provider.PartReasoning, Text: "think"},
+		"empty openai metadata":     {Type: provider.PartReasoning, ProviderOptions: map[string]any{"openai": map[string]any{}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if item, ok := reasoningInputItem(part); ok || item != nil {
+				t.Fatalf("reasoningInputItem() = %#v, %v; want nil, false", item, ok)
+			}
+		})
+	}
+}
+
+func TestBuildResponsesRequest_AutoContinuationInput(t *testing.T) {
+	body := buildResponsesRequest(provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "original"}}},
+			{Role: provider.RoleAssistant, Content: []provider.Part{{Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "lookup", ToolInput: json.RawMessage(`{}`)}}},
+			{Role: provider.RoleTool, Content: []provider.Part{{Type: provider.PartToolResult, ToolCallID: "call-1", ToolOutput: "result"}}},
+		},
+		ProviderOptions: map[string]any{
+			"previousResponseId":         "resp-1",
+			"goaiAutoPreviousResponseID": true,
+		},
+	}, "o3", false)
+	input := body["input"].([]map[string]any)
+	if len(input) != 1 || input[0]["type"] != "function_call_output" || input[0]["call_id"] != "call-1" {
+		t.Fatalf("auto continuation input = %#v", input)
+	}
+}
+
+func TestResponsesToolContinuation_HTTPRoundTrip(t *testing.T) {
+	var requests []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var request map[string]any
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Fatal(err)
+		}
+		requests = append(requests, request)
+		w.Header().Set("Content-Type", "application/json")
+		if len(requests) == 1 {
+			_, _ = fmt.Fprint(w, `{"id":"resp-1","model":"o3","status":"completed","output":[{"type":"function_call","id":"fc-1","call_id":"call-1","name":"lookup","arguments":"{}"}]}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"id":"resp-2","model":"o3","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}]}`)
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	first, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "lookup"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleAssistant, Content: append(first.ReasoningParts, provider.Part{Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "lookup", ToolInput: json.RawMessage(`{}`)})},
+			{Role: provider.RoleTool, Content: []provider.Part{{Type: provider.PartToolResult, ToolCallID: "call-1", ToolOutput: "result"}}},
+		},
+		ProviderOptions: map[string]any{
+			"previousResponseId":         first.Response.ID,
+			"goaiAutoPreviousResponseID": true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(requests))
+	}
+	if requests[1]["previous_response_id"] != "resp-1" {
+		t.Errorf("previous_response_id = %v", requests[1]["previous_response_id"])
+	}
+	input := requests[1]["input"].([]any)
+	if len(input) != 1 || input[0].(map[string]any)["type"] != "function_call_output" {
+		t.Errorf("continuation input = %#v", input)
+	}
+}
+
+func TestStreamResponses_ReasoningEncryptedContent(t *testing.T) {
+	sse := "event: response.output_item.added\n" +
+		`data: {"output_index":0,"item":{"type":"reasoning","id":"rs-1"}}` + "\n\n" +
+		"event: response.reasoning_summary_text.delta\n" +
+		`data: {"item_id":"rs-1","summary_index":0,"delta":"think"}` + "\n\n" +
+		"event: response.output_item.done\n" +
+		`data: {"output_index":0,"item":{"type":"reasoning","id":"rs-1","encrypted_content":"opaque-state"}}` + "\n\n" +
+		"event: response.completed\n" +
+		`data: {"response":{"id":"resp-1","model":"o3"}}` + "\n\n"
+	out := make(chan provider.StreamChunk, 8)
+	streamResponses(context.Background(), io.NopCloser(strings.NewReader(sse)), out)
+
+	var chunks []provider.StreamChunk
+	for chunk := range out {
+		chunks = append(chunks, chunk)
+	}
+	var encrypted bool
+	for _, chunk := range chunks {
+		if openAI, ok := chunk.Metadata["openai"].(map[string]any); ok && openAI["encryptedContent"] == "opaque-state" {
+			encrypted = true
+		}
+	}
+	if !encrypted {
+		t.Fatal("stream did not preserve encrypted reasoning content")
+	}
+}
+
+func TestActiveReasoningForEvent_PrefersCanonicalItemID(t *testing.T) {
+	active := map[int]*responsesReasoning{
+		0: {canonicalID: "rs-0"},
+		1: {canonicalID: "rs-1"},
+	}
+	index, reasoning := activeReasoningForEvent(active, 1, "rs-0")
+	if index != 0 || reasoning.canonicalID != "rs-0" {
+		t.Fatalf("selected reasoning = %d, %#v; want item 0", index, reasoning)
+	}
+}
+
 func TestParseResponsesResult_CachedTokens(t *testing.T) {
 	body := `{
 		"id": "resp-1",

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -46,6 +46,9 @@ func buildResponsesRequest(params provider.GenerateParams, modelID string, strea
 
 	// Messages → Responses API "input" format.
 	body["input"] = convertToResponsesInput(params.Messages)
+	if auto, ok := params.ProviderOptions["goaiAutoPreviousResponseID"].(bool); ok && auto {
+		body["input"] = convertAutoContinuationInput(params.Messages)
+	}
 
 	if params.MaxOutputTokens > 0 {
 		body["max_output_tokens"] = params.MaxOutputTokens
@@ -168,9 +171,10 @@ func applyResponsesProviderOptions(body map[string]any, opts map[string]any) {
 
 	// Known options that should NOT be passed through to the body directly.
 	consumed := map[string]bool{
-		"structuredOutputs": true,
-		"strictJsonSchema":  true,
-		"useResponsesAPI":   true,
+		"structuredOutputs":          true,
+		"strictJsonSchema":           true,
+		"useResponsesAPI":            true,
+		"goaiAutoPreviousResponseID": true,
 	}
 
 	// Item 2: store from ProviderOptions (no longer hardcoded false).
@@ -336,13 +340,17 @@ func convertToResponsesInput(msgs []provider.Message) []map[string]any {
 		case provider.RoleAssistant:
 			var items []map[string]any
 			var textParts []string
+			hasReasoningItem := false
 
 			for _, part := range msg.Content {
 				switch part.Type {
 				case provider.PartText:
 					textParts = append(textParts, part.Text)
 				case provider.PartReasoning:
-					if part.Text != "" {
+					if item, ok := reasoningInputItem(part); ok {
+						items = append(items, item)
+						hasReasoningItem = true
+					} else if part.Text != "" {
 						textParts = append(textParts, part.Text)
 					}
 				case provider.PartToolCall:
@@ -363,14 +371,19 @@ func convertToResponsesInput(msgs []provider.Message) []map[string]any {
 			}
 
 			if len(textParts) > 0 {
-				items = append([]map[string]any{{
+				message := map[string]any{
 					"type": "message",
 					"role": "assistant",
 					"content": []map[string]any{{
 						"type": "output_text",
 						"text": strings.Join(textParts, "\n"),
 					}},
-				}}, items...)
+				}
+				if hasReasoningItem {
+					items = append(items, message)
+				} else {
+					items = append([]map[string]any{message}, items...)
+				}
 			}
 
 			result = append(result, items...)
@@ -422,6 +435,38 @@ func convertToResponsesInput(msgs []provider.Message) []map[string]any {
 	return result
 }
 
+func convertAutoContinuationInput(msgs []provider.Message) []map[string]any {
+	var toolMessages []provider.Message
+	for i := len(msgs) - 1; i >= 0 && msgs[i].Role == provider.RoleTool; i-- {
+		toolMessages = append(toolMessages, msgs[i])
+	}
+	slices.Reverse(toolMessages)
+	return convertToResponsesInput(toolMessages)
+}
+
+func reasoningInputItem(part provider.Part) (map[string]any, bool) {
+	openAI, ok := part.ProviderOptions["openai"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	itemID, _ := openAI["itemId"].(string)
+	encryptedContent, _ := openAI["encryptedContent"].(string)
+	if itemID == "" && encryptedContent == "" {
+		return nil, false
+	}
+	item := map[string]any{"type": "reasoning"}
+	if itemID != "" {
+		item["id"] = itemID
+	}
+	if encryptedContent != "" {
+		item["encrypted_content"] = encryptedContent
+	}
+	if part.Text != "" {
+		item["summary"] = []map[string]any{{"type": "summary_text", "text": part.Text}}
+	}
+	return item, true
+}
+
 func partsToText(parts []provider.Part) string {
 	var texts []string
 	for _, p := range parts {
@@ -449,6 +494,30 @@ type responsesReasoning struct {
 	// lastSummary is the summary_index of the previous delta, or -1 before the
 	// first one. Segments are only delimited by that index, never by the text.
 	lastSummary int
+}
+
+func activeReasoningForEvent(active map[int]*responsesReasoning, current int, itemID string) (int, *responsesReasoning) {
+	for index, reasoning := range active {
+		if reasoning.canonicalID == itemID {
+			return index, reasoning
+		}
+	}
+	if reasoning, ok := active[current]; ok {
+		return current, reasoning
+	}
+	return -1, nil
+}
+
+func openAIReasoningPart(itemID, text, encryptedContent string) provider.Part {
+	openAI := map[string]any{"itemId": itemID}
+	if encryptedContent != "" {
+		openAI["encryptedContent"] = encryptedContent
+	}
+	return provider.Part{
+		Type:            provider.PartReasoning,
+		Text:            text,
+		ProviderOptions: map[string]any{"openai": openAI},
+	}
 }
 
 // summarySeparator delimits consecutive reasoning summaries. Their boundary
@@ -526,16 +595,14 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 			if json.Unmarshal([]byte(data), &ev) == nil && ev.Delta != "" {
 				// Use canonical ID from activeReasoning if available.
 				id, text := ev.ItemID, ev.Delta
-				if currentReasoningIdx >= 0 {
-					if ar := activeReasoning[currentReasoningIdx]; ar != nil {
-						id = ar.canonicalID
-						// A new summary_index opens a separate summary: carry the
-						// boundary in the text, since the deltas never bring it.
-						if ar.lastSummary >= 0 && ev.SummaryIndex != ar.lastSummary {
-							text = summarySeparator + text
-						}
-						ar.lastSummary = ev.SummaryIndex
+				if idx, ar := activeReasoningForEvent(activeReasoning, currentReasoningIdx, ev.ItemID); idx >= 0 {
+					id = ar.canonicalID
+					// A new summary_index opens a separate summary: carry the
+					// boundary in the text, since the deltas never bring it.
+					if ar.lastSummary >= 0 && ev.SummaryIndex != ar.lastSummary {
+						text = summarySeparator + text
 					}
+					ar.lastSummary = ev.SummaryIndex
 				}
 				if !provider.TrySend(ctx, out, provider.StreamChunk{
 					Type: provider.ChunkReasoning,
@@ -645,6 +712,33 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 				_ = json.Unmarshal(ev.Item, &itemHead)
 				switch itemHead.Type {
 				case "reasoning":
+					var item struct {
+						ID               string `json:"id"`
+						EncryptedContent string `json:"encrypted_content"`
+					}
+					_ = json.Unmarshal(ev.Item, &item)
+					if active := activeReasoning[ev.OutputIndex]; active != nil && item.EncryptedContent != "" {
+						id := active.canonicalID
+						if id == "" {
+							id = item.ID
+						}
+						index := active.lastSummary
+						if index < 0 {
+							index = 0
+						}
+						if !provider.TrySend(ctx, out, provider.StreamChunk{
+							Type: provider.ChunkReasoning,
+							Metadata: map[string]any{
+								"reasoningId": fmt.Sprintf("%s:%d", id, index),
+								"openai": map[string]any{
+									"itemId":           id,
+									"encryptedContent": item.EncryptedContent,
+								},
+							},
+						}) {
+							return
+						}
+					}
 					delete(activeReasoning, ev.OutputIndex)
 					if currentReasoningIdx == ev.OutputIndex {
 						currentReasoningIdx = -1
@@ -695,14 +789,14 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 		case "response.completed", "response.incomplete":
 			var ev struct {
 				Response struct {
-					ID    string `json:"id"`
-					Model string `json:"model"`
+					ID                string `json:"id"`
+					Model             string `json:"model"`
 					IncompleteDetails *struct {
 						Reason string `json:"reason"`
 					} `json:"incomplete_details"`
 					Usage struct {
-						InputTokens  int `json:"input_tokens"`
-						OutputTokens int `json:"output_tokens"`
+						InputTokens         int `json:"input_tokens"`
+						OutputTokens        int `json:"output_tokens"`
 						OutputTokensDetails *struct {
 							ReasoningTokens int `json:"reasoning_tokens"`
 						} `json:"output_tokens_details"`
@@ -862,10 +956,10 @@ type responsesResult struct {
 		Type    string `json:"type"`
 		Role    string `json:"role"`
 		Content []struct {
-			Type        string              `json:"type"`
-			Text        string              `json:"text"`
+			Type        string                `json:"type"`
+			Text        string                `json:"text"`
 			Annotations []responsesAnnotation `json:"annotations,omitempty"`
-			Logprobs    *json.RawMessage    `json:"logprobs,omitempty"`
+			Logprobs    *json.RawMessage      `json:"logprobs,omitempty"`
 		} `json:"content,omitempty"`
 
 		// function_call fields
@@ -874,16 +968,17 @@ type responsesResult struct {
 		Arguments string `json:"arguments,omitempty"`
 
 		// reasoning fields
-		ID      string `json:"id,omitempty"`
-		Summary []struct {
+		ID               string `json:"id,omitempty"`
+		EncryptedContent string `json:"encrypted_content,omitempty"`
+		Summary          []struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
 		} `json:"summary,omitempty"`
 	} `json:"output"`
 
 	Usage *struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
+		InputTokens         int `json:"input_tokens"`
+		OutputTokens        int `json:"output_tokens"`
 		OutputTokensDetails *struct {
 			ReasoningTokens int `json:"reasoning_tokens"`
 		} `json:"output_tokens_details,omitempty"`
@@ -945,6 +1040,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 	// Extract text, tool calls, sources, logprobs from output.
 	var textParts []string
 	var reasoningParts []string
+	var reasoningItems []provider.Part
 	var hasFunctionCall bool
 	providerMeta := map[string]any{}
 	var allLogprobs []any
@@ -984,15 +1080,20 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 				Input: json.RawMessage(item.Arguments),
 			})
 		case "reasoning":
+			var itemText []string
 			for _, s := range item.Summary {
 				if s.Text != "" {
 					reasoningParts = append(reasoningParts, s.Text)
+					itemText = append(itemText, s.Text)
 					reasoning, _ := providerMeta["reasoning"].([]map[string]any)
 					providerMeta["reasoning"] = append(reasoning, map[string]any{
 						"type": s.Type,
 						"text": s.Text,
 					})
 				}
+			}
+			if len(itemText) > 0 || item.EncryptedContent != "" {
+				reasoningItems = append(reasoningItems, openAIReasoningPart(item.ID, strings.Join(itemText, summarySeparator), item.EncryptedContent))
 			}
 		default:
 			if isServerExecutedItem(item.Type) && i < len(rawOutput.Output) {
@@ -1020,6 +1121,7 @@ func parseResponsesResult(body []byte) (*provider.GenerateResult, error) {
 	// Each entry is a distinct summary; joining them bare merges the markdown
 	// at the seam, same as in the streaming path.
 	result.Reasoning = strings.Join(reasoningParts, summarySeparator)
+	result.ReasoningParts = reasoningItems
 
 	if len(allLogprobs) > 0 {
 		providerMeta["logprobs"] = allLogprobs

--- a/provider/types.go
+++ b/provider/types.go
@@ -189,6 +189,11 @@ type GenerateResult struct {
 	// provider does not return reasoning or thinking is disabled.
 	Reasoning string
 
+	// ReasoningParts preserves provider-native reasoning blocks for replay.
+	// It is optional; providers that only expose aggregate reasoning may leave
+	// it nil and continue using Reasoning.
+	ReasoningParts []Part
+
 	// ToolCalls requested by the model.
 	ToolCalls []ToolCall
 


### PR DESCRIPTION
## Summary
- preserve OpenAI encrypted reasoning state across streaming and non-streaming replay
- keep distinct reasoning blocks and metadata boundaries
- propagate stateful previous response IDs through tool loops with fresh tool-result input
- add regression coverage and ignore the review report directory

## Verification
- go test ./... passed with 2,852 tests
- edited helper paths have 100% coverage
- independent review approved with no blocking findings