### PR TITLE
fix(openai): include empty annotations array in Responses API output_text for Azure compatibility

### DIFF
--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -354,8 +354,9 @@ func convertToResponsesInput(msgs []provider.Message) []map[string]any {
 					items = append(items, message)
 				}
 				messageContent = append(messageContent, map[string]any{
-					"type": "output_text",
-					"text": text,
+					"type":        "output_text",
+					"text":        text,
+					"annotations": []any{},
 				})
 				message["content"] = messageContent
 			}


### PR DESCRIPTION
## Summary

Includes an empty `annotations: []` array when serializing assistant `output_text` items in `convertToResponsesInput`.

## Motivation

Azure OpenAI enforces OpenAPI schema validation on `/openai/v1/responses`, where `output_text` requires the `annotations` property. In multi-turn requests, missing this field causes Azure to reject the payload with `Invalid payload: Required property 'annotations' is missing`. Supplying an empty array resolves the issue while maintaining full OpenAI compatibility.