### PR TITLE
feat(google): computer use tool (ComputerUse factory)

### DIFF
--- a/provider/google/tools.go
+++ b/provider/google/tools.go
@@ -26,10 +26,19 @@ var Tools = struct {
 	// use the output to formulate its response.
 	// Requires Gemini 2.0+.
 	CodeExecution func() provider.ToolDefinition
+
+	// ComputerUse enables Gemini's computer use tool: the model sees screenshots
+	// and emits UI actions (click, type, scroll, …) that the client executes,
+	// returning a fresh screenshot. Client-executed: each action arrives as a
+	// regular functionCall and its result goes back as a functionResponse.
+	// The Gemini 3.x family has it built-in (just add the tool); 2.5 needs the
+	// dedicated gemini-2.5-computer-use-preview model.
+	ComputerUse func(opts ...ComputerUseOption) provider.ToolDefinition
 }{
 	GoogleSearch:  googleSearchTool,
 	URLContext:    urlContextTool,
 	CodeExecution: codeExecutionTool,
+	ComputerUse:   computerUseTool,
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +127,57 @@ func codeExecutionTool() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:                "code_execution",
 		ProviderDefinedType: "google.code_execution",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ComputerUse
+// ---------------------------------------------------------------------------
+
+// ComputerUseOption configures the computer use tool.
+type ComputerUseOption func(*computerUseConfig)
+
+type computerUseConfig struct {
+	// Environment is the target surface enum the model controls (e.g. the
+	// browser or the full desktop). Passed through verbatim to the wire; the
+	// caller owns the exact enum string the API expects.
+	Environment string
+	// ExcludedPredefinedFunctions lists built-in action names to disable, so the
+	// model never emits them (e.g. omit navigation in a kiosk).
+	ExcludedPredefinedFunctions []string
+}
+
+// WithEnvironment sets the computer use environment (the surface the model
+// controls). The value is the API enum string and is sent unchanged.
+func WithEnvironment(env string) ComputerUseOption {
+	return func(c *computerUseConfig) { c.Environment = env }
+}
+
+// WithExcludedFunctions disables specific predefined actions for this session.
+func WithExcludedFunctions(fns ...string) ComputerUseOption {
+	return func(c *computerUseConfig) { c.ExcludedPredefinedFunctions = fns }
+}
+
+func computerUseTool(opts ...ComputerUseOption) provider.ToolDefinition {
+	cfg := &computerUseConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	providerOpts := map[string]any{}
+	if cfg.Environment != "" {
+		providerOpts["environment"] = cfg.Environment
+	}
+	if len(cfg.ExcludedPredefinedFunctions) > 0 {
+		providerOpts["excludedPredefinedFunctions"] = cfg.ExcludedPredefinedFunctions
+	}
+
+	// googleProviderTool camelCases "google.computer_use" -> "computerUse" and
+	// nests providerOpts under it: {"computerUse": {"environment": "..."}}.
+	return provider.ToolDefinition{
+		Name:                   "computer_use",
+		ProviderDefinedType:    "google.computer_use",
+		ProviderDefinedOptions: providerOpts,
 	}
 }
 

--- a/provider/google/tools_test.go
+++ b/provider/google/tools_test.go
@@ -212,3 +212,51 @@ func TestSnakeToCamel(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ComputerUse
+// ---------------------------------------------------------------------------
+
+func TestTools_ComputerUse_Default(t *testing.T) {
+	def := Tools.ComputerUse()
+	if def.Name != "computer_use" {
+		t.Errorf("Name = %q, want computer_use", def.Name)
+	}
+	if def.ProviderDefinedType != "google.computer_use" {
+		t.Errorf("ProviderDefinedType = %q, want google.computer_use", def.ProviderDefinedType)
+	}
+	if len(def.ProviderDefinedOptions) != 0 {
+		t.Errorf("expected empty options, got %v", def.ProviderDefinedOptions)
+	}
+}
+
+func TestTools_ComputerUse_Options(t *testing.T) {
+	def := Tools.ComputerUse(
+		WithEnvironment("ENVIRONMENT_BROWSER"),
+		WithExcludedFunctions("open_web_browser", "search"),
+	)
+	opts := def.ProviderDefinedOptions
+	if opts["environment"] != "ENVIRONMENT_BROWSER" {
+		t.Errorf("environment = %v, want ENVIRONMENT_BROWSER", opts["environment"])
+	}
+	excluded, ok := opts["excludedPredefinedFunctions"].([]string)
+	if !ok {
+		t.Fatalf("excludedPredefinedFunctions = %T, want []string", opts["excludedPredefinedFunctions"])
+	}
+	if len(excluded) != 2 || excluded[0] != "open_web_browser" || excluded[1] != "search" {
+		t.Errorf("excludedPredefinedFunctions = %v", excluded)
+	}
+}
+
+// The tool reaches the wire under its camelCased key, with the options nested
+// inside it -- the shape the API expects.
+func TestTools_ComputerUse_WireShape(t *testing.T) {
+	wire := googleProviderTool(Tools.ComputerUse(WithEnvironment("ENVIRONMENT_BROWSER")))
+	inner, ok := wire["computerUse"].(map[string]any)
+	if !ok {
+		t.Fatalf("wire = %v, want a computerUse key", wire)
+	}
+	if inner["environment"] != "ENVIRONMENT_BROWSER" {
+		t.Errorf("computerUse.environment = %v", inner["environment"])
+	}
+}


### PR DESCRIPTION
Gemini's computer use tool lets the model drive a UI: it sees a screenshot and emits actions (click, type, scroll) that the client executes, returning a fresh screenshot. The actions arrive as ordinary `functionCall`s and their results go back as `functionResponse`s, so the existing tool loop already handles the round trip — but there is no way to declare the tool in the first place.

`Tools` exposes `GoogleSearch`, `URLContext` and `CodeExecution`; computer use is missing, so a caller has to hand-build the `ToolDefinition` and know the wire key it maps to.

**Change:** add a `Tools.ComputerUse` factory following the same shape as the existing provider-defined tools, with two options:

- `WithEnvironment` selects the surface the model controls. The value is the API enum string and is passed through verbatim, so a new environment does not need an SDK release.
- `WithExcludedFunctions` disables specific predefined actions, which is what you want when the client cannot honour some of them (no navigation in a kiosk, for instance).

Both are optional: `Tools.ComputerUse()` emits the bare tool. The definition reaches the wire through the existing `googleProviderTool` path, which camelCases `google.computer_use` into `computerUse` and nests the options under it, so no new serialization is involved.

Purely additive — it adds a constructor and touches nothing on the request path.

**Tests:** the default definition, both options, and the resulting wire shape. Package coverage 98.6%.
