### PR TITLE
feat: add video generation with Google Veo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Inspired by the [Vercel AI SDK](https://sdk.vercel.ai). The same clean abstracti
 
 ## Features
 
-- **7 core functions**: `GenerateText`, `StreamText`, `GenerateObject[T]`, `StreamObject[T]`, `Embed`, `EmbedMany`, `GenerateImage`
+- **8 core functions**: `GenerateText`, `StreamText`, `GenerateObject[T]`, `StreamObject[T]`, `Embed`, `EmbedMany`, `GenerateImage`, `GenerateVideo`
 - **25+ providers**: OpenAI, Anthropic, Google, Bedrock, Azure, Vertex, Mistral, xAI, Groq, Cohere, DeepSeek, MiniMax, Fireworks, Together, DeepInfra, OpenRouter, Requesty, Perplexity, Cerebras, Ollama, vLLM, RunPod, Cloudflare Workers AI, FPT Smart Cloud, NVIDIA NIM, llama.cpp, + generic OpenAI-compatible
 - **Auto tool loop**: Define tools with `Execute` handlers, set `MaxSteps` for `GenerateText` and `StreamText`
 - **Structured output**: `GenerateObject[T]` auto-generates JSON Schema from Go types via reflection
@@ -327,6 +327,29 @@ os.WriteFile("sunset.png", result.Images[0].Data, 0644)
 ```
 
 Also supported: Google Imagen (`google.Image("imagen-4.0-generate-001")`) and Vertex AI (`vertex.Image(...)`).
+
+## Video Generation
+
+Google Veo video generation uses a long-running operation. GoAI starts the operation, polls until completion, and downloads the resulting video bytes.
+
+```go
+ctx := context.Background()
+model := google.Video("veo-3.1-generate-preview")
+
+result, err := goai.GenerateVideo(ctx, model,
+	goai.WithVideoPrompt("A paper plane taking flight at sunrise"),
+	goai.WithVideoAspectRatio("16:9"),
+	goai.WithVideoResolution("720p"),
+	goai.WithVideoDuration(8*time.Second),
+	goai.WithVideoAudio(true),
+)
+if err != nil {
+	log.Fatal(err)
+}
+os.WriteFile("plane.mp4", result.Video.Data, 0644)
+```
+
+Image-to-video is supported with `WithVideoImage`. First/last frames and image references are available through `WithVideoFrameImages` and `WithVideoInputReferences`.
 
 ## Observability
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,7 +28,7 @@ import (
 
 ## Core API
 
-### 7 Top-Level Functions
+### 8 Top-Level Functions
 
 | Function                                      | Purpose                         | Returns                     |
 | --------------------------------------------- | ------------------------------- | --------------------------- |
@@ -39,10 +39,11 @@ import (
 | `goai.Embed(ctx, model, text, opts...)`       | Single text embedding           | `(*EmbedResult, error)`     |
 | `goai.EmbedMany(ctx, model, texts, opts...)`  | Batch embeddings (auto-chunked) | `(*EmbedManyResult, error)` |
 | `goai.GenerateImage(ctx, model, imgOpts...)`  | Image generation                | `(*ImageResult, error)`     |
+| `goai.GenerateVideo(ctx, model, vidOpts...)`  | Video generation                | `(*VideoResult, error)`     |
 
 ### Model Constructors
 
-Each provider has `Chat()`, and optionally `Embedding()` and `Image()`:
+Each provider has `Chat()`, and optionally `Embedding()`, `Image()`, and `Video()`:
 
 ```go
 // Language models
@@ -64,6 +65,9 @@ ollama.Embedding("nomic-embed-text")
 // Image models
 openai.Image("gpt-image-1")
 google.Image("imagen-4.0-generate-001")
+
+// Video models
+google.Video("veo-3.1-generate-preview")
 ```
 
 ### Auth - Auto-Resolved from Environment
@@ -270,7 +274,20 @@ result, err := goai.GenerateImage(ctx, openai.Image("gpt-image-1"),
 
 **Note**: `GenerateImage` uses `ImageOption` (not `Option`): `WithImagePrompt`, `WithImageCount`, `WithImageSize`, `WithAspectRatio`, `WithImageMaxRetries`, `WithImageTimeout`, `WithImageProviderOptions`.
 
-### 9. Provider-Defined Tools (Server-Side)
+### 9. Video Generation
+
+```go
+result, err := goai.GenerateVideo(ctx, google.Video("veo-3.1-generate-preview"),
+    goai.WithVideoPrompt("A gopher writing Go code"),
+    goai.WithVideoAspectRatio("16:9"),
+    goai.WithVideoDuration(8*time.Second),
+)
+// result.Video.Data = raw bytes, result.Video.MediaType = "video/mp4"
+```
+
+Video generation handles asynchronous operation polling and authenticated downloads. Use `WithVideoImage` for image-to-video and `WithVideoPollTimeout` to bound long-running operations.
+
+### 10. Provider-Defined Tools (Server-Side)
 
 Built-in tools executed by the provider, not your code:
 
@@ -310,7 +327,7 @@ Available provider tools:
 - **xAI**: `WebSearch()`, `XSearch()`
 - **Groq**: `BrowserSearch()`
 
-### 10. Observability Hooks
+### 11. Observability Hooks
 
 ```go
 result, err := goai.GenerateText(ctx, model,

--- a/docs/api/core-functions.md
+++ b/docs/api/core-functions.md
@@ -1,6 +1,6 @@
 ---
 title: Core Functions
-description: "API reference for GoAI's core functions including GenerateText, StreamText, GenerateObject, StreamObject, Embed, EmbedMany, and GenerateImage."
+description: "API reference for GoAI's core functions including GenerateText, StreamText, GenerateObject, StreamObject, Embed, EmbedMany, GenerateImage, and GenerateVideo."
 ---
 
 # Core Functions
@@ -374,6 +374,34 @@ if err != nil {
     log.Fatal(err)
 }
 fmt.Printf("Generated %d image(s)\n", len(result.Images))
+```
+
+---
+
+## GenerateVideo
+
+Generates videos from text and media prompts. Long-running provider operations are polled until completion.
+
+```go
+func GenerateVideo(ctx context.Context, model provider.VideoModel, opts ...VideoOption) (*VideoResult, error)
+```
+
+**Parameters:**
+
+| Name    | Type                  | Description                                                        |
+| ------- | --------------------- | ------------------------------------------------------------------ |
+| `ctx`   | `context.Context`     | Request context.                                                   |
+| `model` | `provider.VideoModel` | The video model to use.                                            |
+| `opts`  | `...VideoOption`      | Video prompt, media, output settings, retry, timeout, and polling. |
+
+**Returns:** `*VideoResult` with `Video` for the first result and `Videos` for all generated videos.
+
+```go
+result, err := goai.GenerateVideo(ctx, google.Video("veo-3.1-generate-preview"),
+    goai.WithVideoPrompt("A cinematic ocean scene"),
+    goai.WithVideoAspectRatio("16:9"),
+    goai.WithVideoDuration(8*time.Second),
+)
 ```
 
 ---

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -1,11 +1,11 @@
 ---
 title: Options
-description: "Reference for all GoAI option functions. Configure prompts, tools, temperature, retries, streaming, structured output, embeddings, and image generation."
+description: "Reference for all GoAI option functions. Configure prompts, tools, temperature, retries, streaming, structured output, embeddings, image generation, and video generation."
 ---
 
 # Options
 
-All option functions for configuring GoAI calls. Options follow the functional options pattern - pass them as variadic arguments to `GenerateText`, `StreamText`, `GenerateObject`, `StreamObject`, `Embed`, or `EmbedMany`.
+All option functions for configuring GoAI calls. Options follow the functional options pattern. Text, object, and embedding calls use `Option`; image and video generation use their dedicated option types.
 
 Import: `github.com/zendev-sh/goai`
 
@@ -32,6 +32,8 @@ func WithPrompt(s string) Option
 ```
 
 **Default:** empty.
+
+---
 
 Use `WithPrompt` for simple single-turn requests. Use `WithMessages` for multi-turn conversations.
 
@@ -596,3 +598,28 @@ func WithImageProviderOptions(opts map[string]any) ImageOption
 ```
 
 **Default:** empty.
+
+---
+
+## Video Options
+
+These options use the separate `VideoOption` type and apply only to `GenerateVideo`.
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| `WithVideoPrompt(string)` | Text prompt. | Empty |
+| `WithVideoImage(provider.MediaData)` | Initial image for image-to-video. | None |
+| `WithVideoCount(int)` | Number of videos. | `1` |
+| `WithVideoAspectRatio(string)` | Output ratio such as `"16:9"`. | Provider default |
+| `WithVideoResolution(string)` | Provider-supported resolution. | Provider default |
+| `WithVideoDuration(time.Duration)` | Requested duration. | Provider default |
+| `WithVideoFPS(int)` | Frames per second when supported. | Provider default |
+| `WithVideoSeed(int64)` | Deterministic seed when supported. | None |
+| `WithVideoFrameImages(...provider.VideoFrame)` | First/last frame images. | None |
+| `WithVideoInputReferences(...provider.MediaData)` | Reference media. | None |
+| `WithVideoAudio(bool)` | Generate audio with video. | Provider default |
+| `WithVideoProviderOptions(map[string]any)` | Provider-specific parameters. | Empty |
+| `WithVideoMaxRetries(int)` | Retries for rate-limited generation-start requests. Ambiguous network and 5xx failures are not replayed. | `2` |
+| `WithVideoTimeout(time.Duration)` | Overall call timeout. | Context only |
+| `WithVideoPollInterval(time.Duration)` | Operation polling interval. | `5s` |
+| `WithVideoPollTimeout(time.Duration)` | Maximum polling duration. | `10m` |

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -130,6 +130,19 @@ type ImageResult struct {
 }
 ```
 
+### VideoResult
+
+The result of video generation. `Video` is the first generated video and `Videos` contains all results.
+
+```go
+type VideoResult struct {
+    Video            provider.VideoData
+    Videos           []provider.VideoData
+    ProviderMetadata map[string]map[string]any
+    Response         provider.ResponseMetadata
+}
+```
+
 ### SchemaFrom
 
 Generates a JSON Schema from a Go struct type `T`. Used by `GenerateObject` and `StreamObject` to describe the expected output structure, and compatible with OpenAI strict-mode schemas.
@@ -220,6 +233,14 @@ A function that configures an image generation call.
 
 ```go
 type ImageOption func(*imageOptions)
+```
+
+### VideoOption
+
+A function that configures a video generation call.
+
+```go
+type VideoOption func(*videoOptions)
 ```
 
 ### RequestInfo
@@ -442,6 +463,17 @@ Interface for image generation models.
 type ImageModel interface {
     ModelID() string
     DoGenerate(ctx context.Context, params ImageParams) (*ImageResult, error)
+}
+```
+
+### VideoModel
+
+Interface for video generation models.
+
+```go
+type VideoModel interface {
+    ModelID() string
+    DoGenerate(ctx context.Context, params VideoParams) (*VideoResult, error)
 }
 ```
 
@@ -778,6 +810,41 @@ type ImageResult struct {
     Response         ResponseMetadata            // Provider metadata.
 }
 ```
+
+### VideoParams
+
+Provider-independent video generation parameters, including prompt, input media, output settings, and polling configuration.
+
+```go
+type VideoParams struct {
+    Prompt          string
+    Image           *MediaData
+    N               int
+    AspectRatio     string
+    Resolution      string
+    Duration        time.Duration
+    FPS             int
+    Seed            *int64
+    FrameImages     []VideoFrame
+    InputReferences []MediaData
+    GenerateAudio   *bool
+    ProviderOptions map[string]any
+    MaxRetries      int
+    PollInterval    time.Duration
+    PollTimeout     time.Duration
+}
+```
+
+### VideoData
+
+```go
+type VideoData struct {
+    Data      []byte
+    MediaType string
+}
+```
+
+`MediaData` represents inline or remote media inputs. `VideoFrame` tags an image as `VideoFrameFirst` or `VideoFrameLast`.
 
 ### ResponseFormat
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,14 +13,14 @@ GoAI is a Go SDK that provides one unified API across 25+ LLM providers. This do
 ┌─────────────────────────────────────────────────────────────────┐
 │                        User Application                         │
 │  goai.GenerateText / StreamText / GenerateObject / StreamObject │
-│  goai.Embed / EmbedMany / GenerateImage                         │
+│  goai.Embed / EmbedMany / GenerateImage / GenerateVideo         │
 └──────────────────────────────┬──────────────────────────────────┘
                                │
                     options, retry, caching
                                │
 ┌──────────────────────────────▼──────────────────────────────────┐
 │                     Provider Interfaces                         │
-│         LanguageModel · EmbeddingModel · ImageModel             │
+│    LanguageModel · EmbeddingModel · ImageModel · VideoModel     │
 └──┬─────────┬──────────┬──────────┬──────────┬─────────┬──────────┘
    │         │          │          │          │         │
 ┌──▼───┐ ┌───▼───┐ ┌───▼───┐ ┌───▼────┐ ┌───▼──┐ ┌───▼────────┐
@@ -59,7 +59,7 @@ GoAI is structured as three layers:
 
 ### 1. Core SDK (`goai` package)
 
-The top-level `goai` package exposes 7 core functions — the only public API that users interact with:
+The top-level `goai` package exposes 8 core functions — the only public API that users interact with:
 
 | Function            | File          | Description                                                |
 | ------------------- | ------------- | ---------------------------------------------------------- |
@@ -70,6 +70,7 @@ The top-level `goai` package exposes 7 core functions — the only public API th
 | `Embed`             | `embed.go`    | Single text embedding                                      |
 | `EmbedMany`         | `embed.go`    | Batch embeddings with auto-chunking and parallel execution |
 | `GenerateImage`     | `image.go`    | Image generation                                           |
+| `GenerateVideo`     | `video.go`    | Video generation with long-running operation polling       |
 
 Supporting modules in the core:
 
@@ -83,7 +84,7 @@ Supporting modules in the core:
 
 ### 2. Provider Interfaces (`provider` package)
 
-The `provider` package defines three model interfaces that all providers implement:
+The `provider` package defines four model interfaces that providers implement as applicable:
 
 ```go
 type LanguageModel interface {
@@ -102,9 +103,14 @@ type ImageModel interface {
     ModelID() string
     DoGenerate(ctx context.Context, params ImageParams) (*ImageResult, error)
 }
+
+type VideoModel interface {
+    ModelID() string
+    DoGenerate(ctx context.Context, params VideoParams) (*VideoResult, error)
+}
 ```
 
-The provider package also defines all shared types: `Message`, `Part`, `StreamChunk`, `Usage`, `ToolDefinition`, `ToolCall`, `Source`, and `ResponseMetadata`.
+The provider package also defines all shared types: `Message`, `Part`, `StreamChunk`, `Usage`, `ToolDefinition`, `ToolCall`, `Source`, `ResponseMetadata`, `VideoParams`, and `VideoData`.
 
 An optional `CapableModel` interface allows providers to declare feature support (temperature, reasoning, attachment, tool calling, modalities).
 
@@ -390,6 +396,7 @@ goai/
 ├── object.go               # GenerateObject[T], StreamObject[T], ObjectStream
 ├── embed.go                # Embed, EmbedMany (auto-chunking, parallel)
 ├── image.go                # GenerateImage
+├── video.go                # GenerateVideo
 ├── options.go              # Functional options (WithPrompt, WithTools, etc.)
 ├── schema.go               # SchemaFrom[T] — JSON Schema from Go structs
 ├── errors.go               # APIError, ContextOverflowError, overflow detection
@@ -397,7 +404,7 @@ goai/
 ├── caching.go              # Prompt cache control
 │
 ├── provider/
-│   ├── provider.go         # LanguageModel, EmbeddingModel, ImageModel interfaces
+│   ├── provider.go         # LanguageModel, EmbeddingModel, ImageModel, VideoModel interfaces
 │   ├── types.go            # Message, Part, StreamChunk, Usage, ToolDefinition, etc.
 │   ├── token.go            # TokenSource, CachedTokenSource, StaticToken
 │   │

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -20,6 +20,7 @@ GoAI SDK is a Go-native AI SDK supporting 25+ LLM providers with minimal depende
 | Prompt caching | ✅ auto | ❌ | ❌ | ❌ |
 | Embeddings | ✅ `Embed` / `EmbedMany` | ✅ | ✅ | ✅ |
 | Image generation | ✅ `GenerateImage` | ❌ | ❌ | ❌ |
+| Video generation | ✅ `GenerateVideo` (Google Veo) | ❌ | ❌ | ❌ |
 | Dependencies | **Minimal** (stdlib + oauth2) | Heavy | Medium | Minimal |
 | Inspired by | Vercel AI SDK | LangChain (Python) | Google ADK | — |
 | License | MIT | MIT | Apache 2.0 | MIT |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -98,7 +98,7 @@ Yes. GoAI SDK is released under the MIT License, which allows free commercial us
 
 ### How do I switch between LLM providers?
 
-Change one line — the provider import and model initialization. All 7 core functions (`GenerateText`, `StreamText`, `GenerateObject`, `StreamObject`, `Embed`, `EmbedMany`, `GenerateImage`) work identically across all 25+ providers.
+Change the provider import and model constructor while keeping the same core API. GoAI exposes eight core functions: `GenerateText`, `StreamText`, `GenerateObject`, `StreamObject`, `Embed`, `EmbedMany`, `GenerateImage`, and `GenerateVideo`. Model capabilities vary by provider.
 
 ### Does GoAI SDK work with local models?
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -1,6 +1,6 @@
 ---
 title: Google Gemini Provider
-description: "Use Google Gemini models in Go with GoAI. Supports chat, embeddings, image generation, Google Search grounding, and code execution tools."
+description: "Use Google Gemini models in Go with GoAI. Supports chat, embeddings, image and Veo video generation, Google Search grounding, and code execution tools."
 ---
 
 # Google
@@ -40,6 +40,7 @@ The provider also reads `GOOGLE_GENERATIVE_AI_BASE_URL` from the environment whe
 | `imagen-4.0-generate-001` | Image | Imagen via :predict endpoint |
 | `imagen-4.0-fast-generate-001` | Image | Imagen fast variant via :predict endpoint |
 | `gemini-2.5-flash-image` | Image | Gemini image via generateContent |
+| `veo-3.1-generate-preview` | Video | Veo via asynchronous predictLongRunning |
 
 ## Tested Models
 
@@ -57,7 +58,7 @@ E2E tested with real API calls. Last run: 2026-03-15.
 | `gemini-flash-latest` | PASS | PASS | Stable |
 | `gemini-flash-lite-latest` | PASS | PASS | Stable |
 
-Unit tested models: `gemini-2.5-flash`, `gemini-2.5-flash-image`, `imagen-4.0-generate-001`, `imagen-4.0-fast-generate-001`, `text-embedding-004`.
+Unit/integration tested models: `gemini-2.5-flash`, `gemini-2.5-flash-image`, `imagen-4.0-generate-001`, `imagen-4.0-fast-generate-001`, `text-embedding-004`, and `veo-3.1-generate-preview` (mock HTTP lifecycle). A credential-gated `e2e` test is available for a real Veo request; it is excluded from normal test runs to prevent accidental billing.
 
 ## Usage
 
@@ -173,6 +174,27 @@ result, err := goai.GenerateImage(ctx, model,
     goai.WithImagePrompt("A cartoon cat programming in Go"),
 )
 ```
+
+### Video Generation (Veo)
+
+Veo generation is asynchronous. GoAI starts the operation, polls it until completion, and downloads the authenticated video result.
+
+```go
+model := google.Video("veo-3.1-generate-preview")
+result, err := goai.GenerateVideo(ctx, model,
+    goai.WithVideoPrompt("A paper plane taking flight at sunrise"),
+    goai.WithVideoAspectRatio("16:9"),
+    goai.WithVideoResolution("720p"),
+    goai.WithVideoDuration(8*time.Second),
+    goai.WithVideoAudio(true),
+)
+if err != nil {
+    panic(err)
+}
+fmt.Printf("Generated %d bytes\n", len(result.Video.Data))
+```
+
+Use `WithVideoImage` for image-to-video generation. `WithVideoFrameImages` supports first and last frames, and `WithVideoInputReferences` accepts image references. The Gemini Developer API does not support the generic seed or FPS options.
 
 ## Options
 

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -194,7 +194,7 @@ if err != nil {
 fmt.Printf("Generated %d bytes\n", len(result.Video.Data))
 ```
 
-Use `WithVideoImage` for image-to-video generation. `WithVideoFrameImages` supports first and last frames, and `WithVideoInputReferences` accepts image references. The Gemini Developer API does not support the generic seed or FPS options.
+Use `WithVideoImage` for image-to-video generation. `WithVideoFrameImages` supports first and last frames, while `WithVideoInputReferences` accepts image references; Veo does not allow combining those two modes. Common pixel resolutions are translated to Google's `720p`, `1080p`, and `4k` values. The Gemini Developer API supports `WithVideoSeed` but not the generic FPS option.
 
 ## Options
 

--- a/examples/video-generation/main.go
+++ b/examples/video-generation/main.go
@@ -1,0 +1,36 @@
+//go:build ignore
+
+// Example: Google Veo video generation with automatic operation polling.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/provider/google"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	result, err := goai.GenerateVideo(ctx, google.Video("veo-3.1-generate-preview"),
+		goai.WithVideoPrompt("A paper plane taking flight at sunrise, cinematic"),
+		goai.WithVideoAspectRatio("16:9"),
+		goai.WithVideoResolution("720p"),
+		goai.WithVideoDuration(8*time.Second),
+		goai.WithVideoAudio(true),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := os.WriteFile("generated-video.mp4", result.Video.Data, 0o644); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Generated %d video(s), saved generated-video.mp4\n", len(result.Videos))
+}

--- a/goai.go
+++ b/goai.go
@@ -12,6 +12,7 @@
 //   - [Embed]: single text embedding
 //   - [EmbedMany]: batch text embeddings with auto-chunking
 //   - [GenerateImage]: image generation from text prompts
+//   - [GenerateVideo]: video generation from text and media prompts
 //
 // # Providers
 //

--- a/provider/google/video.go
+++ b/provider/google/video.go
@@ -1,0 +1,522 @@
+package google
+
+import (
+	"cmp"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/internal/httpc"
+	"github.com/zendev-sh/goai/provider"
+)
+
+var _ provider.VideoModel = (*videoModel)(nil)
+
+const (
+	maxGoogleVideoOperationBytes int64 = 10 << 20
+	maxGoogleVideoDownloadBytes  int64 = 512 << 20
+)
+
+// Video creates a Google Veo video model using the Gemini API.
+func Video(modelID string, opts ...Option) provider.VideoModel {
+	o := options{baseURL: defaultBaseURL}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.tokenSource == nil {
+		if key := cmp.Or(os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY"), os.Getenv("GEMINI_API_KEY")); key != "" {
+			o.tokenSource = provider.StaticToken(key)
+		}
+	}
+	if o.baseURL == defaultBaseURL {
+		if base := os.Getenv("GOOGLE_GENERATIVE_AI_BASE_URL"); base != "" {
+			o.baseURL = base
+		}
+	}
+	return &videoModel{id: modelID, opts: o}
+}
+
+type videoModel struct {
+	id   string
+	opts options
+}
+
+func (m *videoModel) ModelID() string { return m.id }
+
+func (m *videoModel) DoGenerate(ctx context.Context, params provider.VideoParams) (*provider.VideoResult, error) {
+	token, err := m.resolveToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving auth token: %w", err)
+	}
+
+	instance := map[string]any{"prompt": params.Prompt}
+	if params.Image != nil {
+		encoded, err := encodeVideoMedia(*params.Image)
+		if err != nil {
+			return nil, err
+		}
+		instance["image"] = encoded
+	}
+	for _, frame := range params.FrameImages {
+		encoded, err := encodeVideoMedia(frame.Image)
+		if err != nil {
+			return nil, err
+		}
+		switch frame.Type {
+		case provider.VideoFrameFirst:
+			instance["image"] = encoded
+		case provider.VideoFrameLast:
+			instance["lastFrame"] = encoded
+		}
+	}
+
+	parameters := map[string]any{"sampleCount": params.N}
+	if params.AspectRatio != "" {
+		parameters["aspectRatio"] = params.AspectRatio
+	}
+	if params.Resolution != "" {
+		parameters["resolution"] = params.Resolution
+	}
+	if params.Duration > 0 {
+		parameters["durationSeconds"] = int(params.Duration / time.Second)
+	}
+	if params.FPS > 0 {
+		return nil, errors.New("google Gemini video generation does not support fps")
+	}
+	if params.Seed != nil {
+		return nil, errors.New("google Gemini video generation does not support seed")
+	}
+	if params.GenerateAudio != nil {
+		parameters["generateAudio"] = *params.GenerateAudio
+	}
+	if gopts, ok := params.ProviderOptions["google"].(map[string]any); ok {
+		for key, value := range gopts {
+			parameters[key] = value
+		}
+	}
+	if len(params.InputReferences) > 0 {
+		references := make([]map[string]any, 0, len(params.InputReferences))
+		for _, reference := range params.InputReferences {
+			if strings.HasPrefix(reference.MediaType, "video/") {
+				return nil, errors.New("google Gemini video generation only supports image references")
+			}
+			encoded, err := encodeVideoMedia(reference)
+			if err != nil {
+				return nil, err
+			}
+			references = append(references, map[string]any{
+				"image":         encoded,
+				"referenceType": "asset",
+			})
+		}
+		instance["referenceImages"] = references
+	}
+
+	body := map[string]any{
+		"instances":  []map[string]any{instance},
+		"parameters": parameters,
+	}
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:predictLongRunning", m.opts.baseURL, url.PathEscape(m.id))
+	operation, err := m.startOperation(ctx, token, reqURL, body, params.MaxRetries)
+	if err != nil {
+		return nil, err
+	}
+	if operation.Name == "" {
+		return nil, errors.New("google video generation returned an empty operation name")
+	}
+
+	operation, err = m.pollOperation(ctx, token, operation, params.PollInterval, params.PollTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	videos, err := m.downloadVideos(ctx, token, operation.videoFiles())
+	if err != nil {
+		return nil, err
+	}
+	if len(videos) == 0 {
+		return nil, errors.New("google video generation returned no videos")
+	}
+
+	return &provider.VideoResult{
+		Videos: videos,
+		ProviderMetadata: map[string]map[string]any{
+			"google": {"operationName": operation.Name},
+		},
+		Response: provider.ResponseMetadata{ID: operation.Name, Model: m.id},
+	}, nil
+}
+
+func encodeVideoMedia(media provider.MediaData) (map[string]any, error) {
+	if media.URL != "" {
+		return nil, errors.New("google Gemini video generation requires inline image data")
+	}
+	if len(media.Data) == 0 {
+		return nil, errors.New("google Gemini video generation received empty image data")
+	}
+	return map[string]any{
+		"bytesBase64Encoded": base64.StdEncoding.EncodeToString(media.Data),
+		"mimeType":           media.MediaType,
+	}, nil
+}
+
+type googleVideoFile struct {
+	URI                string `json:"uri"`
+	MimeType           string `json:"mimeType"`
+	BytesBase64Encoded string `json:"bytesBase64Encoded"`
+	VideoBytes         string `json:"videoBytes"`
+}
+
+type googleGeneratedVideo struct {
+	Video googleVideoFile `json:"video"`
+}
+
+type googleVideoOperation struct {
+	Name  string `json:"name"`
+	Done  bool   `json:"done"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+	Response struct {
+		GenerateVideoResponse struct {
+			GeneratedSamples []googleGeneratedVideo `json:"generatedSamples"`
+			GeneratedVideos  []googleGeneratedVideo `json:"generatedVideos"`
+		} `json:"generateVideoResponse"`
+		GeneratedSamples []googleGeneratedVideo `json:"generatedSamples"`
+		GeneratedVideos  []googleGeneratedVideo `json:"generatedVideos"`
+	} `json:"response"`
+}
+
+func (o googleVideoOperation) videoFiles() []googleVideoFile {
+	groups := [][]googleGeneratedVideo{
+		o.Response.GenerateVideoResponse.GeneratedSamples,
+		o.Response.GenerateVideoResponse.GeneratedVideos,
+		o.Response.GeneratedSamples,
+		o.Response.GeneratedVideos,
+	}
+	for _, group := range groups {
+		if len(group) == 0 {
+			continue
+		}
+		files := make([]googleVideoFile, len(group))
+		for i, generated := range group {
+			files[i] = generated.Video
+		}
+		return files
+	}
+	return nil
+}
+
+func (m *videoModel) startOperation(ctx context.Context, token, reqURL string, body map[string]any, maxRetries int) (googleVideoOperation, error) {
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	for attempt := 0; ; attempt++ {
+		operation, err := m.requestOperation(ctx, token, http.MethodPost, reqURL, body)
+		if err == nil {
+			return operation, nil
+		}
+
+		var apiErr *goai.APIError
+		if !errors.As(err, &apiErr) || !safeVideoStartRetry(apiErr) || attempt >= maxRetries {
+			if apiErr != nil && safeVideoStartRetry(apiErr) && maxRetries > 0 && attempt >= maxRetries {
+				return googleVideoOperation{}, fmt.Errorf("goai: %d retries exhausted: %w", maxRetries, err)
+			}
+			return googleVideoOperation{}, err
+		}
+		if err := waitForVideoRetry(ctx, videoRetryDelay(apiErr, attempt)); err != nil {
+			return googleVideoOperation{}, err
+		}
+	}
+}
+
+func safeVideoStartRetry(apiErr *goai.APIError) bool {
+	return apiErr.IsRetryable && apiErr.StatusCode == http.StatusTooManyRequests
+}
+
+func videoRetryDelay(apiErr *goai.APIError, attempt int) time.Duration {
+	if serverDelay := videoRetryAfter(apiErr); serverDelay > 0 {
+		return serverDelay
+	}
+	return videoExponentialDelay(attempt)
+}
+
+func videoPollRetryDelay(apiErr *goai.APIError, attempt int) time.Duration {
+	serverDelay := min(videoRetryAfter(apiErr), 60*time.Second)
+	return max(serverDelay, videoExponentialDelay(attempt))
+}
+
+func videoRetryAfter(apiErr *goai.APIError) time.Duration {
+	if apiErr.ResponseHeaders != nil {
+		if value := apiErr.ResponseHeaders["retry-after-ms"]; value != "" {
+			if milliseconds, err := strconv.ParseInt(value, 10, 64); err == nil && milliseconds > 0 {
+				return time.Duration(milliseconds) * time.Millisecond
+			}
+		}
+		if value := apiErr.ResponseHeaders["retry-after"]; value != "" {
+			if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds > 0 {
+				return time.Duration(seconds) * time.Second
+			}
+		}
+	}
+	return 0
+}
+
+func videoExponentialDelay(attempt int) time.Duration {
+	delay := 2 * time.Second * time.Duration(1<<min(attempt, 5))
+	return min(delay, 60*time.Second)
+}
+
+func waitForVideoRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *videoModel) requestOperation(ctx context.Context, token, method, reqURL string, body map[string]any) (googleVideoOperation, error) {
+	if !sameOrigin(reqURL, m.opts.baseURL) {
+		return googleVideoOperation{}, errors.New("google video operation URL must use the configured API origin")
+	}
+	var payload []byte
+	if body != nil {
+		payload = httpc.MustMarshalJSON(body)
+	}
+	req := httpc.MustNewRequest(ctx, method, reqURL, payload)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	m.setHeaders(req, token)
+
+	resp, err := m.operationHTTPClient().Do(req)
+	if err != nil {
+		return googleVideoOperation{}, fmt.Errorf("sending video request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := readLimited(resp.Body, maxGoogleVideoOperationBytes)
+	if err != nil {
+		return googleVideoOperation{}, fmt.Errorf("reading video response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return googleVideoOperation{}, goai.ParseHTTPErrorWithHeaders("google", resp.StatusCode, respBody, resp.Header)
+	}
+
+	var operation googleVideoOperation
+	if err := json.Unmarshal(respBody, &operation); err != nil {
+		return googleVideoOperation{}, fmt.Errorf("parsing video operation: %w", err)
+	}
+	return operation, nil
+}
+
+func (m *videoModel) pollOperation(ctx context.Context, token string, operation googleVideoOperation, interval, timeout time.Duration) (googleVideoOperation, error) {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	deadline := time.Now().Add(timeout)
+	pollCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	reqURL, err := operationURL(m.opts.baseURL, operation.Name)
+	if err != nil {
+		return googleVideoOperation{}, err
+	}
+	nextDelay := interval
+	pollFailures := 0
+
+	for !operation.Done {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return googleVideoOperation{}, fmt.Errorf("google video generation timed out after %s", timeout)
+		}
+		delay := min(nextDelay, remaining)
+		nextDelay = interval
+		timer := time.NewTimer(delay)
+		select {
+		case <-pollCtx.Done():
+			timer.Stop()
+			if ctx.Err() != nil {
+				return googleVideoOperation{}, ctx.Err()
+			}
+			return googleVideoOperation{}, fmt.Errorf("google video generation timed out after %s", timeout)
+		case <-timer.C:
+		}
+
+		var err error
+		operation, err = m.requestOperation(pollCtx, token, http.MethodGet, reqURL, nil)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+				return googleVideoOperation{}, fmt.Errorf("google video generation timed out after %s", timeout)
+			}
+			var apiErr *goai.APIError
+			if errors.As(err, &apiErr) && apiErr.IsRetryable {
+				nextDelay = videoPollRetryDelay(apiErr, pollFailures)
+				if remaining := time.Until(deadline); nextDelay >= remaining {
+					nextDelay = remaining / 2
+				}
+				nextDelay = max(interval, nextDelay)
+				pollFailures++
+				continue
+			}
+			return googleVideoOperation{}, err
+		}
+		pollFailures = 0
+	}
+	if operation.Error != nil {
+		return googleVideoOperation{}, fmt.Errorf("google video generation failed: %s (code %d)", operation.Error.Message, operation.Error.Code)
+	}
+	return operation, nil
+}
+
+func operationURL(baseURL, name string) (string, error) {
+	if strings.HasPrefix(name, "https://") || strings.HasPrefix(name, "http://") {
+		if !sameOrigin(name, baseURL) {
+			return "", errors.New("google video operation URL must use the configured API origin")
+		}
+		return name, nil
+	}
+	return strings.TrimRight(baseURL, "/") + "/v1beta/" + strings.TrimLeft(name, "/"), nil
+}
+
+func (m *videoModel) downloadVideos(ctx context.Context, token string, files []googleVideoFile) ([]provider.VideoData, error) {
+	videos := make([]provider.VideoData, 0, len(files))
+	remainingBytes := maxGoogleVideoDownloadBytes
+	for i, file := range files {
+		encoded := cmp.Or(file.BytesBase64Encoded, file.VideoBytes)
+		if encoded != "" {
+			if int64(base64.StdEncoding.DecodedLen(len(encoded))) > remainingBytes {
+				return nil, fmt.Errorf("video data exceeds %d byte download limit", maxGoogleVideoDownloadBytes)
+			}
+			data, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				return nil, fmt.Errorf("decoding video %d: %w", i, err)
+			}
+			remainingBytes -= int64(len(data))
+			videos = append(videos, provider.VideoData{Data: data, MediaType: cmp.Or(file.MimeType, "video/mp4")})
+			continue
+		}
+		if file.URI == "" {
+			return nil, fmt.Errorf("video %d has no data or URI", i)
+		}
+		if !sameOrigin(file.URI, m.opts.baseURL) {
+			return nil, fmt.Errorf("video %d URL must use the configured API origin", i)
+		}
+
+		req := httpc.MustNewRequest(ctx, http.MethodGet, file.URI, nil)
+		m.setHeaders(req, token)
+		resp, err := m.downloadHTTPClient().Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("downloading video %d: %w", i, err)
+		}
+		if resp.ContentLength > remainingBytes {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("video data exceeds %d byte download limit", maxGoogleVideoDownloadBytes)
+		}
+		data, readErr := readLimited(resp.Body, remainingBytes)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("reading video %d: %w", i, readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, goai.ParseHTTPErrorWithHeaders("google", resp.StatusCode, data, resp.Header)
+		}
+		remainingBytes -= int64(len(data))
+		mediaType := resp.Header.Get("Content-Type")
+		if mediaType == "" {
+			mediaType = cmp.Or(file.MimeType, "video/mp4")
+		}
+		videos = append(videos, provider.VideoData{Data: data, MediaType: mediaType})
+	}
+	return videos, nil
+}
+
+func readLimited(reader io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("response exceeds %d byte limit", limit)
+	}
+	return data, nil
+}
+
+func (m *videoModel) operationHTTPClient() *http.Client {
+	client := *m.httpClient()
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &client
+}
+
+func (m *videoModel) downloadHTTPClient() *http.Client {
+	client := *m.httpClient()
+	previousCheck := client.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !sameOrigin(req.URL.String(), m.opts.baseURL) {
+			req.Header.Del("x-goog-api-key")
+			for key := range m.opts.headers {
+				req.Header.Del(key)
+			}
+			return errors.New("google video request refused a cross-origin redirect")
+		}
+		if previousCheck != nil {
+			return previousCheck(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}
+
+func sameOrigin(rawURL, baseURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == base.Scheme && u.Host == base.Host
+}
+
+func (m *videoModel) setHeaders(req *http.Request, token string) {
+	req.Header.Set("x-goog-api-key", token)
+	for key, value := range m.opts.headers {
+		req.Header.Set(key, value)
+	}
+}
+
+func (m *videoModel) resolveToken(ctx context.Context) (string, error) {
+	if m.opts.tokenSource == nil {
+		return "", errors.New("goai: no API key or token source configured")
+	}
+	return m.opts.tokenSource.Token(ctx)
+}
+
+func (m *videoModel) httpClient() *http.Client {
+	if m.opts.httpClient != nil {
+		return m.opts.httpClient
+	}
+	return http.DefaultClient
+}

--- a/provider/google/video.go
+++ b/provider/google/video.go
@@ -382,7 +382,7 @@ func (m *videoModel) pollOperation(ctx context.Context, token string, operation 
 		if remaining <= 0 {
 			return googleVideoOperation{}, fmt.Errorf("google video generation timed out after %s", timeout)
 		}
-		delay := min(nextDelay, remaining)
+		delay := nextDelay
 		nextDelay = interval
 		timer := time.NewTimer(delay)
 		select {
@@ -431,18 +431,26 @@ func operationURL(baseURL, name string) (string, error) {
 	return strings.TrimRight(baseURL, "/") + "/v1beta/" + strings.TrimLeft(name, "/"), nil
 }
 
+func decodeVideoData(encoded string, remainingBytes int64, index int) ([]byte, error) {
+	if int64(base64.StdEncoding.DecodedLen(len(encoded))) > remainingBytes {
+		return nil, fmt.Errorf("video data exceeds %d byte download limit", maxGoogleVideoDownloadBytes)
+	}
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decoding video %d: %w", index, err)
+	}
+	return data, nil
+}
+
 func (m *videoModel) downloadVideos(ctx context.Context, token string, files []googleVideoFile) ([]provider.VideoData, error) {
 	videos := make([]provider.VideoData, 0, len(files))
 	remainingBytes := maxGoogleVideoDownloadBytes
 	for i, file := range files {
 		encoded := cmp.Or(file.BytesBase64Encoded, file.VideoBytes)
 		if encoded != "" {
-			if int64(base64.StdEncoding.DecodedLen(len(encoded))) > remainingBytes {
-				return nil, fmt.Errorf("video data exceeds %d byte download limit", maxGoogleVideoDownloadBytes)
-			}
-			data, err := base64.StdEncoding.DecodeString(encoded)
+			data, err := decodeVideoData(encoded, remainingBytes, i)
 			if err != nil {
-				return nil, fmt.Errorf("decoding video %d: %w", i, err)
+				return nil, err
 			}
 			remainingBytes -= int64(len(data))
 			videos = append(videos, provider.VideoData{Data: data, MediaType: cmp.Or(file.MimeType, "video/mp4")})

--- a/provider/google/video.go
+++ b/provider/google/video.go
@@ -24,6 +24,7 @@ var _ provider.VideoModel = (*videoModel)(nil)
 
 const (
 	maxGoogleVideoOperationBytes int64 = 10 << 20
+	maxGoogleVideoErrorBytes     int64 = 1 << 20
 	maxGoogleVideoDownloadBytes  int64 = 512 << 20
 )
 
@@ -60,6 +61,9 @@ func (m *videoModel) DoGenerate(ctx context.Context, params provider.VideoParams
 	}
 
 	instance := map[string]any{"prompt": params.Prompt}
+	if len(params.FrameImages) > 0 && len(params.InputReferences) > 0 {
+		return nil, errors.New("google Gemini video generation cannot combine frame images with input references")
+	}
 	if params.Image != nil {
 		encoded, err := encodeVideoMedia(*params.Image)
 		if err != nil {
@@ -67,7 +71,25 @@ func (m *videoModel) DoGenerate(ctx context.Context, params provider.VideoParams
 		}
 		instance["image"] = encoded
 	}
+	hasFirstFrame := params.Image != nil
+	seenFirstFrame := false
+	seenLastFrame := false
 	for _, frame := range params.FrameImages {
+		switch frame.Type {
+		case provider.VideoFrameFirst:
+			if seenFirstFrame {
+				return nil, errors.New("google Gemini video generation received a duplicate first frame")
+			}
+			seenFirstFrame = true
+			hasFirstFrame = true
+		case provider.VideoFrameLast:
+			if seenLastFrame {
+				return nil, errors.New("google Gemini video generation received a duplicate last frame")
+			}
+			seenLastFrame = true
+		default:
+			return nil, fmt.Errorf("google Gemini video generation received unsupported frame type %q", frame.Type)
+		}
 		encoded, err := encodeVideoMedia(frame.Image)
 		if err != nil {
 			return nil, err
@@ -79,13 +101,21 @@ func (m *videoModel) DoGenerate(ctx context.Context, params provider.VideoParams
 			instance["lastFrame"] = encoded
 		}
 	}
+	if seenLastFrame && !hasFirstFrame {
+		return nil, errors.New("google Gemini video generation last frame requires an initial image or first frame")
+	}
 
 	parameters := map[string]any{"sampleCount": params.N}
 	if params.AspectRatio != "" {
 		parameters["aspectRatio"] = params.AspectRatio
 	}
 	if params.Resolution != "" {
-		parameters["resolution"] = params.Resolution
+		resolution := map[string]string{
+			"1280x720":  "720p",
+			"1920x1080": "1080p",
+			"3840x2160": "4k",
+		}[params.Resolution]
+		parameters["resolution"] = cmp.Or(resolution, params.Resolution)
 	}
 	if params.Duration > 0 {
 		parameters["durationSeconds"] = int(params.Duration / time.Second)
@@ -94,7 +124,7 @@ func (m *videoModel) DoGenerate(ctx context.Context, params provider.VideoParams
 		return nil, errors.New("google Gemini video generation does not support fps")
 	}
 	if params.Seed != nil {
-		return nil, errors.New("google Gemini video generation does not support seed")
+		parameters["seed"] = *params.Seed
 	}
 	if params.GenerateAudio != nil {
 		parameters["generateAudio"] = *params.GenerateAudio
@@ -107,7 +137,7 @@ func (m *videoModel) DoGenerate(ctx context.Context, params provider.VideoParams
 	if len(params.InputReferences) > 0 {
 		references := make([]map[string]any, 0, len(params.InputReferences))
 		for _, reference := range params.InputReferences {
-			if strings.HasPrefix(reference.MediaType, "video/") {
+			if !strings.HasPrefix(reference.MediaType, "image/") {
 				return nil, errors.New("google Gemini video generation only supports image references")
 			}
 			encoded, err := encodeVideoMedia(reference)
@@ -163,6 +193,12 @@ func encodeVideoMedia(media provider.MediaData) (map[string]any, error) {
 	}
 	if len(media.Data) == 0 {
 		return nil, errors.New("google Gemini video generation received empty image data")
+	}
+	if !strings.HasPrefix(media.MediaType, "image/") {
+		return nil, errors.New("google Gemini video generation requires an image media type")
+	}
+	if media.MediaType != "image/png" && media.MediaType != "image/jpeg" {
+		return nil, errors.New("google Gemini video generation requires a PNG or JPEG image")
 	}
 	return map[string]any{
 		"bytesBase64Encoded": base64.StdEncoding.EncodeToString(media.Data),
@@ -425,6 +461,14 @@ func (m *videoModel) downloadVideos(ctx context.Context, token string, files []g
 		if err != nil {
 			return nil, fmt.Errorf("downloading video %d: %w", i, err)
 		}
+		if resp.StatusCode != http.StatusOK {
+			data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxGoogleVideoErrorBytes))
+			_ = resp.Body.Close()
+			if readErr != nil {
+				return nil, fmt.Errorf("reading video %d error response: %w", i, readErr)
+			}
+			return nil, goai.ParseHTTPErrorWithHeaders("google", resp.StatusCode, data, resp.Header)
+		}
 		if resp.ContentLength > remainingBytes {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf("video data exceeds %d byte download limit", maxGoogleVideoDownloadBytes)
@@ -433,9 +477,6 @@ func (m *videoModel) downloadVideos(ctx context.Context, token string, files []g
 		_ = resp.Body.Close()
 		if readErr != nil {
 			return nil, fmt.Errorf("reading video %d: %w", i, readErr)
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, goai.ParseHTTPErrorWithHeaders("google", resp.StatusCode, data, resp.Header)
 		}
 		remainingBytes -= int64(len(data))
 		mediaType := resp.Header.Get("Content-Type")

--- a/provider/google/video_coverage_test.go
+++ b/provider/google/video_coverage_test.go
@@ -80,7 +80,7 @@ func TestVideo_RequestOptionsAndInlineResult(t *testing.T) {
 			t.Fatal(err)
 		}
 		instance := body.Instances[0]
-		if instance["image"] == nil || instance["lastFrame"] == nil || instance["referenceImages"] == nil {
+		if instance["image"] == nil || instance["lastFrame"] == nil {
 			t.Fatalf("instance = %#v", instance)
 		}
 		if body.Parameters["resolution"] != "720p" || body.Parameters["negativePrompt"] != "rain" {
@@ -106,7 +106,6 @@ func TestVideo_RequestOptionsAndInlineResult(t *testing.T) {
 			{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("first"), MediaType: "image/png"}},
 			{Type: provider.VideoFrameLast, Image: provider.MediaData{Data: []byte("last"), MediaType: "image/png"}},
 		},
-		InputReferences: []provider.MediaData{{Data: []byte("reference"), MediaType: "image/png"}},
 		ProviderOptions: map[string]any{"google": map[string]any{"negativePrompt": "rain"}},
 	})
 	if err != nil {
@@ -117,8 +116,63 @@ func TestVideo_RequestOptionsAndInlineResult(t *testing.T) {
 	}
 }
 
+func TestVideo_InputReferences(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Instances []map[string]any `json:"instances"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if len(body.Instances) != 1 || body.Instances[0]["referenceImages"] == nil {
+			t.Fatalf("instances = %#v", body.Instances)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"name":"operations/references","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"videoBytes":"dmlkZW8="}}]}}}`)
+	}))
+	defer server.Close()
+
+	model := Video("veo-test", WithAPIKey("key"), WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.VideoParams{
+		Prompt:          "test",
+		N:               1,
+		InputReferences: []provider.MediaData{{Data: []byte("reference"), MediaType: "image/png"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVideo_MapsSeedAndResolution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Parameters map[string]any `json:"parameters"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Parameters["seed"] != float64(42) || body.Parameters["resolution"] != "1080p" {
+			t.Fatalf("parameters = %#v", body.Parameters)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"name":"operations/options","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"videoBytes":"dmlkZW8="}}]}}}`)
+	}))
+	defer server.Close()
+
+	seed := int64(42)
+	model := Video("veo-test", WithAPIKey("key"), WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.VideoParams{
+		Prompt:     "test",
+		N:          1,
+		Resolution: "1920x1080",
+		Seed:       &seed,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestVideo_InputValidation(t *testing.T) {
-	seed := int64(1)
 	tests := []struct {
 		name   string
 		params provider.VideoParams
@@ -126,11 +180,25 @@ func TestVideo_InputValidation(t *testing.T) {
 	}{
 		{name: "image URL", params: provider.VideoParams{Image: &provider.MediaData{URL: "https://example.com/image.png"}}, want: "inline image data"},
 		{name: "empty image", params: provider.VideoParams{Image: &provider.MediaData{}}, want: "empty image data"},
+		{name: "non-image input", params: provider.VideoParams{Image: &provider.MediaData{Data: []byte("audio"), MediaType: "audio/mpeg"}}, want: "requires an image media type"},
+		{name: "unsupported image input", params: provider.VideoParams{Image: &provider.MediaData{Data: []byte("gif"), MediaType: "image/gif"}}, want: "requires a PNG or JPEG image"},
 		{name: "frame URL", params: provider.VideoParams{FrameImages: []provider.VideoFrame{{Type: provider.VideoFrameFirst, Image: provider.MediaData{URL: "https://example.com/image.png"}}}}, want: "inline image data"},
+		{name: "invalid frame type", params: provider.VideoParams{FrameImages: []provider.VideoFrame{{Type: "middle_frame", Image: provider.MediaData{Data: []byte("image"), MediaType: "image/png"}}}}, want: "unsupported frame type"},
+		{name: "duplicate first frame", params: provider.VideoParams{FrameImages: []provider.VideoFrame{
+			{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("first"), MediaType: "image/png"}},
+			{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("duplicate"), MediaType: "image/png"}},
+		}}, want: "duplicate first frame"},
+		{name: "last frame without start", params: provider.VideoParams{FrameImages: []provider.VideoFrame{
+			{Type: provider.VideoFrameLast, Image: provider.MediaData{Data: []byte("last"), MediaType: "image/png"}},
+		}}, want: "last frame requires an initial image or first frame"},
 		{name: "fps", params: provider.VideoParams{FPS: 24}, want: "does not support fps"},
-		{name: "seed", params: provider.VideoParams{Seed: &seed}, want: "does not support seed"},
 		{name: "video reference", params: provider.VideoParams{InputReferences: []provider.MediaData{{Data: []byte("video"), MediaType: "video/mp4"}}}, want: "only supports image references"},
+		{name: "non-image reference", params: provider.VideoParams{InputReferences: []provider.MediaData{{Data: []byte("audio"), MediaType: "audio/mpeg"}}}, want: "only supports image references"},
 		{name: "reference URL", params: provider.VideoParams{InputReferences: []provider.MediaData{{URL: "https://example.com/image.png", MediaType: "image/png"}}}, want: "inline image data"},
+		{name: "frames with references", params: provider.VideoParams{
+			FrameImages:     []provider.VideoFrame{{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("frame"), MediaType: "image/png"}}},
+			InputReferences: []provider.MediaData{{Data: []byte("reference"), MediaType: "image/png"}},
+		}, want: "cannot combine frame images with input references"},
 	}
 	model := &videoModel{id: "veo-test", opts: options{tokenSource: provider.StaticToken("key"), baseURL: "http://127.0.0.1:1"}}
 	for _, tt := range tests {

--- a/provider/google/video_coverage_test.go
+++ b/provider/google/video_coverage_test.go
@@ -188,6 +188,11 @@ func TestVideo_InputValidation(t *testing.T) {
 			{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("first"), MediaType: "image/png"}},
 			{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("duplicate"), MediaType: "image/png"}},
 		}}, want: "duplicate first frame"},
+		{name: "duplicate last frame", params: provider.VideoParams{FrameImages: []provider.VideoFrame{
+			{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("first"), MediaType: "image/png"}},
+			{Type: provider.VideoFrameLast, Image: provider.MediaData{Data: []byte("last"), MediaType: "image/png"}},
+			{Type: provider.VideoFrameLast, Image: provider.MediaData{Data: []byte("duplicate"), MediaType: "image/png"}},
+		}}, want: "duplicate last frame"},
 		{name: "last frame without start", params: provider.VideoParams{FrameImages: []provider.VideoFrame{
 			{Type: provider.VideoFrameLast, Image: provider.MediaData{Data: []byte("last"), MediaType: "image/png"}},
 		}}, want: "last frame requires an initial image or first frame"},
@@ -367,6 +372,31 @@ func TestVideo_PollAndOperationURLEdges(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error = %v", err)
 	}
+
+	_, err = model.pollOperation(t.Context(), "key", googleVideoOperation{Name: "operations/expired"}, time.Hour, time.Nanosecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expired poll error = %v", err)
+	}
+
+	_, err = model.pollOperation(t.Context(), "key", googleVideoOperation{Name: "operations/wait-timeout"}, time.Second, 20*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("wait timeout error = %v", err)
+	}
+
+	nonRetryable := &videoModel{opts: options{
+		baseURL: "https://video.example.test",
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"bad request"}}`)),
+			}, nil
+		})},
+	}}
+	_, err = nonRetryable.pollOperation(t.Context(), "key", googleVideoOperation{Name: "operations/bad"}, time.Nanosecond, time.Second)
+	if err == nil || !strings.Contains(err.Error(), "bad request") {
+		t.Fatalf("non-retryable poll error = %v", err)
+	}
 }
 
 func TestVideo_DownloadInlineAndErrors(t *testing.T) {
@@ -397,6 +427,10 @@ func TestVideo_DownloadInlineAndErrors(t *testing.T) {
 			}
 		})
 	}
+
+	if _, err := decodeVideoData(base64.StdEncoding.EncodeToString([]byte("video")), 2, 0); err == nil || !strings.Contains(err.Error(), "download limit") {
+		t.Fatalf("oversized inline error = %v", err)
+	}
 }
 
 func TestVideo_ReadAndRedirectHelpers(t *testing.T) {
@@ -422,6 +456,15 @@ func TestVideo_ReadAndRedirectHelpers(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "https://video.example.test/next", nil)
 	if err := client.CheckRedirect(req, nil); err == nil || !previousCalled.Load() {
 		t.Fatalf("redirect error = %v, previous called = %v", err, previousCalled.Load())
+	}
+
+	model.opts.headers = map[string]string{"X-Custom": "secret"}
+	client = model.downloadHTTPClient()
+	crossOrigin := httptest.NewRequest(http.MethodGet, "https://other.example.test/next", nil)
+	crossOrigin.Header.Set("x-goog-api-key", "key")
+	crossOrigin.Header.Set("X-Custom", "secret")
+	if err := client.CheckRedirect(crossOrigin, nil); err == nil || crossOrigin.Header.Get("x-goog-api-key") != "" || crossOrigin.Header.Get("X-Custom") != "" {
+		t.Fatalf("cross-origin redirect error = %v, headers = %v", err, crossOrigin.Header)
 	}
 
 	model.opts.httpClient = &http.Client{}

--- a/provider/google/video_coverage_test.go
+++ b/provider/google/video_coverage_test.go
@@ -1,0 +1,365 @@
+package google
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestVideo_ConstructorEnvironmentAndHelpers(t *testing.T) {
+	t.Setenv("GOOGLE_GENERATIVE_AI_API_KEY", "env-key")
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_GENERATIVE_AI_BASE_URL", "https://video.example.test")
+
+	model := Video("veo-test").(*videoModel)
+	if model.ModelID() != "veo-test" || model.opts.baseURL != "https://video.example.test" {
+		t.Fatalf("model = %#v", model)
+	}
+	token, err := model.resolveToken(t.Context())
+	if err != nil || token != "env-key" {
+		t.Fatalf("token = %q, error = %v", token, err)
+	}
+
+	customClient := &http.Client{}
+	model.opts.httpClient = customClient
+	if model.httpClient() != customClient {
+		t.Fatal("custom HTTP client not returned")
+	}
+	model.opts.httpClient = nil
+	if model.httpClient() != http.DefaultClient {
+		t.Fatal("default HTTP client not returned")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://video.example.test", nil)
+	model.opts.headers = map[string]string{"X-Test": "value"}
+	model.setHeaders(req, "key")
+	if req.Header.Get("x-goog-api-key") != "key" || req.Header.Get("X-Test") != "value" {
+		t.Fatalf("headers = %v", req.Header)
+	}
+}
+
+func TestVideo_AuthenticationErrors(t *testing.T) {
+	t.Setenv("GOOGLE_GENERATIVE_AI_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_GENERATIVE_AI_BASE_URL", "")
+
+	model := Video("veo-test").(*videoModel)
+	if _, err := model.DoGenerate(t.Context(), provider.VideoParams{Prompt: "test"}); err == nil || !strings.Contains(err.Error(), "no API key") {
+		t.Fatalf("error = %v", err)
+	}
+
+	model.opts.tokenSource = failingTokenSource{}
+	if _, err := model.DoGenerate(t.Context(), provider.VideoParams{Prompt: "test"}); err == nil || !strings.Contains(err.Error(), "token fetch failed") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestVideo_RequestOptionsAndInlineResult(t *testing.T) {
+	videoData := base64.StdEncoding.EncodeToString([]byte("inline-video"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom") != "yes" {
+			t.Errorf("custom header = %q", r.Header.Get("X-Custom"))
+		}
+		var body struct {
+			Instances  []map[string]any `json:"instances"`
+			Parameters map[string]any   `json:"parameters"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		instance := body.Instances[0]
+		if instance["image"] == nil || instance["lastFrame"] == nil || instance["referenceImages"] == nil {
+			t.Fatalf("instance = %#v", instance)
+		}
+		if body.Parameters["resolution"] != "720p" || body.Parameters["negativePrompt"] != "rain" {
+			t.Fatalf("parameters = %#v", body.Parameters)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"name":"operations/inline","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"videoBytes":%q}}]}}}`, videoData)
+	}))
+	defer server.Close()
+
+	model := Video("veo-test",
+		WithAPIKey("key"),
+		WithBaseURL(server.URL),
+		WithHeaders(map[string]string{"X-Custom": "yes"}),
+		WithHTTPClient(server.Client()),
+	)
+	result, err := model.DoGenerate(t.Context(), provider.VideoParams{
+		Prompt:      "test",
+		N:           1,
+		Resolution:  "720p",
+		PollTimeout: time.Second,
+		FrameImages: []provider.VideoFrame{
+			{Type: provider.VideoFrameFirst, Image: provider.MediaData{Data: []byte("first"), MediaType: "image/png"}},
+			{Type: provider.VideoFrameLast, Image: provider.MediaData{Data: []byte("last"), MediaType: "image/png"}},
+		},
+		InputReferences: []provider.MediaData{{Data: []byte("reference"), MediaType: "image/png"}},
+		ProviderOptions: map[string]any{"google": map[string]any{"negativePrompt": "rain"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Videos) != 1 || string(result.Videos[0].Data) != "inline-video" || result.Videos[0].MediaType != "video/mp4" {
+		t.Fatalf("videos = %#v", result.Videos)
+	}
+}
+
+func TestVideo_InputValidation(t *testing.T) {
+	seed := int64(1)
+	tests := []struct {
+		name   string
+		params provider.VideoParams
+		want   string
+	}{
+		{name: "image URL", params: provider.VideoParams{Image: &provider.MediaData{URL: "https://example.com/image.png"}}, want: "inline image data"},
+		{name: "empty image", params: provider.VideoParams{Image: &provider.MediaData{}}, want: "empty image data"},
+		{name: "frame URL", params: provider.VideoParams{FrameImages: []provider.VideoFrame{{Type: provider.VideoFrameFirst, Image: provider.MediaData{URL: "https://example.com/image.png"}}}}, want: "inline image data"},
+		{name: "fps", params: provider.VideoParams{FPS: 24}, want: "does not support fps"},
+		{name: "seed", params: provider.VideoParams{Seed: &seed}, want: "does not support seed"},
+		{name: "video reference", params: provider.VideoParams{InputReferences: []provider.MediaData{{Data: []byte("video"), MediaType: "video/mp4"}}}, want: "only supports image references"},
+		{name: "reference URL", params: provider.VideoParams{InputReferences: []provider.MediaData{{URL: "https://example.com/image.png", MediaType: "image/png"}}}, want: "inline image data"},
+	}
+	model := &videoModel{id: "veo-test", opts: options{tokenSource: provider.StaticToken("key"), baseURL: "http://127.0.0.1:1"}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := model.DoGenerate(t.Context(), tt.params)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVideo_EmptyOperationAndNoVideos(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     string
+	}{
+		{name: "empty operation", response: `{}`, want: "empty operation name"},
+		{name: "no videos", response: `{"name":"operations/empty","done":true}`, want: "returned no videos"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tt.response)
+			}))
+			defer server.Close()
+			model := Video("veo-test", WithAPIKey("key"), WithBaseURL(server.URL))
+			_, err := model.DoGenerate(t.Context(), provider.VideoParams{Prompt: "test", N: 1})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestGoogleVideoOperation_VideoFileVariants(t *testing.T) {
+	tests := []string{
+		`{"response":{"generateVideoResponse":{"generatedVideos":[{"video":{"uri":"one"}}]}}}`,
+		`{"response":{"generatedSamples":[{"video":{"uri":"two"}}]}}`,
+		`{"response":{"generatedVideos":[{"video":{"uri":"three"}}]}}`,
+	}
+	for _, raw := range tests {
+		var operation googleVideoOperation
+		if err := json.Unmarshal([]byte(raw), &operation); err != nil {
+			t.Fatal(err)
+		}
+		if files := operation.videoFiles(); len(files) != 1 || files[0].URI == "" {
+			t.Fatalf("files = %#v", files)
+		}
+	}
+	if files := (googleVideoOperation{}).videoFiles(); files != nil {
+		t.Fatalf("files = %#v, want nil", files)
+	}
+}
+
+func TestVideo_StartRetryEdges(t *testing.T) {
+	t.Run("negative retries and network error", func(t *testing.T) {
+		model := &videoModel{id: "veo-test", opts: options{
+			baseURL: "https://video.example.test",
+			httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("network failed")
+			})},
+		}}
+		_, err := model.startOperation(t.Context(), "key", "https://video.example.test/start", nil, -1)
+		if err == nil || !strings.Contains(err.Error(), "network failed") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("retry exhausted", func(t *testing.T) {
+		model := rateLimitedVideoModel()
+		_, err := model.startOperation(t.Context(), "key", "https://video.example.test/start", nil, 1)
+		if err == nil || !strings.Contains(err.Error(), "1 retries exhausted") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("cancel during retry wait", func(t *testing.T) {
+		model := rateLimitedVideoModel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := model.startOperation(ctx, "key", "https://video.example.test/start", nil, 1)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func rateLimitedVideoModel() *videoModel {
+	return &videoModel{id: "veo-test", opts: options{
+		baseURL: "https://video.example.test",
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"retry-after-ms": []string{"1"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"limited"}}`)),
+			}, nil
+		})},
+	}}
+}
+
+func TestVideoRetryHelpers(t *testing.T) {
+	if got := videoRetryAfter(&goai.APIError{ResponseHeaders: map[string]string{"retry-after": "2"}}); got != 2*time.Second {
+		t.Fatalf("retry-after = %v", got)
+	}
+	if got := videoRetryAfter(&goai.APIError{ResponseHeaders: map[string]string{"retry-after-ms": "bad", "retry-after": "bad"}}); got != 0 {
+		t.Fatalf("invalid retry-after = %v", got)
+	}
+	if got := videoExponentialDelay(99); got != 60*time.Second {
+		t.Fatalf("capped delay = %v", got)
+	}
+	if err := waitForVideoRetry(t.Context(), time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVideo_RequestOperationErrors(t *testing.T) {
+	baseURL := "https://video.example.test"
+	tests := []struct {
+		name       string
+		requestURL string
+		transport  roundTripFunc
+		want       string
+	}{
+		{name: "cross origin", requestURL: "https://other.example.test/start", want: "configured API origin"},
+		{name: "transport", requestURL: baseURL + "/start", transport: func(*http.Request) (*http.Response, error) { return nil, errors.New("transport failed") }, want: "transport failed"},
+		{name: "read", requestURL: baseURL + "/start", transport: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: &failReader{}}, nil
+		}, want: "reading video response"},
+		{name: "invalid JSON", requestURL: baseURL + "/start", transport: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("{"))}, nil
+		}, want: "parsing video operation"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &videoModel{opts: options{baseURL: baseURL}}
+			if tt.transport != nil {
+				model.opts.httpClient = &http.Client{Transport: tt.transport}
+			}
+			_, err := model.requestOperation(t.Context(), "key", http.MethodGet, tt.requestURL, nil)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVideo_PollAndOperationURLEdges(t *testing.T) {
+	model := &videoModel{opts: options{baseURL: "https://video.example.test"}}
+	done := googleVideoOperation{Name: "operations/done", Done: true}
+	if result, err := model.pollOperation(t.Context(), "key", done, 0, 0); err != nil || result.Name != done.Name {
+		t.Fatalf("result = %#v, error = %v", result, err)
+	}
+	if got, err := operationURL(model.opts.baseURL, "https://video.example.test/operations/one"); err != nil || got == "" {
+		t.Fatalf("URL = %q, error = %v", got, err)
+	}
+	if got, err := operationURL(model.opts.baseURL+"/", "/operations/two"); err != nil || got != "https://video.example.test/v1beta/operations/two" {
+		t.Fatalf("URL = %q, error = %v", got, err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := model.pollOperation(ctx, "key", googleVideoOperation{Name: "operations/wait"}, time.Second, time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestVideo_DownloadInlineAndErrors(t *testing.T) {
+	baseURL := "https://video.example.test"
+	model := &videoModel{opts: options{baseURL: baseURL}}
+
+	videos, err := model.downloadVideos(t.Context(), "key", []googleVideoFile{{
+		BytesBase64Encoded: base64.StdEncoding.EncodeToString([]byte("video")),
+	}})
+	if err != nil || len(videos) != 1 || videos[0].MediaType != "video/mp4" {
+		t.Fatalf("videos = %#v, error = %v", videos, err)
+	}
+
+	tests := []struct {
+		name string
+		file googleVideoFile
+		want string
+	}{
+		{name: "invalid base64", file: googleVideoFile{BytesBase64Encoded: "%%%"}, want: "decoding video"},
+		{name: "missing URI", file: googleVideoFile{}, want: "no data or URI"},
+		{name: "cross origin", file: googleVideoFile{URI: "https://other.example.test/video.mp4"}, want: "configured API origin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := model.downloadVideos(t.Context(), "key", []googleVideoFile{tt.file})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVideo_ReadAndRedirectHelpers(t *testing.T) {
+	if _, err := readLimited(&failReader{}, 10); err == nil {
+		t.Fatal("expected read error")
+	}
+	if _, err := readLimited(strings.NewReader("too long"), 2); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error = %v", err)
+	}
+	if sameOrigin("%", "https://video.example.test") || sameOrigin("https://video.example.test", "%") {
+		t.Fatal("invalid URL reported as same origin")
+	}
+
+	var previousCalled atomic.Bool
+	model := &videoModel{opts: options{
+		baseURL: "https://video.example.test",
+		httpClient: &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+			previousCalled.Store(true)
+			return errors.New("custom redirect policy")
+		}},
+	}}
+	client := model.downloadHTTPClient()
+	req := httptest.NewRequest(http.MethodGet, "https://video.example.test/next", nil)
+	if err := client.CheckRedirect(req, nil); err == nil || !previousCalled.Load() {
+		t.Fatalf("redirect error = %v, previous called = %v", err, previousCalled.Load())
+	}
+
+	model.opts.httpClient = &http.Client{}
+	client = model.downloadHTTPClient()
+	via := make([]*http.Request, 10)
+	if err := client.CheckRedirect(req, via); err == nil || !strings.Contains(err.Error(), "10 redirects") {
+		t.Fatalf("redirect error = %v", err)
+	}
+}

--- a/provider/google/video_e2e_test.go
+++ b/provider/google/video_e2e_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+
+package google_test
+
+import (
+	"cmp"
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/provider/google"
+)
+
+func TestE2E_GoogleVeo_GenerateVideo(t *testing.T) {
+	apiKey := cmp.Or(os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY"), os.Getenv("GEMINI_API_KEY"))
+	if apiKey == "" {
+		t.Skip("Google Gemini API credentials not set")
+	}
+	modelID := os.Getenv("GOOGLE_VEO_MODEL")
+	if modelID == "" {
+		modelID = "veo-3.1-generate-preview"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	result, err := goai.GenerateVideo(ctx, google.Video(modelID, google.WithAPIKey(apiKey)),
+		goai.WithVideoPrompt("A single blue paper plane gliding across a plain white background"),
+		goai.WithVideoCount(1),
+		goai.WithVideoAspectRatio("16:9"),
+		goai.WithVideoDuration(4*time.Second),
+		goai.WithVideoPollTimeout(10*time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Videos) != 1 || len(result.Video.Data) == 0 {
+		t.Fatalf("generated videos = %d, first video bytes = %d", len(result.Videos), len(result.Video.Data))
+	}
+	if !strings.HasPrefix(result.Video.MediaType, "video/") {
+		t.Fatalf("media type = %q, want video/*", result.Video.MediaType)
+	}
+}

--- a/provider/google/video_test.go
+++ b/provider/google/video_test.go
@@ -452,6 +452,67 @@ func TestVideo_LimitsDownloadErrorBody(t *testing.T) {
 	}
 }
 
+func TestVideo_DownloadResponseEdges(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  *http.Response
+		wantError string
+		wantType  string
+	}{
+		{
+			name: "error response read failure",
+			response: &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     make(http.Header),
+				Body:       &failReader{},
+			},
+			wantError: "error response",
+		},
+		{
+			name: "successful response read failure",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       &failReader{},
+			},
+			wantError: "reading video",
+		},
+		{
+			name: "media type fallback",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("video")),
+			},
+			wantType: "video/webm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &videoModel{opts: options{
+				baseURL: "https://video.example.test",
+				httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return tt.response, nil
+				})},
+			}}
+			videos, err := model.downloadVideos(t.Context(), "key", []googleVideoFile{{
+				URI:      "https://video.example.test/video",
+				MimeType: "video/webm",
+			}})
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error = %v, want %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil || len(videos) != 1 || videos[0].MediaType != tt.wantType {
+				t.Fatalf("videos = %#v, error = %v", videos, err)
+			}
+		})
+	}
+}
+
 func TestVideo_CancelsStartRequest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()

--- a/provider/google/video_test.go
+++ b/provider/google/video_test.go
@@ -1,9 +1,12 @@
 package google
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -425,6 +428,88 @@ func TestVideo_RejectsOversizedDownload(t *testing.T) {
 		t.Fatalf("error = %v, want download limit error", err)
 	}
 }
+
+func TestVideo_LimitsDownloadErrorBody(t *testing.T) {
+	body := &countingVideoBody{remaining: 2 << 20}
+	model := &videoModel{opts: options{
+		baseURL:     "https://video.example.test",
+		tokenSource: provider.StaticToken("key"),
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		})},
+	}}
+
+	_, err := model.downloadVideos(t.Context(), "key", []googleVideoFile{{URI: "https://video.example.test/video.mp4"}})
+	if err == nil {
+		t.Fatal("expected download error")
+	}
+	if body.read > (1<<20)+1 {
+		t.Fatalf("read %d error-body bytes, want at most %d", body.read, (1<<20)+1)
+	}
+}
+
+func TestVideo_CancelsStartRequest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	model := Video(
+		"veo-test",
+		WithAPIKey("key"),
+		WithBaseURL("https://video.example.test"),
+		WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})}),
+	)
+	_, err := model.DoGenerate(ctx, provider.VideoParams{Prompt: "test", N: 1})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestVideo_CancelsDownloadRequest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	model := Video(
+		"veo-test",
+		WithAPIKey("key"),
+		WithBaseURL("https://video.example.test"),
+		WithHTTPClient(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})}),
+	).(*videoModel)
+	_, err := model.downloadVideos(ctx, "key", []googleVideoFile{{URI: "https://video.example.test/video.mp4"}})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline exceeded", err)
+	}
+}
+
+type countingVideoBody struct {
+	remaining int64
+	read      int64
+}
+
+func (b *countingVideoBody) Read(p []byte) (int, error) {
+	if b.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if n > b.remaining {
+		n = b.remaining
+	}
+	for i := int64(0); i < n; i++ {
+		p[i] = 'x'
+	}
+	b.remaining -= n
+	b.read += n
+	return int(n), nil
+}
+
+func (*countingVideoBody) Close() error { return nil }
 
 func TestVideo_PollTimeoutBoundsInFlightRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider/google/video_test.go
+++ b/provider/google/video_test.go
@@ -1,0 +1,470 @@
+package google
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/provider"
+)
+
+func TestVideo_GenerateIntegration(t *testing.T) {
+	var polls atomic.Int32
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-goog-api-key") != "test-key" {
+			t.Errorf("x-goog-api-key = %q", r.Header.Get("x-goog-api-key"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1beta/models/veo-3.1-generate-preview:predictLongRunning":
+			if r.Method != http.MethodPost {
+				t.Errorf("method = %s, want POST", r.Method)
+			}
+			var body struct {
+				Instances []struct {
+					Prompt string `json:"prompt"`
+					Image  *struct {
+						BytesBase64Encoded string `json:"bytesBase64Encoded"`
+						MimeType           string `json:"mimeType"`
+					} `json:"image"`
+				} `json:"instances"`
+				Parameters map[string]any `json:"parameters"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if len(body.Instances) != 1 || body.Instances[0].Prompt != "a paper plane taking flight" {
+				t.Errorf("instances = %+v", body.Instances)
+			}
+			if got := body.Instances[0].Image; got == nil || got.BytesBase64Encoded != base64.StdEncoding.EncodeToString([]byte("png")) || got.MimeType != "image/png" {
+				t.Errorf("image = %+v", got)
+			}
+			if body.Parameters["sampleCount"] != float64(1) || body.Parameters["aspectRatio"] != "16:9" {
+				t.Errorf("parameters = %+v", body.Parameters)
+			}
+			if body.Parameters["durationSeconds"] != float64(8) || body.Parameters["generateAudio"] != true {
+				t.Errorf("parameters = %+v", body.Parameters)
+			}
+			_, _ = fmt.Fprint(w, `{"name":"models/veo-3.1-generate-preview/operations/op-123"}`)
+
+		case "/v1beta/models/veo-3.1-generate-preview/operations/op-123":
+			if r.Method != http.MethodGet {
+				t.Errorf("method = %s, want GET", r.Method)
+			}
+			if polls.Add(1) == 1 {
+				_, _ = fmt.Fprint(w, `{"name":"models/veo-3.1-generate-preview/operations/op-123","done":false}`)
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"name":"models/veo-3.1-generate-preview/operations/op-123","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":%q}}]}}}`, serverURL+"/download/video.mp4")
+
+		case "/download/video.mp4":
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("fake-mp4"))
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	model := Video("veo-3.1-generate-preview",
+		WithAPIKey("test-key"),
+		WithBaseURL(server.URL),
+	)
+	result, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("a paper plane taking flight"),
+		goai.WithVideoImage(provider.MediaData{Data: []byte("png"), MediaType: "image/png"}),
+		goai.WithVideoAspectRatio("16:9"),
+		goai.WithVideoDuration(8*time.Second),
+		goai.WithVideoAudio(true),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if polls.Load() != 2 {
+		t.Errorf("polls = %d, want 2", polls.Load())
+	}
+	if len(result.Videos) != 1 || string(result.Video.Data) != "fake-mp4" {
+		t.Fatalf("videos = %+v", result.Videos)
+	}
+	if result.Video.MediaType != "video/mp4" {
+		t.Errorf("media type = %q", result.Video.MediaType)
+	}
+	if result.Response.ID != "models/veo-3.1-generate-preview/operations/op-123" {
+		t.Errorf("response ID = %q", result.Response.ID)
+	}
+}
+
+func TestVideo_OperationError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			_, _ = fmt.Fprint(w, `{"name":"operations/failed"}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"name":"operations/failed","done":true,"error":{"code":13,"message":"generation failed"}}`)
+	}))
+	defer server.Close()
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+		goai.WithVideoMaxRetries(0),
+	)
+	if err == nil || err.Error() != "google video generation failed: generation failed (code 13)" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestVideo_DownloadRedirectDoesNotLeakAPIKey(t *testing.T) {
+	var leakedKey string
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leakedKey = r.Header.Get("x-goog-api-key")
+		w.Header().Set("Content-Type", "video/mp4")
+		_, _ = w.Write([]byte("video"))
+	}))
+	defer downloadServer.Close()
+
+	var apiServerURL string
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-goog-api-key") != "test-key" {
+			t.Errorf("API request key = %q", r.Header.Get("x-goog-api-key"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPost:
+			_, _ = fmt.Fprint(w, `{"name":"operations/redirect"}`)
+		case http.MethodGet:
+			if r.URL.Path == "/download/redirect" {
+				http.Redirect(w, r, downloadServer.URL+"/video.mp4", http.StatusFound)
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"name":"operations/redirect","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":%q}}]}}}`, apiServerURL+"/download/redirect")
+		}
+	}))
+	defer apiServer.Close()
+	apiServerURL = apiServer.URL
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(apiServer.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err == nil || !strings.Contains(err.Error(), "cross-origin redirect") {
+		t.Fatalf("error = %v, want cross-origin redirect error", err)
+	}
+	if leakedKey != "" {
+		t.Fatalf("API key leaked to redirected origin: %q", leakedKey)
+	}
+}
+
+func TestVideo_AllowsSameOriginDownloadRedirect(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-goog-api-key") != "test-key" {
+			t.Errorf("x-goog-api-key = %q", r.Header.Get("x-goog-api-key"))
+		}
+		switch {
+		case r.Method == http.MethodPost:
+			_, _ = fmt.Fprint(w, `{"name":"operations/same-origin-download"}`)
+		case r.URL.Path == "/v1beta/operations/same-origin-download":
+			_, _ = fmt.Fprintf(w, `{"name":"operations/same-origin-download","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":%q}}]}}}`, serverURL+"/download/start")
+		case r.URL.Path == "/download/start":
+			http.Redirect(w, r, serverURL+"/download/final", http.StatusFound)
+		case r.URL.Path == "/download/final":
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("video"))
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(result.Video.Data) != "video" {
+		t.Fatalf("video = %q", result.Video.Data)
+	}
+}
+
+func TestVideo_RejectsOperationRedirect(t *testing.T) {
+	var redirectedCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirected-start" {
+			redirectedCalls.Add(1)
+			_, _ = fmt.Fprint(w, `{"name":"operations/unsafe"}`)
+			return
+		}
+		http.Redirect(w, r, "/redirected-start", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model, goai.WithVideoPrompt("test"))
+	if err == nil {
+		t.Fatal("expected redirect error")
+	}
+	if redirectedCalls.Load() != 0 {
+		t.Fatalf("redirected operation endpoint called %d times", redirectedCalls.Load())
+	}
+}
+
+func TestVideo_TransientPollFailureDoesNotRestartGeneration(t *testing.T) {
+	var starts atomic.Int32
+	var polls atomic.Int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost:
+			starts.Add(1)
+			_, _ = fmt.Fprint(w, `{"name":"operations/retry-poll"}`)
+		case r.URL.Path == "/v1beta/operations/retry-poll":
+			if polls.Add(1) == 1 {
+				w.Header().Set("retry-after-ms", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = fmt.Fprint(w, `{"error":{"message":"try again"}}`)
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"name":"operations/retry-poll","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":%q}}]}}}`, serverURL+"/video.mp4")
+		case r.URL.Path == "/video.mp4":
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("video"))
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if starts.Load() != 1 {
+		t.Fatalf("generation starts = %d, want 1", starts.Load())
+	}
+	if polls.Load() != 2 {
+		t.Fatalf("polls = %d, want 2", polls.Load())
+	}
+}
+
+func TestVideo_RetriesExplicitStartFailure(t *testing.T) {
+	var starts atomic.Int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost:
+			if starts.Add(1) == 1 {
+				w.Header().Set("retry-after-ms", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = fmt.Fprint(w, `{"error":{"message":"try again"}}`)
+				return
+			}
+			_, _ = fmt.Fprint(w, `{"name":"operations/retry-start"}`)
+		case r.URL.Path == "/v1beta/operations/retry-start":
+			_, _ = fmt.Fprintf(w, `{"name":"operations/retry-start","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":%q}}]}}}`, serverURL+"/video.mp4")
+		case r.URL.Path == "/video.mp4":
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("video"))
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoMaxRetries(1),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if starts.Load() != 2 {
+		t.Fatalf("starts = %d, want 2", starts.Load())
+	}
+}
+
+func TestVideo_DoesNotRetryAmbiguousStartFailure(t *testing.T) {
+	var starts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		starts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"error":{"message":"response lost after enqueue may be ambiguous"}}`)
+	}))
+	defer server.Close()
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoMaxRetries(2),
+	)
+	if err == nil {
+		t.Fatal("expected start error")
+	}
+	if starts.Load() != 1 {
+		t.Fatalf("generation starts = %d, want 1", starts.Load())
+	}
+}
+
+func TestVideo_TransientDownloadFailureDoesNotRestartGeneration(t *testing.T) {
+	var starts atomic.Int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost:
+			starts.Add(1)
+			_, _ = fmt.Fprint(w, `{"name":"operations/download-failure"}`)
+		case r.URL.Path == "/v1beta/operations/download-failure":
+			_, _ = fmt.Fprintf(w, `{"name":"operations/download-failure","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":%q}}]}}}`, serverURL+"/video.mp4")
+		case r.URL.Path == "/video.mp4":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprint(w, `{"error":{"message":"temporarily unavailable"}}`)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoMaxRetries(2),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err == nil {
+		t.Fatal("expected download error")
+	}
+	if starts.Load() != 1 {
+		t.Fatalf("generation starts = %d, want 1", starts.Load())
+	}
+}
+
+func TestVideo_RejectsCrossOriginOperationURL(t *testing.T) {
+	var externalCalls atomic.Int32
+	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		externalCalls.Add(1)
+		_, _ = fmt.Fprint(w, `{"done":false}`)
+	}))
+	defer external.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"name":%q}`, external.URL+"/operations/unsafe")
+	}))
+	defer server.Close()
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err == nil || !strings.Contains(err.Error(), "configured API origin") {
+		t.Fatalf("error = %v, want origin error", err)
+	}
+	if externalCalls.Load() != 0 {
+		t.Fatalf("external operation endpoint called %d times", externalCalls.Load())
+	}
+}
+
+func TestVideo_RejectsOversizedDownload(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost:
+			_, _ = fmt.Fprint(w, `{"name":"operations/oversized"}`)
+		case r.URL.Path == "/v1beta/operations/oversized":
+			_, _ = fmt.Fprintf(w, `{"name":"operations/oversized","done":true,"response":{"generateVideoResponse":{"generatedSamples":[{"video":{"uri":%q}}]}}}`, serverURL+"/video.mp4")
+		case r.URL.Path == "/video.mp4":
+			w.Header().Set("Content-Type", "video/mp4")
+			w.Header().Set("Content-Length", fmt.Sprint(maxGoogleVideoDownloadBytes+1))
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(time.Second),
+	)
+	if err == nil || !strings.Contains(err.Error(), "download limit") {
+		t.Fatalf("error = %v, want download limit error", err)
+	}
+}
+
+func TestVideo_PollTimeoutBoundsInFlightRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			_, _ = fmt.Fprint(w, `{"name":"operations/stalled"}`)
+			return
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	model := Video("veo-3.1-generate-preview", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	started := time.Now()
+	_, err := goai.GenerateVideo(t.Context(), model,
+		goai.WithVideoPrompt("test"),
+		goai.WithVideoPollInterval(time.Millisecond),
+		goai.WithVideoPollTimeout(20*time.Millisecond),
+	)
+	if err == nil || !strings.Contains(err.Error(), "timed out after 20ms") {
+		t.Fatalf("error = %v, want poll timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("poll timeout took %v", elapsed)
+	}
+}
+
+func TestVideoRetryDelay_UsesExponentialBackoff(t *testing.T) {
+	apiErr := &goai.APIError{StatusCode: http.StatusServiceUnavailable, IsRetryable: true}
+	if first, second := videoRetryDelay(apiErr, 0), videoRetryDelay(apiErr, 1); first != 2*time.Second || second != 4*time.Second {
+		t.Fatalf("retry delays = %v, %v; want 2s, 4s", first, second)
+	}
+}
+
+func TestVideoPollRetryDelay_EscalatesPastSmallServerHint(t *testing.T) {
+	apiErr := &goai.APIError{
+		StatusCode:      http.StatusTooManyRequests,
+		IsRetryable:     true,
+		ResponseHeaders: map[string]string{"retry-after-ms": "1"},
+	}
+	if first, second := videoPollRetryDelay(apiErr, 0), videoPollRetryDelay(apiErr, 1); first != 2*time.Second || second != 4*time.Second {
+		t.Fatalf("poll retry delays = %v, %v; want 2s, 4s", first, second)
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -54,3 +54,12 @@ type ImageModel interface {
 	// DoGenerate generates images from the given parameters.
 	DoGenerate(ctx context.Context, params ImageParams) (*ImageResult, error)
 }
+
+// VideoModel generates videos from text and media prompts.
+type VideoModel interface {
+	// ModelID returns the provider-specific model identifier.
+	ModelID() string
+
+	// DoGenerate generates videos from the given parameters.
+	DoGenerate(ctx context.Context, params VideoParams) (*VideoResult, error)
+}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -70,6 +70,19 @@ func (m *mockImageModel) DoGenerate(_ context.Context, _ provider.ImageParams) (
 	}, nil
 }
 
+// mockVideoModel implements provider.VideoModel for testing.
+type mockVideoModel struct {
+	id string
+}
+
+func (m *mockVideoModel) ModelID() string { return m.id }
+
+func (m *mockVideoModel) DoGenerate(_ context.Context, _ provider.VideoParams) (*provider.VideoResult, error) {
+	return &provider.VideoResult{
+		Videos: []provider.VideoData{{Data: []byte("fake-mp4"), MediaType: "video/mp4"}},
+	}, nil
+}
+
 func TestLanguageModelInterface(t *testing.T) {
 	var model provider.LanguageModel = &mockLanguageModel{
 		id: "gpt-4o",
@@ -177,6 +190,24 @@ func TestImageModelInterface(t *testing.T) {
 	}
 	if result.Images[0].MediaType != "image/png" {
 		t.Errorf("MediaType = %q, want %q", result.Images[0].MediaType, "image/png")
+	}
+}
+
+func TestVideoModelInterface(t *testing.T) {
+	var model provider.VideoModel = &mockVideoModel{id: "veo-3.1-generate-preview"}
+
+	if model.ModelID() != "veo-3.1-generate-preview" {
+		t.Errorf("ModelID() = %q", model.ModelID())
+	}
+
+	result, err := model.DoGenerate(t.Context(), provider.VideoParams{
+		Prompt: "a cat walking", N: 1, AspectRatio: "16:9",
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate error: %v", err)
+	}
+	if len(result.Videos) != 1 || result.Videos[0].MediaType != "video/mp4" {
+		t.Fatalf("videos = %+v", result.Videos)
 	}
 }
 
@@ -644,7 +675,6 @@ func TestCachedTokenSource_InvalidateDuringFetch(t *testing.T) {
 		t.Errorf("Token = %q, want %q", fetchTok, "slow-token")
 	}
 }
-
 
 // TestToolResult_JSONMarshal_ErrorAsString verifies FIX 19: ToolResult.Error
 // (an interface) marshals as a string via err.Error() rather than the default

--- a/provider/types.go
+++ b/provider/types.go
@@ -668,6 +668,59 @@ type ResponseMetadata struct {
 	ProviderMetadata map[string]any
 }
 
+// VideoFrameType identifies the role of an image in video generation.
+type VideoFrameType string
+
+const (
+	VideoFrameFirst VideoFrameType = "first_frame"
+	VideoFrameLast  VideoFrameType = "last_frame"
+)
+
+// MediaData contains inline or remote media used by video generation.
+type MediaData struct {
+	Data      []byte
+	URL       string
+	MediaType string
+}
+
+// VideoFrame provides a role-tagged image for video generation.
+type VideoFrame struct {
+	Image MediaData
+	Type  VideoFrameType
+}
+
+// VideoParams contains provider-independent video generation parameters.
+type VideoParams struct {
+	Prompt          string
+	Image           *MediaData
+	N               int
+	AspectRatio     string
+	Resolution      string
+	Duration        time.Duration
+	FPS             int
+	Seed            *int64
+	FrameImages     []VideoFrame
+	InputReferences []MediaData
+	GenerateAudio   *bool
+	ProviderOptions map[string]any
+	MaxRetries      int
+	PollInterval    time.Duration
+	PollTimeout     time.Duration
+}
+
+// VideoResult is the response from video generation.
+type VideoResult struct {
+	Videos           []VideoData
+	ProviderMetadata map[string]map[string]any
+	Response         ResponseMetadata
+}
+
+// VideoData contains a single generated video.
+type VideoData struct {
+	Data      []byte
+	MediaType string
+}
+
 // ImageParams contains parameters for image generation.
 type ImageParams struct {
 	// Prompt describes the image to generate.

--- a/video.go
+++ b/video.go
@@ -57,7 +57,7 @@ func GenerateVideo(ctx context.Context, model provider.VideoModel, opts ...Video
 	if err != nil {
 		return nil, err
 	}
-	if len(result.Videos) == 0 {
+	if result == nil || len(result.Videos) == 0 {
 		return nil, errors.New("goai: no video generated")
 	}
 

--- a/video.go
+++ b/video.go
@@ -1,0 +1,202 @@
+package goai
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+const (
+	defaultVideoPollInterval = 5 * time.Second
+	defaultVideoPollTimeout  = 10 * time.Minute
+)
+
+// GenerateVideo generates videos from text and media prompts.
+func GenerateVideo(ctx context.Context, model provider.VideoModel, opts ...VideoOption) (*VideoResult, error) {
+	if model == nil {
+		return nil, errors.New("goai: model must not be nil")
+	}
+
+	o := videoOptions{
+		n:            1,
+		maxRetries:   2,
+		pollInterval: defaultVideoPollInterval,
+		pollTimeout:  defaultVideoPollTimeout,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	if o.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, o.timeout)
+		defer cancel()
+	}
+
+	params := provider.VideoParams{
+		Prompt:          o.prompt,
+		Image:           o.image,
+		N:               o.n,
+		AspectRatio:     o.aspectRatio,
+		Resolution:      o.resolution,
+		Duration:        o.duration,
+		FPS:             o.fps,
+		Seed:            o.seed,
+		FrameImages:     o.frameImages,
+		InputReferences: o.inputReferences,
+		GenerateAudio:   o.generateAudio,
+		ProviderOptions: o.providerOptions,
+		MaxRetries:      o.maxRetries,
+		PollInterval:    o.pollInterval,
+		PollTimeout:     o.pollTimeout,
+	}
+
+	result, err := model.DoGenerate(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Videos) == 0 {
+		return nil, errors.New("goai: no video generated")
+	}
+
+	return &VideoResult{
+		Video:            result.Videos[0],
+		Videos:           result.Videos,
+		ProviderMetadata: result.ProviderMetadata,
+		Response:         result.Response,
+	}, nil
+}
+
+// VideoResult contains generated videos and provider response metadata.
+type VideoResult struct {
+	Video            provider.VideoData
+	Videos           []provider.VideoData
+	ProviderMetadata map[string]map[string]any
+	Response         provider.ResponseMetadata
+}
+
+// VideoOption configures a GenerateVideo call.
+type VideoOption func(*videoOptions)
+
+type videoOptions struct {
+	prompt          string
+	image           *provider.MediaData
+	n               int
+	aspectRatio     string
+	resolution      string
+	duration        time.Duration
+	fps             int
+	seed            *int64
+	frameImages     []provider.VideoFrame
+	inputReferences []provider.MediaData
+	generateAudio   *bool
+	providerOptions map[string]any
+	maxRetries      int
+	timeout         time.Duration
+	pollInterval    time.Duration
+	pollTimeout     time.Duration
+}
+
+func WithVideoPrompt(prompt string) VideoOption {
+	return func(o *videoOptions) { o.prompt = prompt }
+}
+
+// WithVideoImage sets the initial image for image-to-video generation.
+func WithVideoImage(image provider.MediaData) VideoOption {
+	return func(o *videoOptions) { o.image = &image }
+}
+
+// WithVideoCount sets the number of videos to generate.
+func WithVideoCount(n int) VideoOption {
+	return func(o *videoOptions) {
+		if n < 1 {
+			n = 1
+		}
+		o.n = n
+	}
+}
+
+// WithVideoAspectRatio sets the output aspect ratio, such as "16:9".
+func WithVideoAspectRatio(ratio string) VideoOption {
+	return func(o *videoOptions) { o.aspectRatio = ratio }
+}
+
+// WithVideoResolution sets the provider-supported output resolution.
+func WithVideoResolution(resolution string) VideoOption {
+	return func(o *videoOptions) { o.resolution = resolution }
+}
+
+// WithVideoDuration sets the requested video duration.
+func WithVideoDuration(duration time.Duration) VideoOption {
+	return func(o *videoOptions) { o.duration = duration }
+}
+
+// WithVideoFPS sets the requested frames per second when supported.
+func WithVideoFPS(fps int) VideoOption {
+	return func(o *videoOptions) { o.fps = fps }
+}
+
+// WithVideoSeed sets a deterministic seed when supported.
+func WithVideoSeed(seed int64) VideoOption {
+	return func(o *videoOptions) { o.seed = &seed }
+}
+
+// WithVideoFrameImages sets role-tagged first and last frame images.
+func WithVideoFrameImages(frames ...provider.VideoFrame) VideoOption {
+	return func(o *videoOptions) {
+		o.frameImages = append([]provider.VideoFrame(nil), frames...)
+	}
+}
+
+// WithVideoInputReferences sets reference images or videos for supporting models.
+func WithVideoInputReferences(references ...provider.MediaData) VideoOption {
+	return func(o *videoOptions) {
+		o.inputReferences = append([]provider.MediaData(nil), references...)
+	}
+}
+
+// WithVideoAudio controls whether the model generates audio with the video.
+func WithVideoAudio(enabled bool) VideoOption {
+	return func(o *videoOptions) { o.generateAudio = &enabled }
+}
+
+// WithVideoProviderOptions sets provider-specific video parameters.
+func WithVideoProviderOptions(opts map[string]any) VideoOption {
+	validateProviderOptions("WithVideoProviderOptions", opts)
+	return func(o *videoOptions) { o.providerOptions = opts }
+}
+
+// WithVideoMaxRetries sets retries for rate-limited generation-start requests.
+func WithVideoMaxRetries(n int) VideoOption {
+	return func(o *videoOptions) {
+		if n < 0 {
+			n = 0
+		}
+		o.maxRetries = n
+	}
+}
+
+// WithVideoTimeout sets an overall timeout for video generation.
+func WithVideoTimeout(timeout time.Duration) VideoOption {
+	return func(o *videoOptions) { o.timeout = timeout }
+}
+
+// WithVideoPollInterval sets the interval between operation status checks.
+func WithVideoPollInterval(interval time.Duration) VideoOption {
+	return func(o *videoOptions) {
+		if interval > 0 {
+			o.pollInterval = interval
+		}
+	}
+}
+
+// WithVideoPollTimeout sets the maximum time spent polling an operation.
+func WithVideoPollTimeout(timeout time.Duration) VideoOption {
+	return func(o *videoOptions) {
+		if timeout > 0 {
+			o.pollTimeout = timeout
+		}
+	}
+}

--- a/video_test.go
+++ b/video_test.go
@@ -1,0 +1,154 @@
+package goai
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+type mockVideoModel struct {
+	generateFn func(ctx context.Context, params provider.VideoParams) (*provider.VideoResult, error)
+}
+
+func (m *mockVideoModel) ModelID() string { return "test-video-model" }
+
+func (m *mockVideoModel) DoGenerate(ctx context.Context, params provider.VideoParams) (*provider.VideoResult, error) {
+	return m.generateFn(ctx, params)
+}
+
+func TestGenerateVideo_NilModel(t *testing.T) {
+	_, err := GenerateVideo(t.Context(), nil, WithVideoPrompt("test"))
+	if err == nil || err.Error() != "goai: model must not be nil" {
+		t.Fatalf("error = %v, want nil model error", err)
+	}
+}
+
+func TestGenerateVideo_Defaults(t *testing.T) {
+	model := &mockVideoModel{
+		generateFn: func(_ context.Context, params provider.VideoParams) (*provider.VideoResult, error) {
+			if params.Prompt != "a cat walking" {
+				t.Errorf("prompt = %q", params.Prompt)
+			}
+			if params.N != 1 {
+				t.Errorf("n = %d, want 1", params.N)
+			}
+			if params.PollInterval != 5*time.Second {
+				t.Errorf("poll interval = %v, want 5s", params.PollInterval)
+			}
+			if params.PollTimeout != 10*time.Minute {
+				t.Errorf("poll timeout = %v, want 10m", params.PollTimeout)
+			}
+			return &provider.VideoResult{
+				Videos: []provider.VideoData{{Data: []byte("fake-mp4"), MediaType: "video/mp4"}},
+			}, nil
+		},
+	}
+
+	result, err := GenerateVideo(t.Context(), model, WithVideoPrompt("a cat walking"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Videos) != 1 || string(result.Videos[0].Data) != "fake-mp4" {
+		t.Fatalf("videos = %+v", result.Videos)
+	}
+	if result.Video.MediaType != "video/mp4" {
+		t.Errorf("video media type = %q", result.Video.MediaType)
+	}
+}
+
+func TestGenerateVideo_Options(t *testing.T) {
+	seed := int64(42)
+	inputImage := provider.MediaData{Data: []byte("image"), MediaType: "image/png"}
+	firstFrame := provider.VideoFrame{Image: inputImage, Type: provider.VideoFrameFirst}
+	reference := provider.MediaData{URL: "https://example.com/reference.mp4", MediaType: "video/mp4"}
+
+	model := &mockVideoModel{
+		generateFn: func(_ context.Context, params provider.VideoParams) (*provider.VideoResult, error) {
+			if params.N != 3 || params.AspectRatio != "16:9" || params.Resolution != "1280x720" {
+				t.Errorf("unexpected dimensions/count: %+v", params)
+			}
+			if params.Duration != 8*time.Second || params.FPS != 24 {
+				t.Errorf("duration/fps = %v/%d", params.Duration, params.FPS)
+			}
+			if params.Seed == nil || *params.Seed != seed {
+				t.Errorf("seed = %v", params.Seed)
+			}
+			if params.GenerateAudio == nil || !*params.GenerateAudio {
+				t.Errorf("generate audio = %v", params.GenerateAudio)
+			}
+			if params.Image == nil || string(params.Image.Data) != "image" {
+				t.Errorf("image = %+v", params.Image)
+			}
+			if len(params.FrameImages) != 1 || params.FrameImages[0].Type != provider.VideoFrameFirst {
+				t.Errorf("frame images = %+v", params.FrameImages)
+			}
+			if len(params.InputReferences) != 1 || params.InputReferences[0].URL != reference.URL {
+				t.Errorf("references = %+v", params.InputReferences)
+			}
+			if params.ProviderOptions["google"].(map[string]any)["negativePrompt"] != "rain" {
+				t.Errorf("provider options = %+v", params.ProviderOptions)
+			}
+			return &provider.VideoResult{
+				Videos: []provider.VideoData{{Data: []byte("video"), MediaType: "video/mp4"}},
+			}, nil
+		},
+	}
+
+	_, err := GenerateVideo(t.Context(), model,
+		WithVideoPrompt("test"),
+		WithVideoCount(3),
+		WithVideoAspectRatio("16:9"),
+		WithVideoResolution("1280x720"),
+		WithVideoDuration(8*time.Second),
+		WithVideoFPS(24),
+		WithVideoSeed(seed),
+		WithVideoAudio(true),
+		WithVideoImage(inputImage),
+		WithVideoFrameImages(firstFrame),
+		WithVideoInputReferences(reference),
+		WithVideoProviderOptions(map[string]any{"google": map[string]any{"negativePrompt": "rain"}}),
+		WithVideoPollInterval(time.Millisecond),
+		WithVideoPollTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateVideo_Timeout(t *testing.T) {
+	model := &mockVideoModel{
+		generateFn: func(ctx context.Context, _ provider.VideoParams) (*provider.VideoResult, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	_, err := GenerateVideo(t.Context(), model,
+		WithVideoPrompt("test"),
+		WithVideoTimeout(20*time.Millisecond),
+	)
+	if err == nil || err != context.DeadlineExceeded {
+		t.Fatalf("error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestGenerateVideo_PassesRetryBudgetToProvider(t *testing.T) {
+	model := &mockVideoModel{
+		generateFn: func(_ context.Context, params provider.VideoParams) (*provider.VideoResult, error) {
+			if params.MaxRetries != 1 {
+				t.Errorf("max retries = %d, want 1", params.MaxRetries)
+			}
+			return &provider.VideoResult{Videos: []provider.VideoData{{Data: []byte("video")}}}, nil
+		},
+	}
+
+	_, err := GenerateVideo(t.Context(), model,
+		WithVideoPrompt("test"),
+		WithVideoMaxRetries(1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/video_test.go
+++ b/video_test.go
@@ -2,6 +2,7 @@ package goai
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -90,6 +91,9 @@ func TestGenerateVideo_Options(t *testing.T) {
 			if params.ProviderOptions["google"].(map[string]any)["negativePrompt"] != "rain" {
 				t.Errorf("provider options = %+v", params.ProviderOptions)
 			}
+			if params.PollInterval != time.Millisecond || params.PollTimeout != time.Second {
+				t.Errorf("poll interval/timeout = %v/%v", params.PollInterval, params.PollTimeout)
+			}
 			return &provider.VideoResult{
 				Videos: []provider.VideoData{{Data: []byte("video"), MediaType: "video/mp4"}},
 			}, nil
@@ -147,6 +151,48 @@ func TestGenerateVideo_PassesRetryBudgetToProvider(t *testing.T) {
 	_, err := GenerateVideo(t.Context(), model,
 		WithVideoPrompt("test"),
 		WithVideoMaxRetries(1),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateVideo_ErrorAndEmptyResult(t *testing.T) {
+	t.Run("provider error", func(t *testing.T) {
+		want := errors.New("provider failed")
+		model := &mockVideoModel{generateFn: func(context.Context, provider.VideoParams) (*provider.VideoResult, error) {
+			return nil, want
+		}}
+		if _, err := GenerateVideo(t.Context(), model); !errors.Is(err, want) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		model := &mockVideoModel{generateFn: func(context.Context, provider.VideoParams) (*provider.VideoResult, error) {
+			return &provider.VideoResult{}, nil
+		}}
+		if _, err := GenerateVideo(t.Context(), model); err == nil || err.Error() != "goai: no video generated" {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestVideoOptionClamps(t *testing.T) {
+	model := &mockVideoModel{generateFn: func(_ context.Context, params provider.VideoParams) (*provider.VideoResult, error) {
+		if params.N != 1 || params.MaxRetries != 0 {
+			t.Fatalf("params = %#v", params)
+		}
+		if params.PollInterval != defaultVideoPollInterval || params.PollTimeout != defaultVideoPollTimeout {
+			t.Fatalf("poll defaults = %v, %v", params.PollInterval, params.PollTimeout)
+		}
+		return &provider.VideoResult{Videos: []provider.VideoData{{Data: []byte("video")}}}, nil
+	}}
+	_, err := GenerateVideo(t.Context(), model,
+		WithVideoCount(0),
+		WithVideoMaxRetries(-1),
+		WithVideoPollInterval(0),
+		WithVideoPollTimeout(0),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/video_test.go
+++ b/video_test.go
@@ -176,6 +176,15 @@ func TestGenerateVideo_ErrorAndEmptyResult(t *testing.T) {
 			t.Fatalf("error = %v", err)
 		}
 	})
+
+	t.Run("nil result", func(t *testing.T) {
+		model := &mockVideoModel{generateFn: func(context.Context, provider.VideoParams) (*provider.VideoResult, error) {
+			return nil, nil
+		}}
+		if _, err := GenerateVideo(t.Context(), model); err == nil || err.Error() != "goai: no video generated" {
+			t.Fatalf("error = %v", err)
+		}
+	})
 }
 
 func TestVideoOptionClamps(t *testing.T) {


### PR DESCRIPTION
## Summary
- add provider-neutral `GenerateVideo` API and video model contracts
- implement Google Veo long-running generation, polling, authenticated downloads, and safety limits
- add mock HTTP integration coverage, credential-gated E2E coverage, docs, and example

## Verification
- `go build ./...`
- `go vet ./...`
- `go test ./...` (2,896 tests across 35 packages)
- tagged E2E test compiles successfully

## Note
- race tests require CGO/gcc; gcc installation was unavailable in this environment