### PR TITLE
Include attempted name and available tools in unknown-tool result

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1714,7 +1714,13 @@ func executeToolsParallel(
 			// panic prevents Execute from running (the tool should not execute if the
 			// pre-hook crashed). For unknown tools, Execute never runs anyway, so both
 			// hooks fire independently for observability completeness.
-			results[i] = toolOutput{index: i, err: ErrUnknownTool}
+			//
+			// Wrap ErrUnknownTool (preserving errors.Is) with the attempted name and
+			// the registered tools: models occasionally emit corrupted tool names,
+			// and seeing the valid list lets them self-correct in one step.
+			unknownErr := fmt.Errorf("%w %q; available tools: %s",
+				ErrUnknownTool, tc.Name, strings.Join(slices.Sorted(maps.Keys(toolMap)), ", "))
+			results[i] = toolOutput{index: i, err: unknownErr}
 			for _, fn := range hooks.onToolCallStart {
 				func(f func(ToolCallStartInfo)) {
 					defer func() {
@@ -1737,7 +1743,7 @@ func executeToolsParallel(
 						ToolName:   tc.Name,
 						Step:       step,
 						Input:      tc.Input,
-						Error:      ErrUnknownTool,
+						Error:      unknownErr,
 					})
 				}(fn)
 			}

--- a/generate_test.go
+++ b/generate_test.go
@@ -1235,7 +1235,7 @@ func TestGenerateText_ToolLoop_UnknownTool(t *testing.T) {
 			// Check tool result is "error: unknown tool".
 			for _, msg := range params.Messages {
 				for _, p := range msg.Content {
-					if p.Type == provider.PartToolResult && p.ToolOutput == "error: goai: unknown tool" {
+					if p.Type == provider.PartToolResult && p.ToolOutput == `error: goai: unknown tool "nonexistent"; available tools: known` {
 						return &provider.GenerateResult{Text: "ok", FinishReason: provider.FinishStop}, nil
 					}
 				}
@@ -3244,7 +3244,7 @@ func TestStreamText_ToolLoop_UnknownTool(t *testing.T) {
 			// Check tool result has unknown tool error.
 			for _, msg := range params.Messages {
 				for _, p := range msg.Content {
-					if p.Type == provider.PartToolResult && p.ToolOutput == "error: goai: unknown tool" {
+					if p.Type == provider.PartToolResult && p.ToolOutput == `error: goai: unknown tool "nonexistent"; available tools: known` {
 						return streamFromChunks(
 							provider.StreamChunk{Type: provider.ChunkText, Text: "ok"},
 							provider.StreamChunk{Type: provider.ChunkFinish, FinishReason: provider.FinishStop},

--- a/generate_test.go
+++ b/generate_test.go
@@ -1270,6 +1270,9 @@ func TestGenerateText_ToolLoop_UnknownTool(t *testing.T) {
 	if !errors.Is(capturedInfo.Error, ErrUnknownTool) {
 		t.Errorf("ToolCallInfo.Error = %v, want ErrUnknownTool", capturedInfo.Error)
 	}
+	if got := capturedInfo.Error.Error(); got != `goai: unknown tool "nonexistent"; available tools: known` {
+		t.Errorf("ToolCallInfo.Error = %q, want enriched unknown-tool error", got)
+	}
 }
 
 func TestGenerateText_ToolLoop_NoExecuteNoLoop(t *testing.T) {
@@ -3284,6 +3287,9 @@ func TestStreamText_ToolLoop_UnknownTool(t *testing.T) {
 	}
 	if !errors.Is(capturedInfo.Error, ErrUnknownTool) {
 		t.Errorf("ToolCallInfo.Error = %v, want ErrUnknownTool", capturedInfo.Error)
+	}
+	if got := capturedInfo.Error.Error(); got != `goai: unknown tool "nonexistent"; available tools: known` {
+		t.Errorf("ToolCallInfo.Error = %q, want enriched unknown-tool error", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

When the model calls a tool that isn't in the tool map, the tool result it sees is the bare sentinel `error: goai: unknown tool`. In production we see models occasionally emit corrupted tool names at a low rate (~0.1–0.2% of tool calls) — e.g. `semanticSearter`, `keywordSearve` for `semanticSearch`/`keywordSearch`. Runs recover because the error is fed back, but with the bare message the model has to notice its own typo unaided, sometimes burning extra turns. Naming the attempted tool and the valid options makes recovery a deterministic one-shot:

```
error: goai: unknown tool "semanticSearter"; available tools: keywordSearch, readDoc, semanticSearch
```

## Changes

- Wrap `ErrUnknownTool` with `%w` in the unknown-tool branch of `executeToolsParallel`, adding the attempted name and the sorted registered tool names. `errors.Is(err, ErrUnknownTool)` continues to hold.
- Pass the same enriched error to the `OnToolCall` observability hook.
- Update the two tests asserting the exact tool-result string (covers both `GenerateText` and `StreamText` paths).

Tool names are sorted for deterministic output; long tool lists are bounded by the existing 500-rune truncation in `buildToolMessages`.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (no issues in changed files; 12 pre-existing issues elsewhere on main)
- [x] New tests added for new functionality (existing unknown-tool tests updated to assert the enriched message on both generate and stream paths)
- [ ] Examples updated if public API changed (n/a — no public API change)

## Related issues

n/a