### PR TITLE
feat(vertex): add native Gemini transport

### DIFF
--- a/internal/geminichat/bridge.go
+++ b/internal/geminichat/bridge.go
@@ -1,0 +1,32 @@
+package geminichat
+
+import (
+	"net/http"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+// Config contains transport-neutral native Gemini chat configuration.
+type Config struct {
+	Project     string
+	Location    string
+	BaseURL     string
+	TokenSource provider.TokenSource
+	Headers     map[string]string
+	HTTPClient  *http.Client
+}
+
+var factory func(string, Config) provider.LanguageModel
+
+// RegisterFactory installs the native Gemini model implementation.
+func RegisterFactory(f func(string, Config) provider.LanguageModel) {
+	factory = f
+}
+
+// New creates a native Gemini language model through the registered provider.
+func New(modelID string, cfg Config) provider.LanguageModel {
+	if factory == nil {
+		panic("geminichat: provider factory is not registered")
+	}
+	return factory(modelID, cfg)
+}

--- a/internal/geminichat/bridge_test.go
+++ b/internal/geminichat/bridge_test.go
@@ -1,0 +1,42 @@
+package geminichat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/zendev-sh/goai/provider"
+)
+
+type testModel struct{ id string }
+
+func (m *testModel) ModelID() string { return m.id }
+
+func (m *testModel) DoGenerate(context.Context, provider.GenerateParams) (*provider.GenerateResult, error) {
+	return &provider.GenerateResult{}, nil
+}
+
+func (m *testModel) DoStream(context.Context, provider.GenerateParams) (*provider.StreamResult, error) {
+	return &provider.StreamResult{}, nil
+}
+
+func TestFactoryRegistration(t *testing.T) {
+	original := factory
+	t.Cleanup(func() { factory = original })
+
+	factory = nil
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("New() should panic without a registered factory")
+			}
+		}()
+		_ = New("missing", Config{})
+	}()
+
+	RegisterFactory(func(modelID string, _ Config) provider.LanguageModel {
+		return &testModel{id: modelID}
+	})
+	if got := New("registered", Config{}).ModelID(); got != "registered" {
+		t.Errorf("ModelID() = %q, want registered", got)
+	}
+}

--- a/provider/google/embedding.go
+++ b/provider/google/embedding.go
@@ -54,6 +54,9 @@ func (m *embeddingModel) ModelID() string { return m.id }
 func (m *embeddingModel) MaxValuesPerCall() int { return 100 }
 
 func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params provider.EmbedParams) (*provider.EmbedResult, error) {
+	if err := validateNonChatOptions(m.opts); err != nil {
+		return nil, err
+	}
 	token, err := m.resolveToken(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolving auth token: %w", err)

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -45,6 +46,14 @@ type options struct {
 	baseURL     string
 	headers     map[string]string
 	httpClient  *http.Client
+
+	// Vertex AI mode: when isVertex is set, requests route to the
+	// {location}-aiplatform.googleapis.com endpoints and authenticate with a
+	// Bearer OAuth token instead of the x-goog-api-key header. The native wire
+	// format (serialization, SSE, thinking, grounding) is identical.
+	isVertex bool
+	project  string
+	location string
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -58,6 +67,18 @@ func WithAPIKey(key string) Option {
 func WithTokenSource(ts provider.TokenSource) Option {
 	return func(o *options) {
 		o.tokenSource = ts
+	}
+}
+
+// WithVertex routes requests through Google Cloud Vertex AI (native Gemini
+// REST over the aiplatform endpoints, Bearer OAuth auth) instead of the
+// generativelanguage.googleapis.com API. The token source must yield a GCP
+// OAuth access token (see provider.CachedTokenSource over a service account).
+func WithVertex(project, location string) Option {
+	return func(o *options) {
+		o.isVertex = true
+		o.project = project
+		o.location = location
 	}
 }
 
@@ -143,7 +164,10 @@ func (m *chatModel) DoGenerate(ctx context.Context, params provider.GeneratePara
 	if err != nil {
 		return nil, err
 	}
-	reqURL := fmt.Sprintf("%s/v1beta/models/%s:generateContent", m.opts.baseURL, url.PathEscape(m.id))
+	reqURL, err := m.endpointURL("generateContent", "")
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := m.doHTTP(ctx, reqURL, body, params.Headers)
 	if err != nil {
@@ -167,7 +191,10 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	if err != nil {
 		return nil, err
 	}
-	reqURL := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", m.opts.baseURL, url.PathEscape(m.id))
+	reqURL, err := m.endpointURL("streamGenerateContent", "?alt=sse")
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := m.doHTTP(ctx, reqURL, body, params.Headers)
 	if err != nil {
@@ -912,7 +939,11 @@ func (m *chatModel) doHTTP(ctx context.Context, url string, body any, perRequest
 	jsonBody := httpc.MustMarshalJSON(body)
 	req := httpc.MustNewRequest(ctx, "POST", url, jsonBody)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-goog-api-key", token)
+	if m.opts.isVertex {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		req.Header.Set("x-goog-api-key", token)
+	}
 
 	for k, v := range m.opts.headers {
 		req.Header.Set(k, v)
@@ -940,6 +971,41 @@ func (m *chatModel) httpClient() *http.Client {
 		return m.opts.httpClient
 	}
 	return http.DefaultClient
+}
+
+// endpointURL builds the request URL for an action (generateContent /
+// streamGenerateContent). In Vertex mode it targets the aiplatform publisher
+// endpoint; otherwise the generativelanguage base URL. A WithBaseURL override
+// wins in Vertex mode too (testing/proxy).
+func (m *chatModel) endpointURL(action, query string) (string, error) {
+	if !m.opts.isVertex {
+		return fmt.Sprintf("%s/v1beta/models/%s:%s%s", m.opts.baseURL, url.PathEscape(m.id), action, query), nil
+	}
+	if !validGCPIdentifier(m.opts.project) {
+		return "", fmt.Errorf("google: invalid vertex project %q", m.opts.project)
+	}
+	if !validGCPIdentifier(m.opts.location) {
+		return "", fmt.Errorf("google: invalid vertex location %q", m.opts.location)
+	}
+	if base := strings.TrimRight(m.opts.baseURL, "/"); base != defaultBaseURL && base != "" {
+		return fmt.Sprintf("%s/%s:%s%s", base, url.PathEscape(m.id), action, query), nil
+	}
+	// The "global" region has no location prefix on the hostname.
+	host := m.opts.location + "-aiplatform.googleapis.com"
+	if m.opts.location == "global" {
+		host = "aiplatform.googleapis.com"
+	}
+	return fmt.Sprintf("https://%s/v1beta1/projects/%s/locations/%s/publishers/google/models/%s:%s%s",
+		host, m.opts.project, m.opts.location, url.PathEscape(m.id), action, query), nil
+}
+
+// validGCPIdentifier guards project/location before hostname interpolation
+// (anti-SSRF). Allows standard projects (my-project-123), domain-scoped
+// (example.com:proj) and regions (us-east5); blocks /, \, @, .., whitespace.
+var validGCPIdentifierRE = regexp.MustCompile(`^[a-z0-9][a-z0-9.:_-]{0,127}$`)
+
+func validGCPIdentifier(s string) bool {
+	return validGCPIdentifierRE.MatchString(s) && !strings.Contains(s, "..")
 }
 
 func (m *chatModel) resolveToken(ctx context.Context) (string, error) {

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -34,6 +34,8 @@ var (
 	_ provider.LanguageModel          = (*chatModel)(nil)
 	_ provider.CapableModel           = (*chatModel)(nil)
 	_ provider.FileUploadCapableModel = (*chatModel)(nil)
+	_ provider.LanguageModel          = (*vertexChatModel)(nil)
+	_ provider.CapableModel           = (*vertexChatModel)(nil)
 )
 
 const defaultBaseURL = "https://generativelanguage.googleapis.com"
@@ -43,6 +45,7 @@ type Option func(*options)
 
 type options struct {
 	tokenSource provider.TokenSource
+	usesAPIKey  bool
 	baseURL     string
 	headers     map[string]string
 	httpClient  *http.Client
@@ -51,15 +54,17 @@ type options struct {
 	// {location}-aiplatform.googleapis.com endpoints and authenticate with a
 	// Bearer OAuth token instead of the x-goog-api-key header. The native wire
 	// format (serialization, SSE, thinking, grounding) is identical.
-	isVertex bool
-	project  string
-	location string
+	isVertex      bool
+	project       string
+	location      string
+	vertexBaseURL string
 }
 
 // WithAPIKey sets a static API key for authentication.
 func WithAPIKey(key string) Option {
 	return func(o *options) {
 		o.tokenSource = provider.StaticToken(key)
+		o.usesAPIKey = true
 	}
 }
 
@@ -67,6 +72,7 @@ func WithAPIKey(key string) Option {
 func WithTokenSource(ts provider.TokenSource) Option {
 	return func(o *options) {
 		o.tokenSource = ts
+		o.usesAPIKey = false
 	}
 }
 
@@ -79,6 +85,14 @@ func WithVertex(project, location string) Option {
 		o.isVertex = true
 		o.project = project
 		o.location = location
+	}
+}
+
+// WithVertexBaseURL overrides the Vertex models collection URL. The model ID
+// and action are appended to this URL. It has no effect outside Vertex mode.
+func WithVertexBaseURL(url string) Option {
+	return func(o *options) {
+		o.vertexBaseURL = url
 	}
 }
 
@@ -112,21 +126,25 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	// Resolve API key from env if not set.
 	// Support both GOOGLE_GENERATIVE_AI_API_KEY (Vercel AI SDK convention)
 	// and GEMINI_API_KEY (Google's own convention / models.dev).
-	if o.tokenSource == nil {
+	if !o.isVertex && o.tokenSource == nil {
 		if key := cmp.Or(os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY"), os.Getenv("GEMINI_API_KEY")); key != "" {
 			o.tokenSource = provider.StaticToken(key)
 		}
 	}
 	// Resolve base URL from env if not overridden.
-	if o.baseURL == defaultBaseURL {
+	if !o.isVertex && o.baseURL == defaultBaseURL {
 		if base := os.Getenv("GOOGLE_GENERATIVE_AI_BASE_URL"); base != "" {
 			o.baseURL = base
 		}
 	}
-	return &chatModel{
+	model := &chatModel{
 		id:   modelID,
 		opts: o,
 	}
+	if o.isVertex {
+		return &vertexChatModel{model: model}
+	}
+	return model
 }
 
 type chatModel struct {
@@ -154,6 +172,29 @@ func (m *chatModel) Capabilities() provider.ModelCapabilities {
 
 func (m *chatModel) FileUploader() provider.FileUploader {
 	return &fileUploader{opts: m.opts}
+}
+
+// vertexChatModel deliberately does not implement FileUploadCapableModel.
+// Vertex native Gemini endpoints do not support the Gemini Developer API's
+// Files API used by chatModel.FileUploader.
+type vertexChatModel struct {
+	model *chatModel
+}
+
+func (m *vertexChatModel) ModelID() string { return m.model.ModelID() }
+
+func (m *vertexChatModel) Capabilities() provider.ModelCapabilities {
+	caps := m.model.Capabilities()
+	caps.FileUpload = false
+	return caps
+}
+
+func (m *vertexChatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
+	return m.model.DoGenerate(ctx, params)
+}
+
+func (m *vertexChatModel) DoStream(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+	return m.model.DoStream(ctx, params)
 }
 
 func (m *chatModel) DoGenerate(ctx context.Context, params provider.GenerateParams) (*provider.GenerateResult, error) {
@@ -975,8 +1016,7 @@ func (m *chatModel) httpClient() *http.Client {
 
 // endpointURL builds the request URL for an action (generateContent /
 // streamGenerateContent). In Vertex mode it targets the aiplatform publisher
-// endpoint; otherwise the generativelanguage base URL. A WithBaseURL override
-// wins in Vertex mode too (testing/proxy).
+// endpoint; otherwise the generativelanguage base URL.
 func (m *chatModel) endpointURL(action, query string) (string, error) {
 	if !m.opts.isVertex {
 		return fmt.Sprintf("%s/v1beta/models/%s:%s%s", m.opts.baseURL, url.PathEscape(m.id), action, query), nil
@@ -987,7 +1027,7 @@ func (m *chatModel) endpointURL(action, query string) (string, error) {
 	if !validGCPIdentifier(m.opts.location) {
 		return "", fmt.Errorf("google: invalid vertex location %q", m.opts.location)
 	}
-	if base := strings.TrimRight(m.opts.baseURL, "/"); base != defaultBaseURL && base != "" {
+	if base := strings.TrimRight(m.opts.vertexBaseURL, "/"); base != "" {
 		return fmt.Sprintf("%s/%s:%s%s", base, url.PathEscape(m.id), action, query), nil
 	}
 	// The "global" region has no location prefix on the hostname.
@@ -1009,6 +1049,9 @@ func validGCPIdentifier(s string) bool {
 }
 
 func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
+	if m.opts.isVertex && m.opts.usesAPIKey {
+		return "", errors.New("google: WithVertex requires an OAuth token source; API keys are not supported")
+	}
 	if m.opts.tokenSource == nil {
 		return "", errors.New("goai: no API key or token source configured")
 	}

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -1058,6 +1058,13 @@ func (m *chatModel) resolveToken(ctx context.Context) (string, error) {
 	return m.opts.tokenSource.Token(ctx)
 }
 
+func validateNonChatOptions(o options) error {
+	if o.isVertex {
+		return errors.New("google: WithVertex is only supported by Chat; use provider/vertex for other model types")
+	}
+	return nil
+}
+
 // --- Schema sanitization ---
 
 // sanitizeGeminiSchema delegates to the shared internal implementation.

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/internal/gemini"
+	"github.com/zendev-sh/goai/internal/geminichat"
 	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/sse"
 	"github.com/zendev-sh/goai/provider"
@@ -39,6 +40,10 @@ var (
 )
 
 const defaultBaseURL = "https://generativelanguage.googleapis.com"
+
+func init() {
+	geminichat.RegisterFactory(newVertexChat)
+}
 
 // Option configures the Google provider.
 type Option func(*options)
@@ -76,14 +81,7 @@ func WithTokenSource(ts provider.TokenSource) Option {
 	}
 }
 
-// WithVertex routes requests through Google Cloud Vertex AI (native Gemini
-// REST over the aiplatform endpoints, Bearer OAuth auth) instead of the
-// generativelanguage.googleapis.com API. The token source must yield a GCP
-// OAuth access token (see provider.CachedTokenSource over a service account).
-//
-// Applications should normally use vertex.Chat with vertex.WithNativeGemini so
-// Vertex auth, project, location, and environment resolution stay centralized.
-func WithVertex(project, location string) Option {
+func withVertex(project, location string) Option {
 	return func(o *options) {
 		o.isVertex = true
 		o.project = project
@@ -91,15 +89,27 @@ func WithVertex(project, location string) Option {
 	}
 }
 
-// WithVertexBaseURL overrides the Vertex models collection URL. The model ID
-// and action are appended to this URL. It has no effect outside Vertex mode.
-//
-// Applications should normally configure this through vertex.WithBaseURL and
-// vertex.WithNativeGemini.
-func WithVertexBaseURL(url string) Option {
+func withVertexBaseURL(url string) Option {
 	return func(o *options) {
 		o.vertexBaseURL = url
 	}
+}
+
+func newVertexChat(modelID string, cfg geminichat.Config) provider.LanguageModel {
+	model := &chatModel{
+		id: modelID,
+		opts: options{
+			tokenSource:   cfg.TokenSource,
+			baseURL:       defaultBaseURL,
+			headers:       cfg.Headers,
+			httpClient:    cfg.HTTPClient,
+			isVertex:      true,
+			project:       cfg.Project,
+			location:      cfg.Location,
+			vertexBaseURL: cfg.BaseURL,
+		},
+	}
+	return &vertexChatModel{model: model}
 }
 
 // WithBaseURL overrides the default Gemini API base URL.

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -80,6 +80,9 @@ func WithTokenSource(ts provider.TokenSource) Option {
 // REST over the aiplatform endpoints, Bearer OAuth auth) instead of the
 // generativelanguage.googleapis.com API. The token source must yield a GCP
 // OAuth access token (see provider.CachedTokenSource over a service account).
+//
+// Applications should normally use vertex.Chat with vertex.WithNativeGemini so
+// Vertex auth, project, location, and environment resolution stay centralized.
 func WithVertex(project, location string) Option {
 	return func(o *options) {
 		o.isVertex = true
@@ -90,6 +93,9 @@ func WithVertex(project, location string) Option {
 
 // WithVertexBaseURL overrides the Vertex models collection URL. The model ID
 // and action are appended to this URL. It has no effect outside Vertex mode.
+//
+// Applications should normally configure this through vertex.WithBaseURL and
+// vertex.WithNativeGemini.
 func WithVertexBaseURL(url string) Option {
 	return func(o *options) {
 		o.vertexBaseURL = url

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -3363,7 +3363,7 @@ func TestChat_Vertex_Generate_BearerAuth(t *testing.T) {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"hola"}]},"finishReason":"STOP"}]}`)
+		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"hola"}]},"finishReason":"STOP"}]}`)
 	}))
 	defer server.Close()
 
@@ -3414,6 +3414,89 @@ func TestChat_Vertex_RejectsAPIKey(t *testing.T) {
 	}
 }
 
+func TestChat_Vertex_AuthOptionPrecedence(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Errorf("Authorization = %q, want Bearer oauth-token", got)
+		}
+		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer server.Close()
+
+	t.Run("token source after API key wins", func(t *testing.T) {
+		model := Chat("gemini-2.5-pro",
+			WithVertex("my-proj", "us-central1"),
+			WithAPIKey("gemini-api-key"),
+			WithTokenSource(provider.StaticToken("oauth-token")),
+			WithVertexBaseURL(server.URL))
+		if _, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+			Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("API key after token source is rejected", func(t *testing.T) {
+		model := Chat("gemini-2.5-pro",
+			WithVertex("my-proj", "us-central1"),
+			WithTokenSource(provider.StaticToken("oauth-token")),
+			WithAPIKey("gemini-api-key"),
+			WithVertexBaseURL(server.URL))
+		_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+			Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		})
+		if err == nil || !strings.Contains(err.Error(), "OAuth token source") {
+			t.Fatalf("DoGenerate() error = %v, want OAuth token source error", err)
+		}
+	})
+}
+
+func TestChat_Vertex_MissingTokenFailsGenerateAndStream(t *testing.T) {
+	model := Chat("gemini-2.5-pro", WithVertex("my-proj", "us-central1"))
+	params := provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	}
+	if _, err := model.DoGenerate(t.Context(), params); err == nil || !strings.Contains(err.Error(), "no API key or token source") {
+		t.Errorf("DoGenerate() error = %v, want missing token error", err)
+	}
+	if _, err := model.DoStream(t.Context(), params); err == nil || !strings.Contains(err.Error(), "no API key or token source") {
+		t.Errorf("DoStream() error = %v, want missing token error", err)
+	}
+}
+
+func TestVertexOptionsRejectedByNonChatModels(t *testing.T) {
+	t.Setenv("GOOGLE_GENERATIVE_AI_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	opts := []Option{
+		WithVertex("my-proj", "us-central1"),
+		WithTokenSource(provider.StaticToken("oauth-token")),
+	}
+	want := "WithVertex is only supported by Chat"
+
+	for _, modelID := range []string{"imagen-4.0-generate-001", "gemini-2.5-flash-image"} {
+		t.Run("image "+modelID, func(t *testing.T) {
+			_, err := Image(modelID, opts...).DoGenerate(t.Context(), provider.ImageParams{Prompt: "draw", N: 1})
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("DoGenerate() error = %v, want %q", err, want)
+			}
+		})
+	}
+
+	t.Run("embedding", func(t *testing.T) {
+		_, err := Embedding("text-embedding-004", opts...).DoEmbed(t.Context(), []string{"hello"}, provider.EmbedParams{})
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("DoEmbed() error = %v, want %q", err, want)
+		}
+	})
+
+	t.Run("video", func(t *testing.T) {
+		_, err := Video("veo-3.0-generate-preview", opts...).DoGenerate(t.Context(), provider.VideoParams{Prompt: "wave", N: 1})
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("DoGenerate() error = %v, want %q", err, want)
+		}
+	})
+}
+
 func TestChat_Vertex_DoesNotAdvertiseFileUpload(t *testing.T) {
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
@@ -3443,6 +3526,32 @@ func TestChat_Vertex_WithBaseURLDoesNotOverrideVertexEndpoint(t *testing.T) {
 	}
 	want := "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent"
 	if got != want {
+		t.Errorf("endpointURL() = %q, want %q", got, want)
+	}
+}
+
+func TestChat_VertexBaseURLIsNormalizedAndIgnoredOutsideVertex(t *testing.T) {
+	vertex := Chat("gemini-2.5-pro",
+		WithVertex("my-proj", "us-central1"),
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithVertexBaseURL("https://vertex.example.test/models/"))
+	got, err := vertex.(*vertexChatModel).model.endpointURL("generateContent", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://vertex.example.test/models/gemini-2.5-pro:generateContent"; got != want {
+		t.Errorf("endpointURL() = %q, want %q", got, want)
+	}
+
+	gemini := Chat("gemini-2.5-flash",
+		WithAPIKey("api-key"),
+		WithBaseURL("https://gemini.example.test"),
+		WithVertexBaseURL("https://vertex.example.test/models"))
+	got, err = gemini.(*chatModel).endpointURL("generateContent", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://gemini.example.test/v1beta/models/gemini-2.5-flash:generateContent"; got != want {
 		t.Errorf("endpointURL() = %q, want %q", got, want)
 	}
 }
@@ -3481,7 +3590,7 @@ func TestChat_Vertex_BearerAuth(t *testing.T) {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprint(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hola\"}]},\"finishReason\":\"STOP\"}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hola\"}]},\"finishReason\":\"STOP\"}]}\n\n")
 	}))
 	defer server.Close()
 

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/internal/geminichat"
 	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/provider"
 )
@@ -3315,6 +3316,27 @@ func TestChat_PromptCachingIgnored(t *testing.T) {
 
 // --- Vertex mode ---
 
+func TestNewVertexChat(t *testing.T) {
+	model := newVertexChat("gemini-2.5-pro", geminichat.Config{
+		Project:     "my-proj",
+		Location:    "global",
+		BaseURL:     "https://vertex.example.test/models",
+		TokenSource: provider.StaticToken("oauth-token"),
+		Headers:     map[string]string{"X-Custom": "value"},
+		HTTPClient:  &http.Client{},
+	})
+	vertexModel, ok := model.(*vertexChatModel)
+	if !ok {
+		t.Fatalf("newVertexChat() type = %T, want *vertexChatModel", model)
+	}
+	if vertexModel.model.opts.project != "my-proj" || vertexModel.model.opts.location != "global" {
+		t.Errorf("Vertex config = %#v, want project/location preserved", vertexModel.model.opts)
+	}
+	if vertexModel.model.opts.vertexBaseURL != "https://vertex.example.test/models" {
+		t.Errorf("vertexBaseURL = %q", vertexModel.model.opts.vertexBaseURL)
+	}
+}
+
 // TestVertexEndpointURL checks the aiplatform URL construction, the "global"
 // region special case, and the anti-SSRF guard.
 func TestVertexEndpointURL(t *testing.T) {
@@ -3369,8 +3391,8 @@ func TestChat_Vertex_Generate_BearerAuth(t *testing.T) {
 
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithVertex("my-proj", "us-central1"),
-		WithVertexBaseURL(server.URL))
+		withVertex("my-proj", "us-central1"),
+		withVertexBaseURL(server.URL))
 
 	res, err := model.DoGenerate(context.Background(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
@@ -3388,7 +3410,7 @@ func TestChat_Vertex_IgnoresGeminiEnvironment(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "gemini-fallback-key")
 	t.Setenv("GOOGLE_GENERATIVE_AI_BASE_URL", "https://gemini.example.test")
 
-	model := Chat("gemini-2.5-pro", WithVertex("my-proj", "us-central1"))
+	model := Chat("gemini-2.5-pro", withVertex("my-proj", "us-central1"))
 	vertexModel, ok := model.(*vertexChatModel)
 	if !ok {
 		t.Fatalf("Chat() type = %T, want *vertexChatModel", model)
@@ -3403,7 +3425,7 @@ func TestChat_Vertex_IgnoresGeminiEnvironment(t *testing.T) {
 
 func TestChat_Vertex_RejectsAPIKey(t *testing.T) {
 	model := Chat("gemini-2.5-pro",
-		WithVertex("my-proj", "us-central1"),
+		withVertex("my-proj", "us-central1"),
 		WithAPIKey("gemini-api-key"))
 
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
@@ -3425,10 +3447,10 @@ func TestChat_Vertex_AuthOptionPrecedence(t *testing.T) {
 
 	t.Run("token source after API key wins", func(t *testing.T) {
 		model := Chat("gemini-2.5-pro",
-			WithVertex("my-proj", "us-central1"),
+			withVertex("my-proj", "us-central1"),
 			WithAPIKey("gemini-api-key"),
 			WithTokenSource(provider.StaticToken("oauth-token")),
-			WithVertexBaseURL(server.URL))
+			withVertexBaseURL(server.URL))
 		if _, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 			Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 		}); err != nil {
@@ -3438,10 +3460,10 @@ func TestChat_Vertex_AuthOptionPrecedence(t *testing.T) {
 
 	t.Run("API key after token source is rejected", func(t *testing.T) {
 		model := Chat("gemini-2.5-pro",
-			WithVertex("my-proj", "us-central1"),
+			withVertex("my-proj", "us-central1"),
 			WithTokenSource(provider.StaticToken("oauth-token")),
 			WithAPIKey("gemini-api-key"),
-			WithVertexBaseURL(server.URL))
+			withVertexBaseURL(server.URL))
 		_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 			Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 		})
@@ -3452,7 +3474,7 @@ func TestChat_Vertex_AuthOptionPrecedence(t *testing.T) {
 }
 
 func TestChat_Vertex_MissingTokenFailsGenerateAndStream(t *testing.T) {
-	model := Chat("gemini-2.5-pro", WithVertex("my-proj", "us-central1"))
+	model := Chat("gemini-2.5-pro", withVertex("my-proj", "us-central1"))
 	params := provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 	}
@@ -3468,7 +3490,7 @@ func TestVertexOptionsRejectedByNonChatModels(t *testing.T) {
 	t.Setenv("GOOGLE_GENERATIVE_AI_API_KEY", "")
 	t.Setenv("GEMINI_API_KEY", "")
 	opts := []Option{
-		WithVertex("my-proj", "us-central1"),
+		withVertex("my-proj", "us-central1"),
 		WithTokenSource(provider.StaticToken("oauth-token")),
 	}
 	want := "WithVertex is only supported by Chat"
@@ -3500,7 +3522,7 @@ func TestVertexOptionsRejectedByNonChatModels(t *testing.T) {
 func TestChat_Vertex_DoesNotAdvertiseFileUpload(t *testing.T) {
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithVertex("my-proj", "us-central1"))
+		withVertex("my-proj", "us-central1"))
 
 	if _, ok := model.(provider.FileUploadCapableModel); ok {
 		t.Fatalf("Vertex model type %T must not implement FileUploadCapableModel", model)
@@ -3516,7 +3538,7 @@ func TestChat_Vertex_DoesNotAdvertiseFileUpload(t *testing.T) {
 func TestChat_Vertex_WithBaseURLDoesNotOverrideVertexEndpoint(t *testing.T) {
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithVertex("my-proj", "us-central1"),
+		withVertex("my-proj", "us-central1"),
 		WithBaseURL("https://gemini.example.test"))
 	vertexModel := model.(*vertexChatModel)
 
@@ -3532,9 +3554,9 @@ func TestChat_Vertex_WithBaseURLDoesNotOverrideVertexEndpoint(t *testing.T) {
 
 func TestChat_VertexBaseURLIsNormalizedAndIgnoredOutsideVertex(t *testing.T) {
 	vertex := Chat("gemini-2.5-pro",
-		WithVertex("my-proj", "us-central1"),
+		withVertex("my-proj", "us-central1"),
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithVertexBaseURL("https://vertex.example.test/models/"))
+		withVertexBaseURL("https://vertex.example.test/models/"))
 	got, err := vertex.(*vertexChatModel).model.endpointURL("generateContent", "")
 	if err != nil {
 		t.Fatal(err)
@@ -3546,7 +3568,7 @@ func TestChat_VertexBaseURLIsNormalizedAndIgnoredOutsideVertex(t *testing.T) {
 	gemini := Chat("gemini-2.5-flash",
 		WithAPIKey("api-key"),
 		WithBaseURL("https://gemini.example.test"),
-		WithVertexBaseURL("https://vertex.example.test/models"))
+		withVertexBaseURL("https://vertex.example.test/models"))
 	got, err = gemini.(*chatModel).endpointURL("generateContent", "")
 	if err != nil {
 		t.Fatal(err)
@@ -3561,7 +3583,7 @@ func TestChat_VertexBaseURLIsNormalizedAndIgnoredOutsideVertex(t *testing.T) {
 func TestChat_Vertex_InvalidEndpointErrors(t *testing.T) {
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("token")),
-		WithVertex("invalid/project", "us-central1"))
+		withVertex("invalid/project", "us-central1"))
 
 	params := provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
@@ -3597,8 +3619,8 @@ func TestChat_Vertex_BearerAuth(t *testing.T) {
 	// Vertex endpoint overrides are separate from Gemini API base URL overrides.
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithVertex("my-proj", "us-central1"),
-		WithVertexBaseURL(server.URL))
+		withVertex("my-proj", "us-central1"),
+		withVertexBaseURL(server.URL))
 
 	res, err := model.DoStream(context.Background(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -28,6 +28,7 @@ type failTokenSource struct{}
 func (f failTokenSource) Token(_ context.Context) (string, error) {
 	return "", fmt.Errorf("token error")
 }
+
 type googleRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f googleRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
@@ -3369,7 +3370,7 @@ func TestChat_Vertex_Generate_BearerAuth(t *testing.T) {
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
 		WithVertex("my-proj", "us-central1"),
-		WithBaseURL(server.URL))
+		WithVertexBaseURL(server.URL))
 
 	res, err := model.DoGenerate(context.Background(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
@@ -3379,6 +3380,70 @@ func TestChat_Vertex_Generate_BearerAuth(t *testing.T) {
 	}
 	if res.Text != "hola" {
 		t.Errorf("text = %q, want hola", res.Text)
+	}
+}
+
+func TestChat_Vertex_IgnoresGeminiEnvironment(t *testing.T) {
+	t.Setenv("GOOGLE_GENERATIVE_AI_API_KEY", "gemini-api-key")
+	t.Setenv("GEMINI_API_KEY", "gemini-fallback-key")
+	t.Setenv("GOOGLE_GENERATIVE_AI_BASE_URL", "https://gemini.example.test")
+
+	model := Chat("gemini-2.5-pro", WithVertex("my-proj", "us-central1"))
+	vertexModel, ok := model.(*vertexChatModel)
+	if !ok {
+		t.Fatalf("Chat() type = %T, want *vertexChatModel", model)
+	}
+	if vertexModel.model.opts.tokenSource != nil {
+		t.Error("Vertex mode must not use a Gemini API key from the environment")
+	}
+	if vertexModel.model.opts.baseURL != defaultBaseURL {
+		t.Errorf("Vertex baseURL = %q, want default %q", vertexModel.model.opts.baseURL, defaultBaseURL)
+	}
+}
+
+func TestChat_Vertex_RejectsAPIKey(t *testing.T) {
+	model := Chat("gemini-2.5-pro",
+		WithVertex("my-proj", "us-central1"),
+		WithAPIKey("gemini-api-key"))
+
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "OAuth token source") {
+		t.Fatalf("DoGenerate() error = %v, want OAuth token source error", err)
+	}
+}
+
+func TestChat_Vertex_DoesNotAdvertiseFileUpload(t *testing.T) {
+	model := Chat("gemini-2.5-pro",
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithVertex("my-proj", "us-central1"))
+
+	if _, ok := model.(provider.FileUploadCapableModel); ok {
+		t.Fatalf("Vertex model type %T must not implement FileUploadCapableModel", model)
+	}
+	if caps := provider.ModelCapabilitiesOf(model); caps.FileUpload {
+		t.Error("Vertex model must not advertise file upload")
+	}
+	if got := model.ModelID(); got != "gemini-2.5-pro" {
+		t.Errorf("ModelID() = %q, want gemini-2.5-pro", got)
+	}
+}
+
+func TestChat_Vertex_WithBaseURLDoesNotOverrideVertexEndpoint(t *testing.T) {
+	model := Chat("gemini-2.5-pro",
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithVertex("my-proj", "us-central1"),
+		WithBaseURL("https://gemini.example.test"))
+	vertexModel := model.(*vertexChatModel)
+
+	got, err := vertexModel.model.endpointURL("generateContent", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent"
+	if got != want {
+		t.Errorf("endpointURL() = %q, want %q", got, want)
 	}
 }
 
@@ -3420,11 +3485,11 @@ func TestChat_Vertex_BearerAuth(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// WithBaseURL wins in vertex mode (testing), but auth still goes Bearer.
+	// Vertex endpoint overrides are separate from Gemini API base URL overrides.
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
 		WithVertex("my-proj", "us-central1"),
-		WithBaseURL(server.URL))
+		WithVertexBaseURL(server.URL))
 
 	res, err := model.DoStream(context.Background(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -28,7 +28,6 @@ type failTokenSource struct{}
 func (f failTokenSource) Token(_ context.Context) (string, error) {
 	return "", fmt.Errorf("token error")
 }
-
 type googleRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f googleRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
@@ -3310,5 +3309,136 @@ func TestChat_PromptCachingIgnored(t *testing.T) {
 	}
 	if len(texts) != 1 || texts[0] != "ok" {
 		t.Errorf("DoStream texts = %v, want [ok]", texts)
+	}
+}
+
+// --- Vertex mode ---
+
+// TestVertexEndpointURL checks the aiplatform URL construction, the "global"
+// region special case, and the anti-SSRF guard.
+func TestVertexEndpointURL(t *testing.T) {
+	m := &chatModel{id: "gemini-2.5-pro", opts: options{isVertex: true, project: "my-proj", location: "us-central1"}}
+	got, err := m.endpointURL("generateContent", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent"
+	if got != want {
+		t.Errorf("vertex url:\n got %s\nwant %s", got, want)
+	}
+
+	// global region drops the host prefix.
+	mg := &chatModel{id: "gemini-2.5-pro", opts: options{isVertex: true, project: "p", location: "global"}}
+	got, _ = mg.endpointURL("streamGenerateContent", "?alt=sse")
+	want = "https://aiplatform.googleapis.com/v1beta1/projects/p/locations/global/publishers/google/models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+	if got != want {
+		t.Errorf("global url:\n got %s\nwant %s", got, want)
+	}
+
+	// SSRF: a project with a slash must be rejected.
+	bad := &chatModel{id: "x", opts: options{isVertex: true, project: "evil.com/../../foo", location: "us-central1"}}
+	if _, err := bad.endpointURL("generateContent", ""); err == nil {
+		t.Error("expected error for invalid project identifier")
+	}
+
+	// SSRF: a location with a slash must be rejected.
+	badLoc := &chatModel{id: "x", opts: options{isVertex: true, project: "my-proj", location: "evil.com/loc"}}
+	if _, err := badLoc.endpointURL("generateContent", ""); err == nil {
+		t.Error("expected error for invalid location identifier")
+	}
+}
+
+// TestChat_Vertex_Generate_BearerAuth verifies that Vertex mode authenticates
+// DoGenerate with Bearer token and parses the response.
+func TestChat_Vertex_Generate_BearerAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Errorf("Authorization = %q, want Bearer oauth-token", got)
+		}
+		if r.Header.Get("x-goog-api-key") != "" {
+			t.Error("vertex must not send x-goog-api-key")
+		}
+		if !strings.Contains(r.URL.Path, "gemini-2.5-pro") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"hola"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer server.Close()
+
+	model := Chat("gemini-2.5-pro",
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithVertex("my-proj", "us-central1"),
+		WithBaseURL(server.URL))
+
+	res, err := model.DoGenerate(context.Background(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != "hola" {
+		t.Errorf("text = %q, want hola", res.Text)
+	}
+}
+
+// TestChat_Vertex_InvalidEndpointErrors verifies that DoGenerate and DoStream
+// return errors when endpointURL fails due to invalid identifiers.
+func TestChat_Vertex_InvalidEndpointErrors(t *testing.T) {
+	model := Chat("gemini-2.5-pro",
+		WithTokenSource(provider.StaticToken("token")),
+		WithVertex("invalid/project", "us-central1"))
+
+	params := provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	}
+
+	if _, err := model.DoGenerate(context.Background(), params); err == nil {
+		t.Error("DoGenerate should fail for invalid vertex project")
+	}
+
+	if _, err := model.DoStream(context.Background(), params); err == nil {
+		t.Error("DoStream should fail for invalid vertex project")
+	}
+}
+
+// TestChat_Vertex_BearerAuth verifies that Vertex mode authenticates with a
+// Bearer token (not x-goog-api-key) and still parses the native SSE stream.
+func TestChat_Vertex_BearerAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Errorf("Authorization = %q, want Bearer oauth-token", got)
+		}
+		if r.Header.Get("x-goog-api-key") != "" {
+			t.Error("vertex must not send x-goog-api-key")
+		}
+		if !strings.Contains(r.URL.Path, "gemini-2.5-pro") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hola\"}]},\"finishReason\":\"STOP\"}]}\n\n")
+	}))
+	defer server.Close()
+
+	// WithBaseURL wins in vertex mode (testing), but auth still goes Bearer.
+	model := Chat("gemini-2.5-pro",
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithVertex("my-proj", "us-central1"),
+		WithBaseURL(server.URL))
+
+	res, err := model.DoStream(context.Background(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var text string
+	for chunk := range res.Stream {
+		if chunk.Type == provider.ChunkText {
+			text += chunk.Text
+		}
+	}
+	if text != "hola" {
+		t.Errorf("text = %q, want hola", text)
 	}
 }

--- a/provider/google/image.go
+++ b/provider/google/image.go
@@ -81,6 +81,9 @@ type imagenModel struct {
 func (m *imagenModel) ModelID() string { return m.id }
 
 func (m *imagenModel) DoGenerate(ctx context.Context, params provider.ImageParams) (*provider.ImageResult, error) {
+	if err := validateNonChatOptions(m.opts); err != nil {
+		return nil, err
+	}
 	token, err := m.resolveToken(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolving auth token: %w", err)
@@ -188,6 +191,9 @@ type geminiImageModel struct {
 func (m *geminiImageModel) ModelID() string { return m.id }
 
 func (m *geminiImageModel) DoGenerate(ctx context.Context, params provider.ImageParams) (*provider.ImageResult, error) {
+	if err := validateNonChatOptions(m.opts); err != nil {
+		return nil, err
+	}
 	token, err := m.resolveToken(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolving auth token: %w", err)

--- a/provider/google/video.go
+++ b/provider/google/video.go
@@ -55,6 +55,9 @@ type videoModel struct {
 func (m *videoModel) ModelID() string { return m.id }
 
 func (m *videoModel) DoGenerate(ctx context.Context, params provider.VideoParams) (*provider.VideoResult, error) {
+	if err := validateNonChatOptions(m.opts); err != nil {
+		return nil, err
+	}
 	token, err := m.resolveToken(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolving auth token: %w", err)

--- a/provider/vertex/anthropic.go
+++ b/provider/vertex/anthropic.go
@@ -27,6 +27,9 @@ import (
 //	result, err := goai.GenerateText(ctx, model, goai.WithPrompt("Hello"))
 func AnthropicChat(modelID string, opts ...Option) provider.LanguageModel {
 	o := resolveOpts(opts)
+	if err := validateNonChatOptions(o, "AnthropicChat"); err != nil {
+		return &invalidChatModel{id: modelID, err: err}
+	}
 
 	baseURL := anthropicBaseURL(o)
 	ts := resolveAnthropicTokenSource(o)

--- a/provider/vertex/embedding.go
+++ b/provider/vertex/embedding.go
@@ -45,6 +45,9 @@ func (m *embeddingModel) ModelID() string { return m.id }
 func (m *embeddingModel) MaxValuesPerCall() int { return 250 }
 
 func (m *embeddingModel) DoEmbed(ctx context.Context, values []string, params provider.EmbedParams) (*provider.EmbedResult, error) {
+	if err := validateNonChatOptions(m.opts, "Embedding"); err != nil {
+		return nil, err
+	}
 	// Extract vertex-specific options.
 	var vopts map[string]any
 	if v, ok := params.ProviderOptions["vertex"].(map[string]any); ok {

--- a/provider/vertex/image.go
+++ b/provider/vertex/image.go
@@ -45,6 +45,9 @@ type imageModel struct {
 func (m *imageModel) ModelID() string { return m.id }
 
 func (m *imageModel) DoGenerate(ctx context.Context, params provider.ImageParams) (*provider.ImageResult, error) {
+	if err := validateNonChatOptions(m.opts, "Image"); err != nil {
+		return nil, err
+	}
 	// Build parameters from standard params.
 	parameters := map[string]any{
 		"sampleCount": params.N,

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -30,6 +30,7 @@ import (
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/internal/sse"
 	"github.com/zendev-sh/goai/provider"
+	googleprovider "github.com/zendev-sh/goai/provider/google"
 )
 
 // Compile-time interface compliance checks.
@@ -42,12 +43,13 @@ var (
 type Option func(*options)
 
 type options struct {
-	tokenSource provider.TokenSource
-	project     string
-	location    string
-	baseURL     string
-	headers     map[string]string
-	httpClient  *http.Client
+	tokenSource  provider.TokenSource
+	project      string
+	location     string
+	baseURL      string
+	headers      map[string]string
+	httpClient   *http.Client
+	nativeGemini bool
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -98,6 +100,14 @@ func WithHeaders(h map[string]string) Option {
 func WithHTTPClient(c *http.Client) Option {
 	return func(o *options) {
 		o.httpClient = c
+	}
+}
+
+// WithNativeGemini uses Vertex AI's native Gemini generateContent transport
+// instead of the OpenAI-compatible endpoint. The default remains unchanged.
+func WithNativeGemini() Option {
+	return func(o *options) {
+		o.nativeGemini = true
 	}
 }
 
@@ -238,7 +248,35 @@ func isNativeAPIKeyAuth(ts provider.TokenSource) bool {
 // Chat creates a Vertex AI language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	o := resolveOpts(opts)
+	if o.nativeGemini {
+		return nativeGeminiChat(modelID, o)
+	}
 	return &chatModel{id: modelID, opts: o}
+}
+
+func nativeGeminiChat(modelID string, o options) provider.LanguageModel {
+	googleOpts := make([]googleprovider.Option, 0, 6)
+	if apiKey, ok := o.tokenSource.(*apiKeyTokenSource); ok {
+		googleOpts = append(googleOpts, googleprovider.WithAPIKey(apiKey.key))
+		if o.baseURL != "" {
+			googleOpts = append(googleOpts, googleprovider.WithBaseURL(o.baseURL))
+		}
+	} else {
+		googleOpts = append(googleOpts, googleprovider.WithVertex(o.project, o.location))
+		if o.tokenSource != nil {
+			googleOpts = append(googleOpts, googleprovider.WithTokenSource(o.tokenSource))
+		}
+		if o.baseURL != "" {
+			googleOpts = append(googleOpts, googleprovider.WithVertexBaseURL(o.baseURL))
+		}
+	}
+	if o.headers != nil {
+		googleOpts = append(googleOpts, googleprovider.WithHeaders(o.headers))
+	}
+	if o.httpClient != nil {
+		googleOpts = append(googleOpts, googleprovider.WithHTTPClient(o.httpClient))
+	}
+	return googleprovider.Chat(modelID, googleOpts...)
 }
 
 type chatModel struct {

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -1,6 +1,7 @@
 // Package vertex provides a Google Cloud Vertex AI language model implementation for GoAI.
 //
-// Uses the OpenAI-compatible endpoint provided by Vertex AI.
+// Chat uses Vertex AI's OpenAI-compatible endpoint by default. Use
+// WithNativeGemini to select the native generateContent transport.
 //
 // Usage:
 //
@@ -14,6 +15,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -26,11 +28,12 @@ import (
 
 	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/internal/gemini"
+	"github.com/zendev-sh/goai/internal/geminichat"
 	"github.com/zendev-sh/goai/internal/httpc"
 	"github.com/zendev-sh/goai/internal/openaicompat"
 	"github.com/zendev-sh/goai/internal/sse"
 	"github.com/zendev-sh/goai/provider"
-	googleprovider "github.com/zendev-sh/goai/provider/google"
+	_ "github.com/zendev-sh/goai/provider/google"
 )
 
 // Compile-time interface compliance checks.
@@ -43,13 +46,14 @@ var (
 type Option func(*options)
 
 type options struct {
-	tokenSource  provider.TokenSource
-	project      string
-	location     string
-	baseURL      string
-	headers      map[string]string
-	httpClient   *http.Client
-	nativeGemini bool
+	tokenSource   provider.TokenSource
+	project       string
+	location      string
+	baseURL       string
+	nativeBaseURL string
+	headers       map[string]string
+	httpClient    *http.Client
+	nativeGemini  bool
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -82,10 +86,18 @@ func WithLocation(location string) Option {
 	}
 }
 
-// WithBaseURL overrides the default Vertex AI endpoint.
+// WithBaseURL overrides the OpenAI-compatible endpoint origin.
 func WithBaseURL(url string) Option {
 	return func(o *options) {
 		o.baseURL = url
+	}
+}
+
+// WithNativeBaseURL overrides the native Vertex models collection URL. The
+// model ID and generateContent action are appended to this URL.
+func WithNativeBaseURL(url string) Option {
+	return func(o *options) {
+		o.nativeBaseURL = url
 	}
 }
 
@@ -127,8 +139,13 @@ func resolveOpts(opts []Option) options {
 	o.project = cmp.Or(o.project, os.Getenv("GOOGLE_VERTEX_PROJECT"), os.Getenv("GOOGLE_CLOUD_PROJECT"), os.Getenv("GCLOUD_PROJECT"))
 	// Resolve location: explicit > GOOGLE_VERTEX_LOCATION (Vercel) > GOOGLE_CLOUD_LOCATION > us-central1.
 	o.location = cmp.Or(o.location, os.Getenv("GOOGLE_VERTEX_LOCATION"), os.Getenv("GOOGLE_CLOUD_LOCATION"), "us-central1")
-	// Resolve base URL from env if not overridden.
-	o.baseURL = cmp.Or(o.baseURL, os.Getenv("GOOGLE_VERTEX_BASE_URL"))
+	// Keep endpoint overrides transport-specific so their URL contracts do not
+	// change when WithNativeGemini is enabled.
+	if o.nativeGemini {
+		o.nativeBaseURL = cmp.Or(o.nativeBaseURL, os.Getenv("GOOGLE_VERTEX_NATIVE_BASE_URL"))
+	} else {
+		o.baseURL = cmp.Or(o.baseURL, os.Getenv("GOOGLE_VERTEX_BASE_URL"))
+	}
 	// Auto-resolve auth if no explicit token source and no custom baseURL.
 	// Custom baseURL (e.g. testing, proxy) may not need auth.
 	if o.tokenSource == nil && o.baseURL == "" {
@@ -251,32 +268,51 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	if o.nativeGemini {
 		return nativeGeminiChat(modelID, o)
 	}
+	if o.nativeBaseURL != "" {
+		return &invalidChatModel{
+			id:  modelID,
+			err: errors.New("vertex: WithNativeBaseURL requires WithNativeGemini"),
+		}
+	}
 	return &chatModel{id: modelID, opts: o}
 }
 
 func nativeGeminiChat(modelID string, o options) provider.LanguageModel {
-	googleOpts := make([]googleprovider.Option, 0, 6)
-	if apiKey, ok := o.tokenSource.(*apiKeyTokenSource); ok {
-		googleOpts = append(googleOpts, googleprovider.WithAPIKey(apiKey.key))
-		if o.baseURL != "" {
-			googleOpts = append(googleOpts, googleprovider.WithBaseURL(o.baseURL))
-		}
-	} else {
-		googleOpts = append(googleOpts, googleprovider.WithVertex(o.project, o.location))
-		if o.tokenSource != nil {
-			googleOpts = append(googleOpts, googleprovider.WithTokenSource(o.tokenSource))
-		}
-		if o.baseURL != "" {
-			googleOpts = append(googleOpts, googleprovider.WithVertexBaseURL(o.baseURL))
+	if _, ok := o.tokenSource.(*apiKeyTokenSource); ok {
+		return &invalidChatModel{
+			id:  modelID,
+			err: errors.New("vertex: WithNativeGemini requires an OAuth token source; API keys are not supported"),
 		}
 	}
-	if o.headers != nil {
-		googleOpts = append(googleOpts, googleprovider.WithHeaders(o.headers))
+	if o.baseURL != "" {
+		return &invalidChatModel{
+			id:  modelID,
+			err: errors.New("vertex: WithBaseURL configures the OpenAI-compatible transport; use WithNativeBaseURL with WithNativeGemini"),
+		}
 	}
-	if o.httpClient != nil {
-		googleOpts = append(googleOpts, googleprovider.WithHTTPClient(o.httpClient))
-	}
-	return googleprovider.Chat(modelID, googleOpts...)
+	return geminichat.New(modelID, geminichat.Config{
+		Project:     o.project,
+		Location:    o.location,
+		BaseURL:     o.nativeBaseURL,
+		TokenSource: o.tokenSource,
+		Headers:     o.headers,
+		HTTPClient:  o.httpClient,
+	})
+}
+
+type invalidChatModel struct {
+	id  string
+	err error
+}
+
+func (m *invalidChatModel) ModelID() string { return m.id }
+
+func (m *invalidChatModel) DoGenerate(context.Context, provider.GenerateParams) (*provider.GenerateResult, error) {
+	return nil, m.err
+}
+
+func (m *invalidChatModel) DoStream(context.Context, provider.GenerateParams) (*provider.StreamResult, error) {
+	return nil, m.err
 }
 
 type chatModel struct {

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -46,14 +46,14 @@ var (
 type Option func(*options)
 
 type options struct {
-	tokenSource   provider.TokenSource
-	project       string
-	location      string
-	baseURL       string
-	nativeBaseURL string
-	headers       map[string]string
-	httpClient    *http.Client
-	nativeGemini  bool
+	tokenSource       provider.TokenSource
+	project           string
+	location          string
+	baseURL           string
+	nativeChatBaseURL string
+	headers           map[string]string
+	httpClient        *http.Client
+	nativeGemini      bool
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -86,18 +86,19 @@ func WithLocation(location string) Option {
 	}
 }
 
-// WithBaseURL overrides the OpenAI-compatible endpoint origin.
+// WithBaseURL overrides the endpoint used by the selected model constructor.
+// Native Gemini Chat uses WithNativeChatBaseURL instead.
 func WithBaseURL(url string) Option {
 	return func(o *options) {
 		o.baseURL = url
 	}
 }
 
-// WithNativeBaseURL overrides the native Vertex models collection URL. The
+// WithNativeChatBaseURL overrides the native Vertex models collection URL. The
 // model ID and generateContent action are appended to this URL.
-func WithNativeBaseURL(url string) Option {
+func WithNativeChatBaseURL(url string) Option {
 	return func(o *options) {
-		o.nativeBaseURL = url
+		o.nativeChatBaseURL = url
 	}
 }
 
@@ -142,7 +143,7 @@ func resolveOpts(opts []Option) options {
 	// Keep endpoint overrides transport-specific so their URL contracts do not
 	// change when WithNativeGemini is enabled.
 	if o.nativeGemini {
-		o.nativeBaseURL = cmp.Or(o.nativeBaseURL, os.Getenv("GOOGLE_VERTEX_NATIVE_BASE_URL"))
+		o.nativeChatBaseURL = cmp.Or(o.nativeChatBaseURL, os.Getenv("GOOGLE_VERTEX_NATIVE_CHAT_BASE_URL"))
 	} else {
 		o.baseURL = cmp.Or(o.baseURL, os.Getenv("GOOGLE_VERTEX_BASE_URL"))
 	}
@@ -268,10 +269,10 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	if o.nativeGemini {
 		return nativeGeminiChat(modelID, o)
 	}
-	if o.nativeBaseURL != "" {
+	if o.nativeChatBaseURL != "" {
 		return &invalidChatModel{
 			id:  modelID,
-			err: errors.New("vertex: WithNativeBaseURL requires WithNativeGemini"),
+			err: errors.New("vertex: WithNativeChatBaseURL requires WithNativeGemini"),
 		}
 	}
 	return &chatModel{id: modelID, opts: o}
@@ -287,17 +288,24 @@ func nativeGeminiChat(modelID string, o options) provider.LanguageModel {
 	if o.baseURL != "" {
 		return &invalidChatModel{
 			id:  modelID,
-			err: errors.New("vertex: WithBaseURL configures the OpenAI-compatible transport; use WithNativeBaseURL with WithNativeGemini"),
+			err: errors.New("vertex: WithBaseURL configures the OpenAI-compatible transport; use WithNativeChatBaseURL with WithNativeGemini"),
 		}
 	}
 	return geminichat.New(modelID, geminichat.Config{
 		Project:     o.project,
 		Location:    o.location,
-		BaseURL:     o.nativeBaseURL,
+		BaseURL:     o.nativeChatBaseURL,
 		TokenSource: o.tokenSource,
 		Headers:     o.headers,
 		HTTPClient:  o.httpClient,
 	})
+}
+
+func validateNonChatOptions(o options, constructor string) error {
+	if o.nativeGemini || o.nativeChatBaseURL != "" {
+		return fmt.Errorf("vertex: WithNativeGemini and WithNativeChatBaseURL are only supported by Chat, not %s", constructor)
+	}
+	return nil
 }
 
 type invalidChatModel struct {

--- a/provider/vertex/vertex_test.go
+++ b/provider/vertex/vertex_test.go
@@ -71,6 +71,74 @@ func TestChat_Generate(t *testing.T) {
 	}
 }
 
+func TestChat_NativeGeminiVertex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Errorf("Authorization = %q, want Bearer oauth-token", got)
+		}
+		if got := r.Header.Get("X-Custom"); got != "value" {
+			t.Errorf("X-Custom = %q, want value", got)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/gemini-2.5-pro:generateContent") {
+			t.Errorf("path = %q, want native generateContent endpoint", r.URL.Path)
+		}
+		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"native"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer server.Close()
+
+	model := Chat("gemini-2.5-pro",
+		WithNativeGemini(),
+		WithProject("my-proj"),
+		WithLocation("global"),
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithBaseURL(server.URL+"/models"),
+		WithHeaders(map[string]string{"X-Custom": "value"}),
+		WithHTTPClient(server.Client()))
+
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "native" {
+		t.Errorf("Text = %q, want native", result.Text)
+	}
+	if _, ok := model.(provider.FileUploadCapableModel); ok {
+		t.Fatalf("native Vertex model type %T must not implement FileUploadCapableModel", model)
+	}
+}
+
+func TestChat_NativeGeminiAPIKeyFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("x-goog-api-key"); got != "api-key" {
+			t.Errorf("x-goog-api-key = %q, want api-key", got)
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Error("Gemini API fallback must not send Authorization")
+		}
+		if !strings.HasSuffix(r.URL.Path, "/v1beta/models/gemini-2.5-flash:generateContent") {
+			t.Errorf("path = %q, want Gemini native endpoint", r.URL.Path)
+		}
+		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"fallback"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer server.Close()
+
+	model := Chat("gemini-2.5-flash",
+		WithNativeGemini(),
+		WithAPIKey("api-key"),
+		WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Text != "fallback" {
+		t.Errorf("Text = %q, want fallback", result.Text)
+	}
+}
+
 func TestNoProject(t *testing.T) {
 	t.Setenv("GOOGLE_VERTEX_PROJECT", "")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "")

--- a/provider/vertex/vertex_test.go
+++ b/provider/vertex/vertex_test.go
@@ -91,7 +91,7 @@ func TestChat_NativeGeminiVertex(t *testing.T) {
 		WithProject("my-proj"),
 		WithLocation("global"),
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithBaseURL(server.URL+"/models"),
+		WithNativeBaseURL(server.URL+"/models"),
 		WithHeaders(map[string]string{"X-Custom": "value"}),
 		WithHTTPClient(server.Client()))
 
@@ -109,33 +109,47 @@ func TestChat_NativeGeminiVertex(t *testing.T) {
 	}
 }
 
-func TestChat_NativeGeminiAPIKeyFallback(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("x-goog-api-key"); got != "api-key" {
-			t.Errorf("x-goog-api-key = %q, want api-key", got)
-		}
-		if r.Header.Get("Authorization") != "" {
-			t.Error("Gemini API fallback must not send Authorization")
-		}
-		if !strings.HasSuffix(r.URL.Path, "/v1beta/models/gemini-2.5-flash:generateContent") {
-			t.Errorf("path = %q, want Gemini native endpoint", r.URL.Path)
-		}
-		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"fallback"}]},"finishReason":"STOP"}]}`)
-	}))
-	defer server.Close()
-
+func TestChat_NativeGeminiRejectsAPIKey(t *testing.T) {
 	model := Chat("gemini-2.5-flash",
 		WithNativeGemini(),
-		WithAPIKey("api-key"),
-		WithBaseURL(server.URL))
-	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		WithAPIKey("api-key"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 	})
-	if err != nil {
-		t.Fatal(err)
+	if err == nil || !strings.Contains(err.Error(), "OAuth token source") {
+		t.Fatalf("DoGenerate() error = %v, want OAuth token source error", err)
 	}
-	if result.Text != "fallback" {
-		t.Errorf("Text = %q, want fallback", result.Text)
+}
+
+func TestChat_NativeGeminiRejectsCompatBaseURL(t *testing.T) {
+	model := Chat("gemini-2.5-pro",
+		WithNativeGemini(),
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithBaseURL("https://compat.example.test"))
+	if got := model.ModelID(); got != "gemini-2.5-pro" {
+		t.Errorf("ModelID() = %q, want gemini-2.5-pro", got)
+	}
+	params := provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	}
+	want := "use WithNativeBaseURL"
+	if _, err := model.DoGenerate(t.Context(), params); err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("DoGenerate() error = %v, want %q", err, want)
+	}
+	if _, err := model.DoStream(t.Context(), params); err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("DoStream() error = %v, want %q", err, want)
+	}
+}
+
+func TestChat_NativeBaseURLRequiresNativeTransport(t *testing.T) {
+	model := Chat("gemini-2.5-pro",
+		WithTokenSource(provider.StaticToken("oauth-token")),
+		WithNativeBaseURL("https://vertex.example.test/models"))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires WithNativeGemini") {
+		t.Fatalf("DoGenerate() error = %v, want native transport error", err)
 	}
 }
 

--- a/provider/vertex/vertex_test.go
+++ b/provider/vertex/vertex_test.go
@@ -91,7 +91,7 @@ func TestChat_NativeGeminiVertex(t *testing.T) {
 		WithProject("my-proj"),
 		WithLocation("global"),
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithNativeBaseURL(server.URL+"/models"),
+		WithNativeChatBaseURL(server.URL+"/models"),
 		WithHeaders(map[string]string{"X-Custom": "value"}),
 		WithHTTPClient(server.Client()))
 
@@ -132,7 +132,7 @@ func TestChat_NativeGeminiRejectsCompatBaseURL(t *testing.T) {
 	params := provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 	}
-	want := "use WithNativeBaseURL"
+	want := "use WithNativeChatBaseURL"
 	if _, err := model.DoGenerate(t.Context(), params); err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("DoGenerate() error = %v, want %q", err, want)
 	}
@@ -141,16 +141,47 @@ func TestChat_NativeGeminiRejectsCompatBaseURL(t *testing.T) {
 	}
 }
 
-func TestChat_NativeBaseURLRequiresNativeTransport(t *testing.T) {
+func TestChat_NativeChatBaseURLRequiresNativeTransport(t *testing.T) {
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("oauth-token")),
-		WithNativeBaseURL("https://vertex.example.test/models"))
+		WithNativeChatBaseURL("https://vertex.example.test/models"))
 	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "requires WithNativeGemini") {
 		t.Fatalf("DoGenerate() error = %v, want native transport error", err)
 	}
+}
+
+func TestChatOnlyOptionsRejectedByOtherConstructors(t *testing.T) {
+	want := "only supported by Chat"
+	token := WithTokenSource(provider.StaticToken("oauth-token"))
+
+	t.Run("image", func(t *testing.T) {
+		model := Image("imagen-4.0-generate-001", token, WithNativeChatBaseURL("https://vertex.example.test/models"))
+		_, err := model.DoGenerate(t.Context(), provider.ImageParams{Prompt: "draw", N: 1})
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("DoGenerate() error = %v, want %q", err, want)
+		}
+	})
+
+	t.Run("embedding", func(t *testing.T) {
+		model := Embedding("text-embedding-004", token, WithNativeGemini())
+		_, err := model.DoEmbed(t.Context(), []string{"hello"}, provider.EmbedParams{})
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("DoEmbed() error = %v, want %q", err, want)
+		}
+	})
+
+	t.Run("anthropic", func(t *testing.T) {
+		model := AnthropicChat("claude-sonnet-4", token, WithNativeChatBaseURL("https://vertex.example.test/models"))
+		_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+			Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		})
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("DoGenerate() error = %v, want %q", err, want)
+		}
+	})
 }
 
 func TestNoProject(t *testing.T) {


### PR DESCRIPTION
## Summary

Add native Gemini `generateContent` transport for Vertex AI while keeping `provider/vertex` as the sole public Vertex boundary.

- Add `vertex.WithNativeGemini()`; the existing OpenAI-compatible transport remains the default.
- Add chat-specific `vertex.WithNativeChatBaseURL()` with a stable models-collection URL contract. `WithBaseURL` retains its existing constructor-specific behavior.
- Reject chat-only options from Image, Embedding, and Anthropic constructors instead of silently ignoring them.
- Reuse the Google native request/response codec through `internal/geminichat`; no public Vertex options are exposed from `provider/google`.
- Keep Vertex project/location, ADC/environment resolution, headers, HTTP client, and endpoint overrides under `provider/vertex`.
- Support regional and `global` Vertex endpoints with validated project/location values.
- Require OAuth/ADC for native Vertex mode and reject API keys before network I/O.
- Return a distinct native Vertex model type that does not advertise or implement the Gemini Developer API Files capability.
- Reject Vertex-only options on Google Image, Embedding, and Video models before credentials can reach incompatible Gemini API routes.

## Verification

- `go test ./...` — 2,976 tests passed across 36 packages.
- `go build ./...` — passed.
- `go vet ./internal/geminichat ./provider/google ./provider/vertex` — passed.
- Changed bridge/constructor/options/endpoints — 100% coverage.
