### PR TITLE
feat(google): support Gemini server-side tool invocations

### DIFF
--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -305,6 +305,16 @@ func (m *chatModel) buildRequest(params provider.GenerateParams) (geminiRequestB
 			toolConfig["retrievalConfig"] = rc
 		}
 	}
+	// Gemini 3.x supports this additional toolConfig field. Accept only the
+	// documented boolean from the Google namespace; SDK-derived fields above
+	// must not be overridden by raw provider options.
+	if gopts != nil {
+		if tc, ok := gopts["toolConfig"].(map[string]any); ok {
+			if include, ok := tc["includeServerSideToolInvocations"].(bool); ok {
+				toolConfig["includeServerSideToolInvocations"] = include
+			}
+		}
+	}
 
 	if len(toolConfig) > 0 {
 		body.ToolConfig = toolConfig

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -3310,5 +3311,133 @@ func TestChat_PromptCachingIgnored(t *testing.T) {
 	}
 	if len(texts) != 1 || texts[0] != "ok" {
 		t.Errorf("DoStream texts = %v, want [ok]", texts)
+	}
+}
+
+func TestBuildRequest_ToolConfigRequiresGoogleNamespace(t *testing.T) {
+	m := &chatModel{id: "gemini-3.5-flash", opts: options{baseURL: defaultBaseURL}}
+	tests := []struct {
+		name string
+		opts map[string]any
+		want bool
+	}{
+		{
+			name: "flat option is ignored",
+			opts: map[string]any{
+				"toolConfig": map[string]any{"includeServerSideToolInvocations": true},
+			},
+		},
+		{
+			name: "unsupported spelling is ignored",
+			opts: map[string]any{
+				"google": map[string]any{
+					"toolConfig": map[string]any{"include_server_side_tool_invocations": true},
+				},
+			},
+		},
+		{
+			name: "non-boolean value is ignored",
+			opts: map[string]any{
+				"google": map[string]any{
+					"toolConfig": map[string]any{"includeServerSideToolInvocations": map[string]any{"enabled": true}},
+				},
+			},
+		},
+		{
+			name: "google option is accepted",
+			opts: map[string]any{
+				"google": map[string]any{
+					"toolConfig": map[string]any{"includeServerSideToolInvocations": true},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := m.buildRequest(provider.GenerateParams{
+				Messages:        []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "search"}}}},
+				ProviderOptions: tt.opts,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.want {
+				tc := body.ToolConfig.(map[string]any)
+				if got := tc["includeServerSideToolInvocations"]; got != true {
+					t.Errorf("includeServerSideToolInvocations = %v, want true", got)
+				}
+			} else if body.ToolConfig != nil {
+				t.Errorf("ToolConfig = %v, want nil", body.ToolConfig)
+			}
+		})
+	}
+}
+
+func TestBuildRequest_RawToolConfigCannotOverrideSDKFields(t *testing.T) {
+	m := &chatModel{id: "gemini-3.5-flash", opts: options{baseURL: defaultBaseURL}}
+	wantRetrieval := map[string]any{"latLng": map[string]any{"latitude": 1.0, "longitude": 2.0}}
+	body, err := m.buildRequest(provider.GenerateParams{
+		Messages:   []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "search"}}}},
+		ToolChoice: "auto",
+		ProviderOptions: map[string]any{
+			"google": map[string]any{
+				"retrievalConfig": wantRetrieval,
+				"toolConfig": map[string]any{
+					"includeServerSideToolInvocations": true,
+					"functionCallingConfig":            map[string]any{"mode": "NONE"},
+					"retrievalConfig":                  map[string]any{"invalid": true},
+					"unsupported":                      true,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := body.ToolConfig.(map[string]any)
+	if got := tc["functionCallingConfig"].(map[string]any)["mode"]; got != "AUTO" {
+		t.Errorf("functionCallingConfig.mode = %v, want AUTO", got)
+	}
+	if got := tc["retrievalConfig"]; !reflect.DeepEqual(got, wantRetrieval) {
+		t.Errorf("retrievalConfig = %#v, want %#v", got, wantRetrieval)
+	}
+	if got := tc["includeServerSideToolInvocations"]; got != true {
+		t.Errorf("includeServerSideToolInvocations = %v, want true", got)
+	}
+	if _, ok := tc["unsupported"]; ok {
+		t.Error("unsupported raw toolConfig field must not be forwarded")
+	}
+}
+
+func TestChat_Generate_SerializesIncludeServerSideToolInvocations(t *testing.T) {
+	var request map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer server.Close()
+
+	model := Chat("gemini-3.5-flash", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	_, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "search"}}}},
+		ProviderOptions: map[string]any{
+			"google": map[string]any{
+				"toolConfig": map[string]any{"includeServerSideToolInvocations": true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := request["toolConfig"].(map[string]any)
+	if got := tc["includeServerSideToolInvocations"]; got != true {
+		t.Errorf("includeServerSideToolInvocations = %v, want true", got)
+	}
+	if _, ok := tc["include_server_side_tool_invocations"]; ok {
+		t.Error("snake_case include_server_side_tool_invocations must not be serialized")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `google.toolConfig.includeServerSideToolInvocations` support using the documented REST wire key.
- Keep Google-specific options under `ProviderOptions["google"]`.
- Accept only the supported boolean field so raw provider options cannot override SDK-owned `functionCallingConfig` or `retrievalConfig`.
- Verify the serialized HTTP request uses camelCase and never emits the unsupported snake_case spelling.

This change was split from #158 so the OpenAI-compatible completion-token fix and Gemini provider behavior can be reviewed and released independently.

## Verification

- `go test ./...` — 2,963 tests passed across 35 packages.
- `go build ./...` — passed.
- `golangci-lint run ./provider/google/...` — 0 issues.
- Changed paths: `buildRequest` 100%, `doHTTP` 100%.
