### PR TITLE
fix: repair zenflow review workflow syntax

### DIFF
--- a/.github/workflows/zenflow-review.yml
+++ b/.github/workflows/zenflow-review.yml
@@ -64,9 +64,9 @@ jobs:
           wc -l .zenflow/diff.patch
 
       - name: Run zenflow review
-         env:
-           ZENFLOW_MODEL: fptcloud/Qwen3.6-27B
-           FPT_API_KEY: ${{ secrets.FPT_API_KEY }}
+        env:
+          ZENFLOW_MODEL: fptcloud/Qwen3.6-27B
+          FPT_API_KEY: ${{ secrets.FPT_API_KEY }}
         run: |
           # --sandbox grants the safe tool set (read, write, grep, glob)
           # without bash. Without an explicit permission flag zenflow


### PR DESCRIPTION
## Summary
- fix invalid indentation in the zenflow review workflow
- restore valid GitHub Actions YAML parsing

## Verification
- parsed `.github/workflows/zenflow-review.yml` successfully with PyYAML
- `git diff --check`