### PR TITLE
chore: prepare v0.9.3 release

### DIFF
--- a/docs/public/versions.json
+++ b/docs/public/versions.json
@@ -1,10 +1,15 @@
 {
-  "latest": "v0.9.2",
+  "latest": "v0.9.3",
   "versions": [
+    {
+      "tag": "v0.9.3",
+      "date": "2026-07-31",
+      "label": "v0.9.3 (latest)"
+    },
     {
       "tag": "v0.9.2",
       "date": "2026-07-28",
-      "label": "v0.9.2 (latest)"
+      "label": "v0.9.2"
     },
     {
       "tag": "v0.9.1",


### PR DESCRIPTION
## Summary
- mark v0.9.3 as the latest documentation version
- add the 2026-07-31 release entry

## Verification
- go test ./... passed
- VitePress documentation build passed
- versions.json validated as JSON