### PR TITLE
Add OpenAI Responses stream idle timeout and protocol checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ fmt.Printf("\nTokens: %d in, %d out\n",
 	result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)
 ```
 
+OpenAI Responses streams enforce a five-minute provider-event idle timeout.
+Configure this per model with `openai.WithResponsesStreamIdleTimeout`; pass `0`
+to explicitly disable the watchdog. Premature EOF and a bare `[DONE]` sentinel
+are rejected by default. Non-standard endpoints that require `[DONE]` can opt
+in explicitly with `openai.WithResponsesStreamDoneCompatibility(true)`. Idle
+and protocol interruptions are exposed as typed
+`openai.StreamIdleTimeoutError` and `openai.StreamProtocolError` values.
+
 Streaming with tools:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -139,8 +139,12 @@ OpenAI Responses streams enforce a five-minute provider-event idle timeout.
 Configure this per model with `openai.WithResponsesStreamIdleTimeout`; pass `0`
 to explicitly disable the watchdog. Premature EOF and a bare `[DONE]` sentinel
 are rejected by default. Non-standard endpoints that require `[DONE]` can opt
-in explicitly with `openai.WithResponsesStreamDoneCompatibility(true)`. Idle
-and protocol interruptions are exposed as typed
+in explicitly with `openai.WithResponsesStreamDoneCompatibility(true)`; this
+option changes only terminal-sentinel handling and does not relax event schema
+validation. Every JSON data event must identify its type through either the JSON
+`type` property or the SSE `event:` field, and malformed recognized events
+terminate the stream. Endpoints should use SSE comments, not untyped data
+frames, for keepalives. Idle and protocol interruptions are exposed as typed
 `openai.StreamIdleTimeoutError` and `openai.StreamProtocolError` values.
 
 Streaming with tools:

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -169,9 +169,11 @@ When using `WithTokenSource`, the provider sends `Authorization: Bearer {token}`
 | `WithHeaders(h)`             | `map[string]string`    | Additional HTTP headers.                                                                              |
 | `WithHTTPClient(c)`          | `*http.Client`         | Custom HTTP client.                                                                                   |
 | `WithResponsesStreamIdleTimeout(d)` | `time.Duration` | Maximum wait for a complete Azure OpenAI Responses event. Default: `5m`; `0` disables the watchdog. |
-| `WithResponsesStreamDoneCompatibility(b)` | `bool` | Allow a non-standard Azure OpenAI Responses endpoint to terminate with bare `[DONE]`. Default: `false`. |
+| `WithResponsesStreamDoneCompatibility(b)` | `bool` | Allow only a non-standard bare `[DONE]` terminal sentinel; event schema validation remains strict. Default: `false`. |
 | `WithAPIVersion(v)`          | `string`               | `api-version` query parameter. Only honoured on the legacy deployment-based path (opt in via `WithDeploymentBasedURLs(true)`); the v1 GA path drops it per Azure spec. Default: `"2025-03-01-preview"`. |
 | `WithDeploymentBasedURLs(b)` | `bool`                 | Use legacy deployment-based URL format. Default: `false`.                                             |
+
+Azure Responses streams use the same event validation as the OpenAI provider: each JSON data event must identify its type through the JSON `type` property or SSE `event:` field, and malformed recognized events terminate the stream. Use SSE comments for keepalives. The `[DONE]` compatibility option does not relax event schema validation.
 
 ### Environment Variables
 

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -168,6 +168,8 @@ When using `WithTokenSource`, the provider sends `Authorization: Bearer {token}`
 | `WithEndpoint(url)`          | `string`               | Azure endpoint URL. Falls back to `AZURE_OPENAI_ENDPOINT`, or constructed from `AZURE_RESOURCE_NAME`. |
 | `WithHeaders(h)`             | `map[string]string`    | Additional HTTP headers.                                                                              |
 | `WithHTTPClient(c)`          | `*http.Client`         | Custom HTTP client.                                                                                   |
+| `WithResponsesStreamIdleTimeout(d)` | `time.Duration` | Maximum wait for a complete Azure OpenAI Responses event. Default: `5m`; `0` disables the watchdog. |
+| `WithResponsesStreamDoneCompatibility(b)` | `bool` | Allow a non-standard Azure OpenAI Responses endpoint to terminate with bare `[DONE]`. Default: `false`. |
 | `WithAPIVersion(v)`          | `string`               | `api-version` query parameter. Only honoured on the legacy deployment-based path (opt in via `WithDeploymentBasedURLs(true)`); the v1 GA path drops it per Azure spec. Default: `"2025-03-01-preview"`. |
 | `WithDeploymentBasedURLs(b)` | `bool`                 | Use legacy deployment-based URL format. Default: `false`.                                             |
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -173,7 +173,7 @@ result, err := goai.GenerateText(ctx, model,
 | `WithHeaders(h)` | `map[string]string` | Additional HTTP headers on every request. |
 | `WithHTTPClient(c)` | `*http.Client` | Custom HTTP client for proxies, logging, URL rewriting. |
 | `WithResponsesStreamIdleTimeout(d)` | `time.Duration` | Maximum wait for a complete Responses stream event. Default: `5m`; `0` disables the watchdog. |
-| `WithResponsesStreamDoneCompatibility(b)` | `bool` | Allow a non-standard Responses endpoint to terminate with bare `[DONE]`. Default: `false`. |
+| `WithResponsesStreamDoneCompatibility(b)` | `bool` | Allow only a non-standard bare `[DONE]` terminal sentinel; event schema validation remains strict. Default: `false`. |
 
 ### Responses Stream Reliability
 
@@ -187,7 +187,9 @@ model := openai.Chat("gpt-5",
 
 Pass `0` only when an endpoint intentionally permits unlimited idle time. Negative durations are rejected when a Responses stream is started. The option does not affect non-streaming calls or Chat Completions.
 
-Responses streams derive the event type from the JSON payload and fall back to the SSE `event:` field when the payload omits `type`, so standard data-only SSE and event-typed streams are both accepted. When both types are present they must agree. Streams must end with `response.completed`, `response.incomplete`, `response.failed`, or a top-level `error` event. EOF or a bare `[DONE]` before one of those terminal events is a protocol error; completed and incomplete responses return immediately without waiting for the connection to close. For a non-standard endpoint that only emits `[DONE]`, explicitly opt in with `openai.WithResponsesStreamDoneCompatibility(true)`.
+Responses streams derive the event type from the JSON payload and fall back to the SSE `event:` field when the payload omits `type`, so standard data-only SSE and event-typed streams are both accepted. When both types are present they must agree. A JSON data frame with neither type is not a valid keepalive; endpoints should use SSE comments for keepalives. Once an event type is recognized, malformed JSON, wrong field types, and missing or null fields required to project that event terminate the stream with `StreamProtocolError` instead of silently dropping output.
+
+Streams must end with `response.completed`, `response.incomplete`, `response.failed`, or a top-level `error` event. EOF or a bare `[DONE]` before one of those terminal events is a protocol error; completed and incomplete responses return immediately without waiting for the connection to close. For a non-standard endpoint that only emits `[DONE]`, explicitly opt in with `openai.WithResponsesStreamDoneCompatibility(true)`. That option changes only terminal-sentinel handling; it does not relax event typing or schema validation.
 
 Terminal usage is captured when provided. For compatibility with existing gateways, a completed or incomplete response that omits `usage` finishes with zero usage; when a `usage` object is present, both `input_tokens` and `output_tokens` are required.
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -187,7 +187,7 @@ model := openai.Chat("gpt-5",
 
 Pass `0` only when an endpoint intentionally permits unlimited idle time. Negative durations are rejected when a Responses stream is started. The option does not affect non-streaming calls or Chat Completions.
 
-Responses streams must end with `response.completed`, `response.incomplete`, `response.failed`, or a top-level `error` event. EOF or a bare `[DONE]` before one of those terminal events is a protocol error; completed and incomplete responses return immediately without waiting for the connection to close. For a non-standard endpoint that only emits `[DONE]`, explicitly opt in with `openai.WithResponsesStreamDoneCompatibility(true)`.
+Responses streams derive the event type from the JSON payload and fall back to the SSE `event:` field when the payload omits `type`, so standard data-only SSE and event-typed streams are both accepted. When both types are present they must agree. Streams must end with `response.completed`, `response.incomplete`, `response.failed`, or a top-level `error` event. EOF or a bare `[DONE]` before one of those terminal events is a protocol error; completed and incomplete responses return immediately without waiting for the connection to close. For a non-standard endpoint that only emits `[DONE]`, explicitly opt in with `openai.WithResponsesStreamDoneCompatibility(true)`.
 
 Terminal usage is captured when provided. For compatibility with existing gateways, a completed or incomplete response that omits `usage` finishes with zero usage; when a `usage` object is present, both `input_tokens` and `output_tokens` are required.
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -172,6 +172,39 @@ result, err := goai.GenerateText(ctx, model,
 | `WithBaseURL(url)` | `string` | Override base URL. Falls back to `OPENAI_BASE_URL` env var. |
 | `WithHeaders(h)` | `map[string]string` | Additional HTTP headers on every request. |
 | `WithHTTPClient(c)` | `*http.Client` | Custom HTTP client for proxies, logging, URL rewriting. |
+| `WithResponsesStreamIdleTimeout(d)` | `time.Duration` | Maximum wait for a complete Responses stream event. Default: `5m`; `0` disables the watchdog. |
+| `WithResponsesStreamDoneCompatibility(b)` | `bool` | Allow a non-standard Responses endpoint to terminate with bare `[DONE]`. Default: `false`. |
+
+### Responses Stream Reliability
+
+Responses API streams use a five-minute event-level idle timeout by default. The timer resets for every complete provider event, including lifecycle and unknown valid events that do not emit a GoAI chunk. SSE comments, empty framing lines, and partial event fragments do not reset it.
+
+```go
+model := openai.Chat("gpt-5",
+    openai.WithResponsesStreamIdleTimeout(2*time.Minute),
+)
+```
+
+Pass `0` only when an endpoint intentionally permits unlimited idle time. Negative durations are rejected when a Responses stream is started. The option does not affect non-streaming calls or Chat Completions.
+
+Responses streams must end with `response.completed`, `response.incomplete`, `response.failed`, or a top-level `error` event. EOF or a bare `[DONE]` before one of those terminal events is a protocol error; completed and incomplete responses return immediately without waiting for the connection to close. For a non-standard endpoint that only emits `[DONE]`, explicitly opt in with `openai.WithResponsesStreamDoneCompatibility(true)`.
+
+Terminal usage is captured when provided. For compatibility with existing gateways, a completed or incomplete response that omits `usage` finishes with zero usage; when a `usage` object is present, both `input_tokens` and `output_tokens` are required.
+
+Idle and protocol failures are typed:
+
+```go
+var idleErr *openai.StreamIdleTimeoutError
+var protocolErr *openai.StreamProtocolError
+streamErr := stream.Err()
+
+if errors.As(streamErr, &idleErr) {
+    // Transient provider inactivity. idleErr also satisfies net.Error.
+}
+if errors.As(streamErr, &protocolErr) {
+    // Premature EOF, malformed terminal event, or invalid Responses framing.
+}
+```
 
 ### Provider Options (via `goai.WithProviderOptions`)
 

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -1,6 +1,6 @@
 // Package sse provides a scanner for Server-Sent Events (SSE) streams.
 //
-// It handles the "data: " prefix, blank line skipping, and [DONE] sentinel.
+// It handles data payloads, complete event framing, and the [DONE] sentinel.
 // JSON deserialization is left to the caller.
 package sse
 
@@ -20,6 +20,17 @@ import (
 // (a DoS vector). Lines exceeding this size cause Next to stop and Err to
 // report the violation.
 const MaxLineSize = 16 << 20 // 16 MiB
+
+// MaxEventSize is the upper bound on the aggregate data payload of one SSE
+// event, in bytes. Multi-line data fields are joined with a single newline.
+const MaxEventSize = 16 << 20 // 16 MiB
+
+// Event is one complete SSE event. Type is empty when the event field was not
+// present. Data contains all data fields joined with a newline.
+type Event struct {
+	Type string
+	Data []byte
+}
 
 // Scanner reads SSE data payloads from an io.Reader.
 type Scanner struct {
@@ -61,6 +72,65 @@ func (s *Scanner) NextLine() (line string, ok bool) {
 		}
 	}
 	return strings.TrimRight(raw, "\r\n"), true
+}
+
+// NextEvent returns the next complete SSE event. Comments and events without
+// data fields are ignored. A final event without a trailing blank line is
+// returned at EOF. Field values may omit the optional space after the colon.
+//
+// Mix NextEvent with Next or NextLine on the same scanner at your own risk;
+// pick one mode per stream.
+func (s *Scanner) NextEvent() (Event, bool) {
+	if s.err != nil {
+		return Event{}, false
+	}
+
+	var event Event
+	var hasData bool
+	for {
+		raw, err := s.readLine()
+		if len(raw) > 0 {
+			line := strings.TrimRight(raw, "\r\n")
+			if line == "" {
+				if hasData {
+					return event, true
+				}
+				event.Type = ""
+			} else if line[0] != ':' {
+				field, value, _ := strings.Cut(line, ":")
+				value = strings.TrimPrefix(value, " ")
+				switch field {
+				case "event":
+					event.Type = value
+				case "data":
+					additional := len(value)
+					if hasData {
+						additional++
+					}
+					if len(event.Data)+additional > MaxEventSize {
+						s.err = fmt.Errorf("sse: event exceeds %d bytes", MaxEventSize)
+						return Event{}, false
+					}
+					if hasData {
+						event.Data = append(event.Data, '\n')
+					}
+					event.Data = append(event.Data, value...)
+					hasData = true
+				}
+			}
+		}
+
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				s.err = err
+				return Event{}, false
+			}
+			if hasData {
+				return event, true
+			}
+			return Event{}, false
+		}
+	}
 }
 
 // Next returns the next SSE data payload (with "data: " prefix stripped).

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -5,7 +5,7 @@
 package sse
 
 import (
-	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -34,18 +34,24 @@ type Event struct {
 
 // Scanner reads SSE data payloads from an io.Reader.
 type Scanner struct {
-	reader *bufio.Reader
-	err    error
-	done   bool
+	reader   io.Reader
+	readBuf  [4096]byte
+	pending  []byte
+	scanFrom int
+	readErr  error
+	atStart  bool
+	skipLF   bool
+	err      error
+	done     bool
 }
 
-// NewScanner creates an SSE scanner backed by a bufio.Reader.
+// NewScanner creates an SSE scanner for r.
 //
 // Lines up to [MaxLineSize] bytes are accepted; longer lines cause the
 // scanner to stop with an error reported via Err. This lifts the 1 MiB
 // limit imposed by bufio.Scanner while still bounding memory use.
 func NewScanner(r io.Reader) *Scanner {
-	return &Scanner{reader: bufio.NewReader(r)}
+	return &Scanner{reader: r, atStart: true}
 }
 
 // NextLine returns the next line from the SSE stream with trailing CR/LF
@@ -75,8 +81,9 @@ func (s *Scanner) NextLine() (line string, ok bool) {
 }
 
 // NextEvent returns the next complete SSE event. Comments and events without
-// data fields are ignored. A final event without a trailing blank line is
-// returned at EOF. Field values may omit the optional space after the colon.
+// data fields are ignored. An event is complete only after a blank line; any
+// pending event is discarded at EOF. Field values may omit the optional space
+// after the colon.
 //
 // Mix NextEvent with Next or NextLine on the same scanner at your own risk;
 // pick one mode per stream.
@@ -123,10 +130,6 @@ func (s *Scanner) NextEvent() (Event, bool) {
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				s.err = err
-				return Event{}, false
-			}
-			if hasData {
-				return event, true
 			}
 			return Event{}, false
 		}
@@ -165,32 +168,92 @@ func (s *Scanner) Next() (data string, ok bool) {
 	}
 }
 
-// readLine reads one '\n'-terminated line, accumulating across the
-// underlying bufio.Reader's internal buffer so we are not limited by its
-// size. It enforces [MaxLineSize] to prevent unbounded memory growth from
-// a hostile or malformed stream.
+// readLine reads one CR, LF, or CRLF-terminated line with fixed-size reads. It
+// enforces [MaxLineSize] to prevent unbounded memory growth from a hostile or
+// malformed stream.
 //
-// Returns the line (which may include the trailing '\n') together with
-// any terminal error. A final partial line at EOF is returned with
-// io.EOF.
+// Returns the line (including its terminator, when present) together with any
+// terminal error. A final partial line at EOF is returned with io.EOF. One
+// leading UTF-8 BOM is stripped from the stream before field parsing.
 func (s *Scanner) readLine() (string, error) {
-	var buf []byte
+	const maxConsecutiveEmptyReads = 100
+	emptyReads := 0
+
 	for {
-		slice, err := s.reader.ReadSlice('\n')
-		if len(buf)+len(slice) > MaxLineSize {
+		if s.skipLF {
+			if len(s.pending) > 0 {
+				if s.pending[0] == '\n' {
+					s.pending = s.pending[1:]
+				}
+				s.skipLF = false
+			} else if s.readErr != nil {
+				s.skipLF = false
+			}
+		}
+
+		if end, complete := s.lineEnd(); complete {
+			if end > MaxLineSize {
+				return "", fmt.Errorf("sse: line exceeds %d bytes", MaxLineSize)
+			}
+			line := s.pending[:end]
+			s.pending = s.pending[end:]
+			s.scanFrom = 0
+			if len(s.pending) == 0 {
+				s.pending = nil
+			}
+			return string(s.stripInitialBOM(line)), nil
+		}
+
+		if len(s.pending) > MaxLineSize {
 			return "", fmt.Errorf("sse: line exceeds %d bytes", MaxLineSize)
 		}
-		// ReadSlice returns a reference into the reader's internal buffer
-		// that may be overwritten on the next read; append copies it out.
-		buf = append(buf, slice...)
-		if err == nil {
-			return string(buf), nil
+		if s.readErr != nil {
+			if len(s.pending) == 0 {
+				return "", s.readErr
+			}
+			line := s.pending
+			s.pending = nil
+			s.scanFrom = 0
+			return string(s.stripInitialBOM(line)), s.readErr
 		}
-		if errors.Is(err, bufio.ErrBufferFull) {
-			continue
+
+		n, err := s.reader.Read(s.readBuf[:])
+		if n > 0 {
+			s.pending = append(s.pending, s.readBuf[:n]...)
+			emptyReads = 0
+		} else if err == nil {
+			emptyReads++
+			if emptyReads >= maxConsecutiveEmptyReads {
+				s.readErr = io.ErrNoProgress
+			}
 		}
-		return string(buf), err
+		if err != nil {
+			s.readErr = err
+		}
 	}
+}
+
+func (s *Scanner) lineEnd() (int, bool) {
+	index := bytes.IndexAny(s.pending[s.scanFrom:], "\r\n")
+	if index < 0 {
+		s.scanFrom = len(s.pending)
+		return 0, false
+	}
+	index += s.scanFrom
+
+	end := index + 1
+	if s.pending[index] == '\r' {
+		s.skipLF = true
+	}
+	return end, true
+}
+
+func (s *Scanner) stripInitialBOM(line []byte) []byte {
+	if !s.atStart {
+		return line
+	}
+	s.atStart = false
+	return bytes.TrimPrefix(line, []byte{0xef, 0xbb, 0xbf})
 }
 
 // Err returns the first non-EOF error encountered while reading,

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -355,3 +355,80 @@ func TestScanner_NextLine_LargeLine(t *testing.T) {
 		t.Errorf("got len=%d, want %d", len(got), len("data: ")+len(payload))
 	}
 }
+
+func TestScanner_NextEvent(t *testing.T) {
+	input := strings.Join([]string{
+		": ignored comment",
+		"event:first",
+		"data:{\"part\":1}",
+		"data: {\"part\":2}",
+		"",
+		"event: second\r",
+		"data: payload\r",
+		"\r",
+	}, "\n")
+	s := NewScanner(strings.NewReader(input))
+
+	first, ok := s.NextEvent()
+	if !ok {
+		t.Fatal("NextEvent() did not return first event")
+	}
+	if first.Type != "first" || string(first.Data) != "{\"part\":1}\n{\"part\":2}" {
+		t.Fatalf("first event = %#v", first)
+	}
+
+	second, ok := s.NextEvent()
+	if !ok {
+		t.Fatal("NextEvent() did not return second event")
+	}
+	if second.Type != "second" || string(second.Data) != "payload" {
+		t.Fatalf("second event = %#v", second)
+	}
+	if _, ok := s.NextEvent(); ok {
+		t.Fatal("NextEvent() returned an event after EOF")
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err() = %v", err)
+	}
+}
+
+func TestScanner_NextEvent_IgnoresCommentsAndEmptyFrames(t *testing.T) {
+	input := ": ping\n\n\nevent: metadata\n\ndata: value\n\n"
+	s := NewScanner(strings.NewReader(input))
+
+	event, ok := s.NextEvent()
+	if !ok {
+		t.Fatal("NextEvent() did not return data event")
+	}
+	if event.Type != "" || string(event.Data) != "value" {
+		t.Fatalf("event = %#v", event)
+	}
+}
+
+func TestScanner_NextEvent_FinalPartialEvent(t *testing.T) {
+	s := NewScanner(strings.NewReader("event: final\ndata: payload"))
+
+	event, ok := s.NextEvent()
+	if !ok {
+		t.Fatal("NextEvent() did not return final partial event")
+	}
+	if event.Type != "final" || string(event.Data) != "payload" {
+		t.Fatalf("event = %#v", event)
+	}
+	if _, ok := s.NextEvent(); ok {
+		t.Fatal("NextEvent() returned an event after EOF")
+	}
+}
+
+func TestScanner_NextEvent_EventExceedsMaxSize(t *testing.T) {
+	line := strings.Repeat("x", MaxEventSize/2)
+	input := "data: " + line + "\ndata: " + line + "\ndata: x\n\n"
+	s := NewScanner(strings.NewReader(input))
+
+	if _, ok := s.NextEvent(); ok {
+		t.Fatal("NextEvent() succeeded for oversized event")
+	}
+	if err := s.Err(); err == nil || !strings.Contains(err.Error(), "event exceeds") {
+		t.Fatalf("Err() = %v, want event size error", err)
+	}
+}

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestScanner_BasicEvents(t *testing.T) {
@@ -142,6 +143,10 @@ type errReader struct{ err error }
 
 func (e *errReader) Read(_ []byte) (int, error) { return 0, e.err }
 
+type noProgressReader struct{}
+
+func (noProgressReader) Read(_ []byte) (int, error) { return 0, nil }
+
 func TestScanner_ReadError(t *testing.T) {
 	injected := errors.New("stream broken")
 	// First reader yields one valid event; second reader immediately returns the error.
@@ -163,6 +168,17 @@ func TestScanner_ReadError(t *testing.T) {
 
 	if err := s.Err(); !errors.Is(err, injected) {
 		t.Errorf("Err() = %v; want injected error %v", err, injected)
+	}
+}
+
+func TestScanner_NoProgress(t *testing.T) {
+	s := NewScanner(noProgressReader{})
+
+	if _, ok := s.NextEvent(); ok {
+		t.Fatal("NextEvent() returned an event from a reader making no progress")
+	}
+	if err := s.Err(); !errors.Is(err, io.ErrNoProgress) {
+		t.Fatalf("Err() = %v, want io.ErrNoProgress", err)
 	}
 }
 
@@ -392,6 +408,81 @@ func TestScanner_NextEvent(t *testing.T) {
 	}
 }
 
+func TestScanner_NextEvent_LineEndings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "CR", input: "event: first\rdata: payload\r\r"},
+		{name: "mixed", input: "event: first\r\ndata: payload\n\r"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScanner(strings.NewReader(tt.input))
+			event, ok := s.NextEvent()
+			if !ok {
+				t.Fatalf("NextEvent() did not return event; Err=%v", s.Err())
+			}
+			if event.Type != "first" || string(event.Data) != "payload" {
+				t.Fatalf("event = %#v", event)
+			}
+			if _, ok := s.NextEvent(); ok {
+				t.Fatal("NextEvent() returned an event after EOF")
+			}
+			if err := s.Err(); err != nil {
+				t.Fatalf("Err() = %v", err)
+			}
+		})
+	}
+}
+
+func TestScanner_NextEvent_CRDispatchesBeforeEOF(t *testing.T) {
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = writer.Close()
+		_ = reader.Close()
+	})
+	s := NewScanner(reader)
+
+	result := make(chan Event, 1)
+	go func() {
+		event, ok := s.NextEvent()
+		if ok {
+			result <- event
+		}
+		close(result)
+	}()
+
+	if _, err := io.WriteString(writer, "event: first\rdata: payload\r\r"); err != nil {
+		t.Fatalf("write CR-only event: %v", err)
+	}
+
+	select {
+	case event, ok := <-result:
+		if !ok {
+			t.Fatalf("NextEvent() stopped before EOF; Err=%v", s.Err())
+		}
+		if event.Type != "first" || string(event.Data) != "payload" {
+			t.Fatalf("event = %#v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("NextEvent() did not dispatch CR-only event before EOF")
+	}
+}
+
+func TestScanner_NextEvent_StripsInitialBOM(t *testing.T) {
+	s := NewScanner(strings.NewReader("\xef\xbb\xbfevent: first\ndata: payload\n\n"))
+
+	event, ok := s.NextEvent()
+	if !ok {
+		t.Fatalf("NextEvent() did not return event; Err=%v", s.Err())
+	}
+	if event.Type != "first" || string(event.Data) != "payload" {
+		t.Fatalf("event = %#v", event)
+	}
+}
+
 func TestScanner_NextEvent_IgnoresCommentsAndEmptyFrames(t *testing.T) {
 	input := ": ping\n\n\nevent: metadata\n\ndata: value\n\n"
 	s := NewScanner(strings.NewReader(input))
@@ -405,18 +496,33 @@ func TestScanner_NextEvent_IgnoresCommentsAndEmptyFrames(t *testing.T) {
 	}
 }
 
-func TestScanner_NextEvent_FinalPartialEvent(t *testing.T) {
+func TestScanner_NextEvent_DiscardsFinalPartialEvent(t *testing.T) {
 	s := NewScanner(strings.NewReader("event: final\ndata: payload"))
 
-	event, ok := s.NextEvent()
-	if !ok {
-		t.Fatal("NextEvent() did not return final partial event")
+	if _, ok := s.NextEvent(); ok {
+		t.Fatal("NextEvent() returned an unterminated event")
 	}
-	if event.Type != "final" || string(event.Data) != "payload" {
-		t.Fatalf("event = %#v", event)
+	if err := s.Err(); err != nil {
+		t.Fatalf("Err() = %v", err)
+	}
+}
+
+func TestScanner_NextEvent_ReadError(t *testing.T) {
+	injected := errors.New("stream broken")
+	r := io.MultiReader(
+		strings.NewReader("event: partial\ndata: payload\n"),
+		&errReader{err: injected},
+	)
+	s := NewScanner(r)
+
+	if _, ok := s.NextEvent(); ok {
+		t.Fatal("NextEvent() returned an event after read error")
+	}
+	if err := s.Err(); !errors.Is(err, injected) {
+		t.Fatalf("Err() = %v, want injected error", err)
 	}
 	if _, ok := s.NextEvent(); ok {
-		t.Fatal("NextEvent() returned an event after EOF")
+		t.Fatal("NextEvent() returned an event on repeat call after error")
 	}
 }
 
@@ -430,5 +536,8 @@ func TestScanner_NextEvent_EventExceedsMaxSize(t *testing.T) {
 	}
 	if err := s.Err(); err == nil || !strings.Contains(err.Error(), "event exceeds") {
 		t.Fatalf("Err() = %v, want event size error", err)
+	}
+	if _, ok := s.NextEvent(); ok {
+		t.Fatal("NextEvent() returned an event on repeat call after size error")
 	}
 }

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/zendev-sh/goai/provider"
 	"github.com/zendev-sh/goai/provider/anthropic"
@@ -39,13 +40,15 @@ const defaultAPIVersion = "2025-03-01-preview"
 type Option func(*options)
 
 type options struct {
-	apiKey                 string
-	tokenSource            provider.TokenSource
-	endpoint               string
-	headers                map[string]string
-	httpClient             *http.Client
-	apiVersion             string
-	useDeploymentBasedURLs bool
+	apiKey                     string
+	tokenSource                provider.TokenSource
+	endpoint                   string
+	headers                    map[string]string
+	httpClient                 *http.Client
+	apiVersion                 string
+	useDeploymentBasedURLs     bool
+	responsesStreamIdleTimeout time.Duration
+	responsesStreamAllowDone   bool
 }
 
 // WithAPIKey sets the Azure API key.
@@ -80,6 +83,25 @@ func WithHeaders(h map[string]string) Option {
 func WithHTTPClient(c *http.Client) Option {
 	return func(o *options) {
 		o.httpClient = c
+	}
+}
+
+// WithResponsesStreamIdleTimeout configures the event-level idle timeout for
+// Azure OpenAI Responses streams. A positive duration enables the watchdog,
+// zero disables it, and a negative duration is rejected when a Responses
+// stream starts. The default matches [openai.DefaultResponsesStreamIdleTimeout].
+func WithResponsesStreamIdleTimeout(timeout time.Duration) Option {
+	return func(o *options) {
+		o.responsesStreamIdleTimeout = timeout
+	}
+}
+
+// WithResponsesStreamDoneCompatibility allows a non-standard Azure OpenAI
+// Responses endpoint to terminate a stream with a bare [DONE] sentinel. It is
+// disabled by default; standard Responses streams use typed terminal events.
+func WithResponsesStreamDoneCompatibility(enabled bool) Option {
+	return func(o *options) {
+		o.responsesStreamAllowDone = enabled
 	}
 }
 
@@ -176,7 +198,7 @@ func buildHTTPClient(o *options, modelID string) *http.Client {
 // Claude via a separate API that speaks the Anthropic Messages protocol, not
 // OpenAI Chat Completions.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
-	o := options{}
+	o := options{responsesStreamIdleTimeout: openai.DefaultResponsesStreamIdleTimeout}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -210,6 +232,8 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	openaiOpts := []openai.Option{
 		openai.WithHTTPClient(httpClient),
 		openai.WithAPIKey("azure-delegated"),
+		openai.WithResponsesStreamIdleTimeout(o.responsesStreamIdleTimeout),
+		openai.WithResponsesStreamDoneCompatibility(o.responsesStreamAllowDone),
 		// Use a placeholder base URL -- azureRoundTripper rewrites it.
 		openai.WithBaseURL("https://azure-placeholder"),
 	}
@@ -397,7 +421,14 @@ func buildCognitiveServicesModel(o *options, modelID string) provider.LanguageMo
 	httpClient := &http.Client{Transport: transport}
 
 	// openai.Chat defaults to Responses API which is what codex/pro models need.
-	return openai.Chat(modelID, openai.WithHTTPClient(httpClient), openai.WithAPIKey("azure-delegated"), openai.WithBaseURL(baseURL))
+	return openai.Chat(
+		modelID,
+		openai.WithHTTPClient(httpClient),
+		openai.WithAPIKey("azure-delegated"),
+		openai.WithBaseURL(baseURL),
+		openai.WithResponsesStreamIdleTimeout(o.responsesStreamIdleTimeout),
+		openai.WithResponsesStreamDoneCompatibility(o.responsesStreamAllowDone),
+	)
 }
 
 // aiServicesRoundTripper injects Azure auth headers and api-version query parameter

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -70,6 +70,40 @@ func TestChat_Stream(t *testing.T) {
 	}
 }
 
+func TestChat_ResponsesStreamDataOnlyFraming(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "\xef\xbb\xbfdata: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\r\r")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\r\r")
+	}))
+	defer server.Close()
+
+	model := Chat("gpt-5", WithAPIKey("test-key"), WithEndpoint(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var text string
+	var gotFinish bool
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		if chunk.Type == provider.ChunkText {
+			text += chunk.Text
+		}
+		gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+	}
+	if text != "Hello" || !gotFinish {
+		t.Fatalf("text = %q, finish = %v; want Hello and finish", text, gotFinish)
+	}
+}
+
 func TestChat_ResponsesStreamIdleTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -3,12 +3,14 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zendev-sh/goai/provider"
 	"github.com/zendev-sh/goai/provider/openai"
@@ -65,6 +67,78 @@ func TestChat_Stream(t *testing.T) {
 	}
 	if len(texts) != 1 || texts[0] != "Hello" {
 		t.Errorf("texts = %v, want [Hello]", texts)
+	}
+}
+
+func TestChat_ResponsesStreamIdleTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	model := Chat(
+		"gpt-5",
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithResponsesStreamIdleTimeout(25*time.Millisecond),
+	)
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var streamErr error
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			streamErr = chunk.Error
+		}
+	}
+	var idleErr *openai.StreamIdleTimeoutError
+	if !errors.As(streamErr, &idleErr) || idleErr.Idle != 25*time.Millisecond {
+		t.Fatalf("stream error = %T %v, want Azure-forwarded idle timeout", streamErr, streamErr)
+	}
+}
+
+func TestChat_ResponsesStreamDoneCompatibility(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat(
+		"gpt-5",
+		WithAPIKey("test-key"),
+		WithEndpoint(server.URL),
+		WithResponsesStreamDoneCompatibility(true),
+	)
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotFinish bool
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+	}
+	if !gotFinish {
+		t.Fatal("Azure [DONE] compatibility option did not finish the stream")
 	}
 }
 
@@ -1196,8 +1270,8 @@ func TestAIServices_TokenSourceError(t *testing.T) {
 func TestForceChatCompletions_PreservesExistingOptions(t *testing.T) {
 	params := provider.GenerateParams{
 		ProviderOptions: map[string]any{
-			"user":       "test-user",
-			"customKey":  42,
+			"user":      "test-user",
+			"customKey": 42,
 		},
 	}
 	forceChatCompletions(&params)

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -17,7 +17,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"sync"
+	"time"
 
 	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/internal/httpc"
@@ -38,10 +38,12 @@ const defaultBaseURL = "https://api.openai.com/v1"
 type Option func(*options)
 
 type options struct {
-	tokenSource provider.TokenSource
-	baseURL     string
-	headers     map[string]string
-	httpClient  *http.Client
+	tokenSource                provider.TokenSource
+	baseURL                    string
+	headers                    map[string]string
+	httpClient                 *http.Client
+	responsesStreamIdleTimeout time.Duration
+	responsesStreamAllowDone   bool
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -85,7 +87,10 @@ func WithHTTPClient(c *http.Client) Option {
 
 // Chat creates an OpenAI language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
-	o := options{baseURL: defaultBaseURL}
+	o := options{
+		baseURL:                    defaultBaseURL,
+		responsesStreamIdleTimeout: DefaultResponsesStreamIdleTimeout,
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -190,6 +195,10 @@ func (m *chatModel) doGenerateChatCompletions(ctx context.Context, params provid
 // --- Responses API ---
 
 func (m *chatModel) doStreamResponses(ctx context.Context, params provider.GenerateParams) (*provider.StreamResult, error) {
+	if m.opts.responsesStreamIdleTimeout < 0 {
+		return nil, fmt.Errorf("openai: Responses stream idle timeout must be non-negative: %s", m.opts.responsesStreamIdleTimeout)
+	}
+
 	body := buildResponsesRequest(params, m.id, true)
 
 	resp, err := m.doHTTP(ctx, m.opts.baseURL+"/responses", body)
@@ -199,22 +208,10 @@ func (m *chatModel) doStreamResponses(ctx context.Context, params provider.Gener
 
 	out := make(chan provider.StreamChunk, 64)
 	go func() {
-		var closeOnce sync.Once
-		closeBody := func() { closeOnce.Do(func() { _ = resp.Body.Close() }) }
-		// Close body on context cancellation to unblock scanner.Scan().
-		// Without this, the goroutine leaks if the server stalls mid-stream.
-		done := make(chan struct{})
-		defer close(done)
-		go func() {
-			select {
-			case <-ctx.Done():
-				closeBody()
-			case <-done:
-			}
-		}()
-		// Wrap body so streamResponses' defer close calls closeBody, not raw Close,
-		// preventing double-close when context cancellation races with normal completion.
-		streamResponses(ctx, onceCloser{resp.Body, closeBody}, out)
+		streamResponsesWithConfig(ctx, resp.Body, out, responsesStreamConfig{
+			idleTimeout: m.opts.responsesStreamIdleTimeout,
+			allowDone:   m.opts.responsesStreamAllowDone,
+		})
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil
@@ -235,19 +232,6 @@ func (m *chatModel) doGenerateResponses(ctx context.Context, params provider.Gen
 	}
 
 	return parseResponsesResult(respBody)
-}
-
-// onceCloser wraps an io.ReadCloser so that Close is idempotent via a provided
-// close function. Used to prevent double-close when context cancellation races
-// with the normal end-of-stream close inside streamResponses.
-type onceCloser struct {
-	io.Reader
-	closeFn func()
-}
-
-func (o onceCloser) Close() error {
-	o.closeFn()
-	return nil
 }
 
 // --- HTTP helpers ---
@@ -290,4 +274,3 @@ func (m *chatModel) shouldUseResponsesAPI(params provider.GenerateParams) bool {
 	// Default: all models use Responses API (matches Vercel).
 	return true
 }
-

--- a/provider/openai/openai_test.go
+++ b/provider/openai/openai_test.go
@@ -2397,20 +2397,27 @@ func TestStreamResponses_ReasoningEncryptedContent(t *testing.T) {
 		"event: response.completed\n" +
 		`data: {"response":{"id":"resp-1","model":"o3"}}` + "\n\n"
 	out := make(chan provider.StreamChunk, 8)
-	streamResponses(context.Background(), io.NopCloser(strings.NewReader(sse)), out)
+	streamResponses(t.Context(), io.NopCloser(strings.NewReader(sse)), out)
 
 	var chunks []provider.StreamChunk
 	for chunk := range out {
 		chunks = append(chunks, chunk)
 	}
-	var encrypted bool
+	var encrypted, gotFinish bool
 	for _, chunk := range chunks {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
 		if openAI, ok := chunk.Metadata["openai"].(map[string]any); ok && openAI["encryptedContent"] == "opaque-state" {
 			encrypted = true
 		}
 	}
 	if !encrypted {
 		t.Fatal("stream did not preserve encrypted reasoning content")
+	}
+	if !gotFinish {
+		t.Fatal("usage-less terminal event did not finish the stream")
 	}
 }
 
@@ -2531,14 +2538,48 @@ func TestStreamResponses_ContentFilterIncomplete(t *testing.T) {
 	}
 }
 
-func TestStreamResponses_DONE(t *testing.T) {
+func TestStreamResponses_DONERejectedByDefault(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
 	}))
 	defer server.Close()
 
-	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	model := Chat("gpt-5", WithAPIKey("key"), WithBaseURL(server.URL))
+	result, err := model.DoStream(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotError error
+	for chunk := range result.Stream {
+		if chunk.Type == provider.ChunkError {
+			gotError = chunk.Error
+		}
+	}
+	var protocolErr *StreamProtocolError
+	if !errors.As(gotError, &protocolErr) {
+		t.Fatalf("error = %T %v, want strict Responses protocol error", gotError, gotError)
+	}
+}
+
+func TestStreamResponses_DONECompatibility(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	model := Chat(
+		"gpt-5",
+		WithAPIKey("key"),
+		WithBaseURL(server.URL),
+		WithResponsesStreamDoneCompatibility(true),
+	)
 	result, err := model.DoStream(t.Context(), provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
@@ -2550,12 +2591,87 @@ func TestStreamResponses_DONE(t *testing.T) {
 
 	var gotFinish bool
 	for chunk := range result.Stream {
-		if chunk.Type == provider.ChunkFinish {
-			gotFinish = true
-		}
+		gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
 	}
 	if !gotFinish {
-		t.Error("expected finish chunk from [DONE]")
+		t.Fatal("compatibility option did not accept [DONE]")
+	}
+}
+
+func TestStreamResponses_PrematureEOF(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantReasoning bool
+	}{
+		{
+			name:  "before output",
+			input: "event: response.created\ndata: {\"response\":{\"id\":\"resp_1\"}}\n\n",
+		},
+		{
+			name:          "after reasoning delta",
+			input:         "event: response.reasoning_summary_text.delta\ndata: {\"item_id\":\"rs_1\",\"summary_index\":0,\"delta\":\"thinking\"}\n\n",
+			wantReasoning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := make(chan provider.StreamChunk, 4)
+			streamResponses(t.Context(), io.NopCloser(strings.NewReader(tt.input)), out)
+
+			var gotReasoning, gotError bool
+			for chunk := range out {
+				gotReasoning = gotReasoning || chunk.Type == provider.ChunkReasoning
+				gotError = gotError || chunk.Type == provider.ChunkError
+			}
+			if gotReasoning != tt.wantReasoning {
+				t.Fatalf("reasoning chunk = %v, want %v", gotReasoning, tt.wantReasoning)
+			}
+			if !gotError {
+				t.Fatal("expected premature EOF to emit a stream error")
+			}
+		})
+	}
+}
+
+func TestStreamResponses_MalformedTerminal(t *testing.T) {
+	terminalEvents := []string{
+		"response.completed",
+		"response.incomplete",
+		"response.failed",
+		"error",
+	}
+
+	for _, eventType := range terminalEvents {
+		for _, payload := range []struct {
+			name string
+			data string
+		}{
+			{name: "invalid JSON", data: "{not-json}"},
+			{name: "invalid shape", data: `{"response":"invalid","error":"invalid"}`},
+			{name: "missing required fields", data: `{}`},
+		} {
+			t.Run(eventType+"/"+payload.name, func(t *testing.T) {
+				input := fmt.Sprintf("event: %s\ndata: %s\n\n", eventType, payload.data)
+				out := make(chan provider.StreamChunk, 4)
+				streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
+
+				var gotError error
+				for chunk := range out {
+					if chunk.Type == provider.ChunkError {
+						gotError = chunk.Error
+					}
+				}
+				if gotError == nil {
+					t.Fatal("expected malformed terminal event to emit a stream error")
+				}
+				var protocolErr *StreamProtocolError
+				if !errors.As(gotError, &protocolErr) || protocolErr.EventType != eventType {
+					t.Fatalf("error = %T %#v, want protocol error for %q", gotError, gotError, eventType)
+				}
+			})
+		}
 	}
 }
 
@@ -2602,14 +2718,18 @@ func TestStreamResponses_ScannerError(t *testing.T) {
 	out := make(chan provider.StreamChunk, 64)
 	go streamResponses(t.Context(), &errorReader{}, out)
 
-	var gotError bool
+	var gotError error
 	for chunk := range out {
 		if chunk.Type == provider.ChunkError {
-			gotError = true
+			gotError = chunk.Error
 		}
 	}
-	if !gotError {
+	if gotError == nil {
 		t.Error("expected error chunk from scanner error")
+	}
+	var protocolErr *StreamProtocolError
+	if !errors.As(gotError, &protocolErr) || protocolErr.Reason != "stream read failed" || errors.Unwrap(protocolErr) == nil {
+		t.Fatalf("error = %T %#v, want wrapped stream protocol error", gotError, gotError)
 	}
 }
 

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -694,17 +694,45 @@ func streamResponsesWithConfig(
 
 		case "response.reasoning_summary_part.added":
 			var ev struct {
-				ItemID         string `json:"item_id"`
-				OutputIndex    int    `json:"output_index"`
-				SummaryIndex   int    `json:"summary_index"`
-				SequenceNumber int    `json:"sequence_number"`
+				ItemID         *string `json:"item_id"`
+				OutputIndex    *int    `json:"output_index"`
+				SummaryIndex   *int    `json:"summary_index"`
+				SequenceNumber *int    `json:"sequence_number"`
 				Part           *struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
 				} `json:"part"`
 			}
+			ev.ItemID = new(string)
+			ev.OutputIndex = new(int)
+			ev.SummaryIndex = new(int)
+			ev.SequenceNumber = new(int)
+			ev.Part = &struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			}{}
 			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
 				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.ItemID == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "item_id"))
+				return
+			}
+			if ev.OutputIndex == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "output_index"))
+				return
+			}
+			if ev.SummaryIndex == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "summary_index"))
+				return
+			}
+			if ev.SequenceNumber == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "sequence_number"))
+				return
+			}
+			if ev.Part == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "part"))
 				return
 			}
 			// New summary segments do not emit chunks, but decoding validates the
@@ -903,11 +931,21 @@ func streamResponsesWithConfig(
 					// emit a ChunkToolCall so it round-trips into the
 					// assistant turn via ToolCall.Metadata.
 					var itemIdentity struct {
-						ID   string `json:"id"`
-						Name string `json:"name"`
+						ID   *string `json:"id"`
+						Name *string `json:"name"`
 					}
+					itemIdentity.ID = new(string)
+					itemIdentity.Name = new(string)
 					if err := decodeResponsesEvent(eventType, ev.Item, &itemIdentity); err != nil {
 						trySendResponsesError(ctx, out, err)
+						return
+					}
+					if itemIdentity.ID == nil {
+						trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "item.id"))
+						return
+					}
+					if itemIdentity.Name == nil {
+						trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "item.name"))
 						return
 					}
 					var rawItem map[string]any
@@ -915,8 +953,8 @@ func streamResponsesWithConfig(
 						trySendResponsesError(ctx, out, err)
 						return
 					}
-					id := itemIdentity.ID
-					name := itemIdentity.Name
+					id := *itemIdentity.ID
+					name := *itemIdentity.Name
 					if name == "" {
 						name = itemType
 					}

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -609,47 +609,83 @@ func streamResponsesWithConfig(
 		switch eventType {
 		case "response.output_text.delta":
 			var ev struct {
-				Delta string `json:"delta"`
+				Delta *string `json:"delta"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil && ev.Delta != "" {
-				if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkText, Text: ev.Delta}) {
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.Delta == nil {
+				trySendResponsesError(ctx, out, missingResponsesEventField(eventType, "delta"))
+				return
+			}
+			if *ev.Delta != "" {
+				if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkText, Text: *ev.Delta}) {
 					return
 				}
 			}
 
 		case "response.refusal.delta":
 			var ev struct {
-				Delta string `json:"delta"`
+				Delta *string `json:"delta"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil && ev.Delta != "" {
-				if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkText, Text: ev.Delta}) {
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.Delta == nil {
+				trySendResponsesError(ctx, out, missingResponsesEventField(eventType, "delta"))
+				return
+			}
+			if *ev.Delta != "" {
+				if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkText, Text: *ev.Delta}) {
 					return
 				}
 			}
 
 		case "response.reasoning_summary_text.delta":
 			var ev struct {
-				ItemID       string `json:"item_id"`
-				SummaryIndex int    `json:"summary_index"`
-				Delta        string `json:"delta"`
+				ItemID       *string `json:"item_id"`
+				SummaryIndex *int    `json:"summary_index"`
+				Delta        *string `json:"delta"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil && ev.Delta != "" {
+			// Preseeding keeps omitted legacy fields at their zero values while
+			// still letting json.Unmarshal expose an explicit null as nil.
+			ev.ItemID = new(string)
+			ev.SummaryIndex = new(int)
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.ItemID == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "item_id"))
+				return
+			}
+			if ev.SummaryIndex == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "summary_index"))
+				return
+			}
+			if ev.Delta == nil {
+				trySendResponsesError(ctx, out, missingResponsesEventField(eventType, "delta"))
+				return
+			}
+			if *ev.Delta != "" {
 				// Use canonical ID from activeReasoning if available.
-				id, text := ev.ItemID, ev.Delta
-				if idx, ar := activeReasoningForEvent(activeReasoning, currentReasoningIdx, ev.ItemID); idx >= 0 {
+				id, text := *ev.ItemID, *ev.Delta
+				if idx, ar := activeReasoningForEvent(activeReasoning, currentReasoningIdx, *ev.ItemID); idx >= 0 {
 					id = ar.canonicalID
 					// A new summary_index opens a separate summary: carry the
 					// boundary in the text, since the deltas never bring it.
-					if ar.lastSummary >= 0 && ev.SummaryIndex != ar.lastSummary {
+					if ar.lastSummary >= 0 && *ev.SummaryIndex != ar.lastSummary {
 						text = summarySeparator + text
 					}
-					ar.lastSummary = ev.SummaryIndex
+					ar.lastSummary = *ev.SummaryIndex
 				}
 				if !provider.TrySend(ctx, out, provider.StreamChunk{
 					Type: provider.ChunkReasoning,
 					Text: text,
 					Metadata: map[string]any{
-						"reasoningId": fmt.Sprintf("%s:%d", id, ev.SummaryIndex),
+						"reasoningId": fmt.Sprintf("%s:%d", id, *ev.SummaryIndex),
 					},
 				}) {
 					return
@@ -662,56 +698,84 @@ func streamResponsesWithConfig(
 
 		case "response.output_item.added":
 			var ev struct {
-				OutputIndex int `json:"output_index"`
-				Item        struct {
-					Type   string `json:"type"`
-					ID     string `json:"id"`
-					CallID string `json:"call_id"`
-					Name   string `json:"name"`
+				OutputIndex *int `json:"output_index"`
+				Item        *struct {
+					Type   *string `json:"type"`
+					ID     string  `json:"id"`
+					CallID string  `json:"call_id"`
+					Name   string  `json:"name"`
 				} `json:"item"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil {
-				switch ev.Item.Type {
-				case "function_call":
-					hasFunctionCall = true
-					activeTools[ev.OutputIndex] = &responsesToolCall{
-						id:   ev.Item.CallID,
-						name: ev.Item.Name,
-					}
-					if !provider.TrySend(ctx, out, provider.StreamChunk{
-						Type:       provider.ChunkToolCallStreamStart,
-						ToolCallID: ev.Item.CallID,
-						ToolName:   ev.Item.Name,
-					}) {
-						return
-					}
-				case "reasoning":
-					activeReasoning[ev.OutputIndex] = &responsesReasoning{
-						canonicalID: ev.Item.ID,
-						lastSummary: -1,
-					}
-					currentReasoningIdx = ev.OutputIndex
+			ev.OutputIndex = new(int)
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.OutputIndex == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "output_index"))
+				return
+			}
+			if ev.Item == nil {
+				trySendResponsesError(ctx, out, missingResponsesEventField(eventType, "item"))
+				return
+			}
+			if ev.Item.Type == nil || *ev.Item.Type == "" {
+				trySendResponsesError(ctx, out, missingResponsesEventField(eventType, "item.type"))
+				return
+			}
+			switch *ev.Item.Type {
+			case "function_call":
+				hasFunctionCall = true
+				activeTools[*ev.OutputIndex] = &responsesToolCall{
+					id:   ev.Item.CallID,
+					name: ev.Item.Name,
 				}
+				if !provider.TrySend(ctx, out, provider.StreamChunk{
+					Type:       provider.ChunkToolCallStreamStart,
+					ToolCallID: ev.Item.CallID,
+					ToolName:   ev.Item.Name,
+				}) {
+					return
+				}
+			case "reasoning":
+				activeReasoning[*ev.OutputIndex] = &responsesReasoning{
+					canonicalID: ev.Item.ID,
+					lastSummary: -1,
+				}
+				currentReasoningIdx = *ev.OutputIndex
 			}
 
 		case "response.function_call_arguments.delta":
 			var ev struct {
-				OutputIndex int    `json:"output_index"`
-				Delta       string `json:"delta"`
+				OutputIndex *int    `json:"output_index"`
+				Delta       *string `json:"delta"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil && ev.Delta != "" {
-				active := activeTools[ev.OutputIndex]
+			ev.OutputIndex = new(int)
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.OutputIndex == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "output_index"))
+				return
+			}
+			if ev.Delta == nil {
+				trySendResponsesError(ctx, out, missingResponsesEventField(eventType, "delta"))
+				return
+			}
+			if *ev.Delta != "" {
+				active := activeTools[*ev.OutputIndex]
 				if active == nil {
 					active = &responsesToolCall{}
-					activeTools[ev.OutputIndex] = active
+					activeTools[*ev.OutputIndex] = active
 				}
-				active.args.WriteString(ev.Delta)
+				active.args.WriteString(*ev.Delta)
 
 				if !provider.TrySend(ctx, out, provider.StreamChunk{
 					Type:       provider.ChunkToolCallDelta,
 					ToolCallID: active.id,
 					ToolName:   active.name,
-					ToolInput:  ev.Delta,
+					ToolInput:  *ev.Delta,
 				}) {
 					return
 				}
@@ -723,10 +787,131 @@ func streamResponsesWithConfig(
 
 		case "response.function_call_arguments.done":
 			var ev struct {
-				OutputIndex int `json:"output_index"`
+				OutputIndex *int `json:"output_index"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil {
-				if active := activeTools[ev.OutputIndex]; active != nil {
+			ev.OutputIndex = new(int)
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.OutputIndex == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "output_index"))
+				return
+			}
+			if active := activeTools[*ev.OutputIndex]; active != nil {
+				if remaining := active.args.String(); remaining != "" {
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type:       provider.ChunkToolCall,
+						ToolCallID: active.id,
+						ToolName:   active.name,
+						ToolInput:  remaining,
+					}) {
+						return
+					}
+					active.args.Reset()
+				}
+			}
+
+		case "response.output_item.done":
+			var ev struct {
+				OutputIndex *int            `json:"output_index"`
+				Item        json.RawMessage `json:"item"`
+			}
+			ev.OutputIndex = new(int)
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.OutputIndex == nil {
+				trySendResponsesError(ctx, out, nullResponsesEventField(eventType, "output_index"))
+				return
+			}
+			var itemHead *struct {
+				Type *string `json:"type"`
+			}
+			if len(ev.Item) > 0 {
+				if err := decodeResponsesEvent(eventType, ev.Item, &itemHead); err != nil {
+					trySendResponsesError(ctx, out, err)
+					return
+				}
+				if itemHead == nil {
+					trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "event payload has null item", nil))
+					return
+				}
+				if itemHead.Type == nil || *itemHead.Type == "" {
+					trySendResponsesError(ctx, out, missingResponsesEventField(eventType, "item.type"))
+					return
+				}
+			}
+			itemType := ""
+			if itemHead != nil {
+				itemType = *itemHead.Type
+			}
+			switch itemType {
+			case "reasoning":
+				var item struct {
+					ID               string `json:"id"`
+					EncryptedContent string `json:"encrypted_content"`
+				}
+				if err := decodeResponsesEvent(eventType, ev.Item, &item); err != nil {
+					trySendResponsesError(ctx, out, err)
+					return
+				}
+				if active := activeReasoning[*ev.OutputIndex]; active != nil && item.EncryptedContent != "" {
+					id := active.canonicalID
+					if id == "" {
+						id = item.ID
+					}
+					index := active.lastSummary
+					if index < 0 {
+						index = 0
+					}
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type: provider.ChunkReasoning,
+						Metadata: map[string]any{
+							"reasoningId": fmt.Sprintf("%s:%d", id, index),
+							"openai": map[string]any{
+								"itemId":           id,
+								"encryptedContent": item.EncryptedContent,
+							},
+						},
+					}) {
+						return
+					}
+				}
+				delete(activeReasoning, *ev.OutputIndex)
+				if currentReasoningIdx == *ev.OutputIndex {
+					currentReasoningIdx = -1
+				}
+			default:
+				if isServerExecutedItem(itemType) {
+					// Capture the full server-executed item payload and
+					// emit a ChunkToolCall so it round-trips into the
+					// assistant turn via ToolCall.Metadata.
+					var rawItem map[string]any
+					if err := decodeResponsesEvent(eventType, ev.Item, &rawItem); err != nil {
+						trySendResponsesError(ctx, out, err)
+						return
+					}
+					id, _ := rawItem["id"].(string)
+					name, _ := rawItem["name"].(string)
+					if name == "" {
+						name = itemType
+					}
+					if !provider.TrySend(ctx, out, provider.StreamChunk{
+						Type:       provider.ChunkToolCall,
+						ToolCallID: id,
+						ToolName:   name,
+						Metadata: map[string]any{
+							"providerExecuted": true,
+							"rawItem":          rawItem,
+						},
+					}) {
+						return
+					}
+				} else if active := activeTools[*ev.OutputIndex]; active != nil {
+					// Safety net for an item closed without its arguments.done.
+					// The normal path resets the buffer, so this stays empty.
 					if remaining := active.args.String(); remaining != "" {
 						if !provider.TrySend(ctx, out, provider.StreamChunk{
 							Type:       provider.ChunkToolCall,
@@ -739,92 +924,7 @@ func streamResponsesWithConfig(
 						active.args.Reset()
 					}
 				}
-			}
-
-		case "response.output_item.done":
-			var ev struct {
-				OutputIndex int             `json:"output_index"`
-				Item        json.RawMessage `json:"item"`
-			}
-			if json.Unmarshal([]byte(data), &ev) == nil {
-				var itemHead struct {
-					Type string `json:"type"`
-				}
-				_ = json.Unmarshal(ev.Item, &itemHead)
-				switch itemHead.Type {
-				case "reasoning":
-					var item struct {
-						ID               string `json:"id"`
-						EncryptedContent string `json:"encrypted_content"`
-					}
-					_ = json.Unmarshal(ev.Item, &item)
-					if active := activeReasoning[ev.OutputIndex]; active != nil && item.EncryptedContent != "" {
-						id := active.canonicalID
-						if id == "" {
-							id = item.ID
-						}
-						index := active.lastSummary
-						if index < 0 {
-							index = 0
-						}
-						if !provider.TrySend(ctx, out, provider.StreamChunk{
-							Type: provider.ChunkReasoning,
-							Metadata: map[string]any{
-								"reasoningId": fmt.Sprintf("%s:%d", id, index),
-								"openai": map[string]any{
-									"itemId":           id,
-									"encryptedContent": item.EncryptedContent,
-								},
-							},
-						}) {
-							return
-						}
-					}
-					delete(activeReasoning, ev.OutputIndex)
-					if currentReasoningIdx == ev.OutputIndex {
-						currentReasoningIdx = -1
-					}
-				default:
-					if isServerExecutedItem(itemHead.Type) {
-						// Capture the full server-executed item payload and
-						// emit a ChunkToolCall so it round-trips into the
-						// assistant turn via ToolCall.Metadata.
-						var raw map[string]any
-						if err := json.Unmarshal(ev.Item, &raw); err == nil {
-							id, _ := raw["id"].(string)
-							name, _ := raw["name"].(string)
-							if name == "" {
-								name = itemHead.Type
-							}
-							if !provider.TrySend(ctx, out, provider.StreamChunk{
-								Type:       provider.ChunkToolCall,
-								ToolCallID: id,
-								ToolName:   name,
-								Metadata: map[string]any{
-									"providerExecuted": true,
-									"rawItem":          raw,
-								},
-							}) {
-								return
-							}
-						}
-					} else if active := activeTools[ev.OutputIndex]; active != nil {
-						// Safety net for an item closed without its arguments.done.
-						// The normal path resets the buffer, so this stays empty.
-						if remaining := active.args.String(); remaining != "" {
-							if !provider.TrySend(ctx, out, provider.StreamChunk{
-								Type:       provider.ChunkToolCall,
-								ToolCallID: active.id,
-								ToolName:   active.name,
-								ToolInput:  remaining,
-							}) {
-								return
-							}
-							active.args.Reset()
-						}
-					}
-					delete(activeTools, ev.OutputIndex)
-				}
+				delete(activeTools, *ev.OutputIndex)
 			}
 
 		case "response.completed", "response.incomplete":

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -590,26 +590,20 @@ func streamResponsesWithConfig(
 			return
 		}
 
-		eventType := read.event.Type
 		data := string(read.event.Data)
-		terminalEvent := isResponsesTerminalEvent(eventType)
 
 		if data == "[DONE]" {
 			if config.allowDone {
 				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, Usage: usage})
 				return
 			}
-			trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "stream ended with [DONE] before a terminal event", nil))
+			trySendResponsesError(ctx, out, newStreamProtocolError(read.event.Type, "stream ended with [DONE] before a terminal event", nil))
 			return
 		}
-		if !json.Valid(read.event.Data) {
-			err := newStreamProtocolError(eventType, "event data is not valid JSON", nil)
-			if terminalEvent {
-				trySendResponsesError(ctx, out, err)
-				return
-			}
-			idleTimer.reset(config.idleTimeout)
-			continue
+		eventType, err := responsesEventType(read.event)
+		if err != nil {
+			trySendResponsesError(ctx, out, err)
+			return
 		}
 
 		switch eventType {
@@ -835,7 +829,6 @@ func streamResponsesWithConfig(
 
 		case "response.completed", "response.incomplete":
 			var ev struct {
-				Type     string `json:"type"`
 				Response *struct {
 					ID                string `json:"id"`
 					Model             string `json:"model"`
@@ -856,10 +849,6 @@ func streamResponsesWithConfig(
 			}
 			if err := json.Unmarshal(read.event.Data, &ev); err != nil {
 				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "malformed terminal event", err))
-				return
-			}
-			if err := validateResponsesPayloadType(eventType, ev.Type); err != nil {
-				trySendResponsesError(ctx, out, err)
 				return
 			}
 			if ev.Response == nil {
@@ -919,7 +908,6 @@ func streamResponsesWithConfig(
 
 		case "response.failed":
 			var ev struct {
-				Type     string `json:"type"`
 				Response *struct {
 					Error struct {
 						Message string `json:"message"`
@@ -929,10 +917,6 @@ func streamResponsesWithConfig(
 			}
 			if err := json.Unmarshal(read.event.Data, &ev); err != nil {
 				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "malformed terminal event", err))
-				return
-			}
-			if err := validateResponsesPayloadType(eventType, ev.Type); err != nil {
-				trySendResponsesError(ctx, out, err)
 				return
 			}
 			if ev.Response == nil {
@@ -947,7 +931,6 @@ func streamResponsesWithConfig(
 		case "error":
 			// OpenAI documents flat message/code fields, but production often nests them under error.
 			var ev struct {
-				Type    string `json:"type"`
 				Message string `json:"message"`
 				Code    string `json:"code"`
 				Error   *struct {
@@ -957,10 +940,6 @@ func streamResponsesWithConfig(
 			}
 			if err := json.Unmarshal(read.event.Data, &ev); err != nil {
 				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "malformed terminal event", err))
-				return
-			}
-			if err := validateResponsesPayloadType(eventType, ev.Type); err != nil {
-				trySendResponsesError(ctx, out, err)
 				return
 			}
 			// Prefer the nested error fields when present, but fall back to

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/zendev-sh/goai"
-	"github.com/zendev-sh/goai/internal/sse"
 	"github.com/zendev-sh/goai/provider"
 )
 
@@ -530,17 +529,27 @@ func openAIReasoningPart(itemID, text, encryptedContent string) provider.Part {
 // together and merges the markdown at the seam.
 const summarySeparator = "\n\n"
 
-// streamResponses parses SSE from the OpenAI Responses API.
-// Uses sse.Scanner.NextLine because the Responses API has event-typed SSE
-// (event: + data: pairs), unlike Chat Completions (data: only).
+// streamResponses parses SSE from the OpenAI Responses API with the default
+// event-level idle timeout.
 func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provider.StreamChunk) {
-	defer close(out)
-	defer func() { _ = body.Close() }()
+	streamResponsesWithConfig(ctx, body, out, defaultResponsesStreamConfig())
+}
 
-	scanner := sse.NewScanner(body)
+func streamResponsesWithConfig(
+	ctx context.Context,
+	body io.ReadCloser,
+	out chan<- provider.StreamChunk,
+	config responsesStreamConfig,
+) {
+	defer close(out)
+
+	reader := newResponsesEventReader(ctx, body)
+	defer reader.close()
+
+	idleTimer := newResponsesIdleTimer(config.idleTimeout)
+	defer idleTimer.stop()
 
 	var usage provider.Usage
-	var eventType string
 	var hasFunctionCall bool
 
 	activeTools := make(map[int]*responsesToolCall)
@@ -548,26 +557,59 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 	currentReasoningIdx := -1
 
 	for {
-		line, ok := scanner.NextLine()
-		if !ok {
-			break
-		}
-
-		if strings.HasPrefix(line, "event: ") {
-			eventType = strings.TrimPrefix(line, "event: ")
-			continue
-		}
-
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-		data := strings.TrimPrefix(line, "data: ")
-
-		if data == "[DONE]" {
-			if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, Usage: usage}) {
+		var read responsesReadResult
+		select {
+		case <-ctx.Done():
+			trySendResponsesError(ctx, out, ctx.Err())
+			return
+		case <-idleTimer.c:
+			if err := ctx.Err(); err != nil {
+				trySendResponsesError(ctx, out, err)
 				return
 			}
+			err := &StreamIdleTimeoutError{
+				Provider: responsesStreamProvider,
+				API:      responsesStreamAPI,
+				Idle:     config.idleTimeout,
+			}
+			trySendResponsesError(ctx, out, err)
 			return
+		case read = <-reader.results:
+		}
+
+		if err := ctx.Err(); err != nil {
+			trySendResponsesError(ctx, out, err)
+			return
+		}
+		if read.err != nil {
+			trySendResponsesError(ctx, out, newStreamProtocolError("", "stream read failed", read.err))
+			return
+		}
+		if read.eof {
+			trySendResponsesError(ctx, out, newStreamProtocolError("", "stream ended before a terminal event", nil))
+			return
+		}
+
+		eventType := read.event.Type
+		data := string(read.event.Data)
+		terminalEvent := isResponsesTerminalEvent(eventType)
+
+		if data == "[DONE]" {
+			if config.allowDone {
+				provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkFinish, Usage: usage})
+				return
+			}
+			trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "stream ended with [DONE] before a terminal event", nil))
+			return
+		}
+		if !json.Valid(read.event.Data) {
+			err := newStreamProtocolError(eventType, "event data is not valid JSON", nil)
+			if terminalEvent {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			idleTimer.reset(config.idleTimeout)
+			continue
 		}
 
 		switch eventType {
@@ -793,15 +835,16 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 
 		case "response.completed", "response.incomplete":
 			var ev struct {
-				Response struct {
+				Type     string `json:"type"`
+				Response *struct {
 					ID                string `json:"id"`
 					Model             string `json:"model"`
 					IncompleteDetails *struct {
 						Reason string `json:"reason"`
 					} `json:"incomplete_details"`
-					Usage struct {
-						InputTokens         int `json:"input_tokens"`
-						OutputTokens        int `json:"output_tokens"`
+					Usage *struct {
+						InputTokens         *int `json:"input_tokens"`
+						OutputTokens        *int `json:"output_tokens"`
 						OutputTokensDetails *struct {
 							ReasoningTokens int `json:"reasoning_tokens"`
 						} `json:"output_tokens_details"`
@@ -811,15 +854,31 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 					} `json:"usage"`
 				} `json:"response"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil {
-				usage.InputTokens = ev.Response.Usage.InputTokens
-				usage.OutputTokens = ev.Response.Usage.OutputTokens
-				usage.TotalTokens = ev.Response.Usage.InputTokens + ev.Response.Usage.OutputTokens
-				if ev.Response.Usage.OutputTokensDetails != nil {
-					usage.ReasoningTokens = ev.Response.Usage.OutputTokensDetails.ReasoningTokens
+			if err := json.Unmarshal(read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "malformed terminal event", err))
+				return
+			}
+			if err := validateResponsesPayloadType(eventType, ev.Type); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.Response == nil {
+				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "terminal event is missing response", nil))
+				return
+			}
+			if responseUsage := ev.Response.Usage; responseUsage != nil {
+				if responseUsage.InputTokens == nil || responseUsage.OutputTokens == nil {
+					trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "terminal event has incomplete response usage", nil))
+					return
 				}
-				if ev.Response.Usage.InputTokensDetails != nil {
-					usage.CacheReadTokens = ev.Response.Usage.InputTokensDetails.CachedTokens
+				usage.InputTokens = *responseUsage.InputTokens
+				usage.OutputTokens = *responseUsage.OutputTokens
+				usage.TotalTokens = *responseUsage.InputTokens + *responseUsage.OutputTokens
+				if responseUsage.OutputTokensDetails != nil {
+					usage.ReasoningTokens = responseUsage.OutputTokensDetails.ReasoningTokens
+				}
+				if responseUsage.InputTokensDetails != nil {
+					usage.CacheReadTokens = responseUsage.InputTokensDetails.CachedTokens
 				}
 				usage.InputTokens -= usage.CacheReadTokens
 			}
@@ -860,23 +919,35 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 
 		case "response.failed":
 			var ev struct {
-				Response struct {
+				Type     string `json:"type"`
+				Response *struct {
 					Error struct {
 						Message string `json:"message"`
 						Code    string `json:"code"`
 					} `json:"error"`
 				} `json:"response"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil {
-				if !provider.TrySend(ctx, out, responsesStreamError(data, ev.Response.Error.Message, ev.Response.Error.Code, "response failed")) {
-					return
-				}
+			if err := json.Unmarshal(read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "malformed terminal event", err))
+				return
+			}
+			if err := validateResponsesPayloadType(eventType, ev.Type); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			if ev.Response == nil {
+				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "terminal event is missing response", nil))
+				return
+			}
+			if !provider.TrySend(ctx, out, responsesStreamError(data, ev.Response.Error.Message, ev.Response.Error.Code, "response failed")) {
+				return
 			}
 			return
 
 		case "error":
 			// OpenAI documents flat message/code fields, but production often nests them under error.
 			var ev struct {
+				Type    string `json:"type"`
 				Message string `json:"message"`
 				Code    string `json:"code"`
 				Error   *struct {
@@ -884,30 +955,37 @@ func streamResponses(ctx context.Context, body io.ReadCloser, out chan<- provide
 					Code    string `json:"code"`
 				} `json:"error"`
 			}
-			if json.Unmarshal([]byte(data), &ev) == nil {
-				// Prefer the nested error fields when present, but fall back to
-				// the flat fields per-field so a partial nested object (e.g. a
-				// nested code with no nested message) does not clobber a flat
-				// message/code with an empty string.
-				msg, code := ev.Message, ev.Code
-				if ev.Error != nil {
-					msg = cmp.Or(ev.Error.Message, msg)
-					code = cmp.Or(ev.Error.Code, code)
-				}
-				if !provider.TrySend(ctx, out, responsesStreamError(data, msg, code, "stream error")) {
-					return
-				}
+			if err := json.Unmarshal(read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "malformed terminal event", err))
+				return
+			}
+			if err := validateResponsesPayloadType(eventType, ev.Type); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			// Prefer the nested error fields when present, but fall back to
+			// the flat fields per-field so a partial nested object (e.g. a
+			// nested code with no nested message) does not clobber a flat
+			// message/code with an empty string.
+			msg, code := ev.Message, ev.Code
+			if ev.Error != nil {
+				msg = cmp.Or(ev.Error.Message, msg)
+				code = cmp.Or(ev.Error.Code, code)
+			}
+			if msg == "" && code == "" {
+				trySendResponsesError(ctx, out, newStreamProtocolError(eventType, "terminal error event is missing error details", nil))
+				return
+			}
+			if !provider.TrySend(ctx, out, responsesStreamError(data, msg, code, "stream error")) {
+				return
 			}
 			return
 		}
 
-		eventType = ""
-	}
-
-	if err := scanner.Err(); err != nil {
-		if !provider.TrySend(ctx, out, provider.StreamChunk{Type: provider.ChunkError, Error: fmt.Errorf("reading stream: %w", err)}) {
-			return
-		}
+		// Projection may block on downstream backpressure. Restart the provider
+		// idle window only after projection completes so consumer latency cannot
+		// be misreported as provider inactivity.
+		idleTimer.reset(config.idleTimeout)
 	}
 }
 

--- a/provider/openai/responses.go
+++ b/provider/openai/responses.go
@@ -693,8 +693,22 @@ func streamResponsesWithConfig(
 			}
 
 		case "response.reasoning_summary_part.added":
-			// New summary segment within same reasoning item -- no-op for chunk emission
-			// but tracked for canonical ID resolution.
+			var ev struct {
+				ItemID         string `json:"item_id"`
+				OutputIndex    int    `json:"output_index"`
+				SummaryIndex   int    `json:"summary_index"`
+				SequenceNumber int    `json:"sequence_number"`
+				Part           *struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"part"`
+			}
+			if err := decodeResponsesEvent(eventType, read.event.Data, &ev); err != nil {
+				trySendResponsesError(ctx, out, err)
+				return
+			}
+			// New summary segments do not emit chunks, but decoding validates the
+			// recognized event before it counts as stream activity.
 
 		case "response.output_item.added":
 			var ev struct {
@@ -888,13 +902,21 @@ func streamResponsesWithConfig(
 					// Capture the full server-executed item payload and
 					// emit a ChunkToolCall so it round-trips into the
 					// assistant turn via ToolCall.Metadata.
+					var itemIdentity struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					}
+					if err := decodeResponsesEvent(eventType, ev.Item, &itemIdentity); err != nil {
+						trySendResponsesError(ctx, out, err)
+						return
+					}
 					var rawItem map[string]any
 					if err := decodeResponsesEvent(eventType, ev.Item, &rawItem); err != nil {
 						trySendResponsesError(ctx, out, err)
 						return
 					}
-					id, _ := rawItem["id"].(string)
-					name, _ := rawItem["name"].(string)
+					id := itemIdentity.ID
+					name := itemIdentity.Name
 					if name == "" {
 						name = itemType
 					}

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -222,7 +222,25 @@ func responsesEventType(event sse.Event) (string, error) {
 	if event.Type != "" {
 		return event.Type, nil
 	}
+	if envelope.Type == "" {
+		return "", newStreamProtocolError("", "event is missing type", nil)
+	}
 	return envelope.Type, nil
+}
+
+func decodeResponsesEvent(eventType string, data []byte, target any) error {
+	if err := json.Unmarshal(data, target); err != nil {
+		return newStreamProtocolError(eventType, "event payload does not match event schema", err)
+	}
+	return nil
+}
+
+func missingResponsesEventField(eventType, field string) error {
+	return newStreamProtocolError(eventType, fmt.Sprintf("event payload is missing required %s", field), nil)
+}
+
+func nullResponsesEventField(eventType, field string) error {
+	return newStreamProtocolError(eventType, fmt.Sprintf("event payload has null %s", field), nil)
 }
 
 func trySendResponsesError(ctx context.Context, out chan<- provider.StreamChunk, err error) bool {

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
@@ -208,20 +209,20 @@ func (t *responsesIdleTimer) stop() {
 	}
 }
 
-func isResponsesTerminalEvent(eventType string) bool {
-	switch eventType {
-	case "response.completed", "response.incomplete", "response.failed", "error":
-		return true
-	default:
-		return false
+func responsesEventType(event sse.Event) (string, error) {
+	var envelope struct {
+		Type string `json:"type"`
 	}
-}
-
-func validateResponsesPayloadType(eventType, payloadType string) error {
-	if payloadType != "" && payloadType != eventType {
-		return newStreamProtocolError(eventType, "event type does not match payload type", nil)
+	if err := json.Unmarshal(event.Data, &envelope); err != nil {
+		return "", newStreamProtocolError(event.Type, "event data is not valid JSON", err)
 	}
-	return nil
+	if event.Type != "" && envelope.Type != "" && event.Type != envelope.Type {
+		return "", newStreamProtocolError(event.Type, "event type does not match payload type", nil)
+	}
+	if event.Type != "" {
+		return event.Type, nil
+	}
+	return envelope.Type, nil
 }
 
 func trySendResponsesError(ctx context.Context, out chan<- provider.StreamChunk, err error) bool {

--- a/provider/openai/responses_stream.go
+++ b/provider/openai/responses_stream.go
@@ -1,0 +1,238 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/zendev-sh/goai/internal/sse"
+	"github.com/zendev-sh/goai/provider"
+)
+
+const (
+	// DefaultResponsesStreamIdleTimeout is the maximum time a Responses API
+	// stream waits for a complete provider event by default.
+	DefaultResponsesStreamIdleTimeout = 5 * time.Minute
+
+	responsesStreamProvider = "openai"
+	responsesStreamAPI      = "responses"
+	responsesReaderWait     = 250 * time.Millisecond
+)
+
+// WithResponsesStreamIdleTimeout configures the event-level idle timeout for
+// OpenAI Responses streams. A positive duration enables the watchdog, zero
+// disables it, and a negative duration makes Responses streaming fail during
+// request setup. The default is [DefaultResponsesStreamIdleTimeout].
+func WithResponsesStreamIdleTimeout(timeout time.Duration) Option {
+	return func(o *options) {
+		o.responsesStreamIdleTimeout = timeout
+	}
+}
+
+// WithResponsesStreamDoneCompatibility allows a non-standard Responses
+// endpoint to terminate a stream with a bare [DONE] sentinel. It is disabled by
+// default because the Responses API uses typed terminal events and accepting a
+// bare sentinel can hide a truncated response.
+func WithResponsesStreamDoneCompatibility(enabled bool) Option {
+	return func(o *options) {
+		o.responsesStreamAllowDone = enabled
+	}
+}
+
+// StreamIdleTimeoutError reports that an OpenAI Responses stream received no
+// complete provider event within its configured idle window.
+type StreamIdleTimeoutError struct {
+	Provider string
+	API      string
+	Idle     time.Duration
+}
+
+func (e *StreamIdleTimeoutError) Error() string {
+	return fmt.Sprintf("%s %s stream idle for %s", e.Provider, e.API, e.Idle)
+}
+
+// Timeout reports that this error is a timeout, satisfying net.Error.
+func (e *StreamIdleTimeoutError) Timeout() bool { return true }
+
+// Temporary reports that an idle stream interruption may be retried.
+func (e *StreamIdleTimeoutError) Temporary() bool { return true }
+
+// StreamProtocolError reports an invalid or interrupted OpenAI Responses
+// stream. Event payloads are intentionally excluded from this type.
+type StreamProtocolError struct {
+	Provider  string
+	API       string
+	EventType string
+	Reason    string
+	cause     error
+}
+
+func (e *StreamProtocolError) Error() string {
+	if e.EventType != "" {
+		return fmt.Sprintf("%s %s stream protocol error for %s: %s", e.Provider, e.API, e.EventType, e.Reason)
+	}
+	return fmt.Sprintf("%s %s stream protocol error: %s", e.Provider, e.API, e.Reason)
+}
+
+// Unwrap returns the underlying body-read or decode error, when present.
+func (e *StreamProtocolError) Unwrap() error { return e.cause }
+
+type responsesStreamConfig struct {
+	idleTimeout time.Duration
+	allowDone   bool
+}
+
+func defaultResponsesStreamConfig() responsesStreamConfig {
+	return responsesStreamConfig{idleTimeout: DefaultResponsesStreamIdleTimeout}
+}
+
+func newStreamProtocolError(eventType, reason string, cause error) *StreamProtocolError {
+	return &StreamProtocolError{
+		Provider:  responsesStreamProvider,
+		API:       responsesStreamAPI,
+		EventType: eventType,
+		Reason:    reason,
+		cause:     cause,
+	}
+}
+
+type responsesReadResult struct {
+	event sse.Event
+	err   error
+	eof   bool
+}
+
+type responsesEventReader struct {
+	results   <-chan responsesReadResult
+	cancel    context.CancelFunc
+	closeBody func()
+	closeDone <-chan struct{}
+	done      <-chan struct{}
+}
+
+func newResponsesEventReader(ctx context.Context, body io.ReadCloser) *responsesEventReader {
+	readerCtx, cancel := context.WithCancel(ctx)
+	closeDone := make(chan struct{})
+	closeBody := sync.OnceFunc(func() {
+		// A custom RoundTripper may return a body whose Close blocks. Keep that
+		// implementation bug from preventing the coordinator and output channel
+		// from reaching their bounded terminal state.
+		go func() {
+			defer close(closeDone)
+			_ = body.Close()
+		}()
+	})
+	results := make(chan responsesReadResult, 1)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		scanner := sse.NewScanner(body)
+		for {
+			event, ok := scanner.NextEvent()
+			if !ok {
+				result := responsesReadResult{err: scanner.Err(), eof: scanner.Err() == nil}
+				select {
+				case results <- result:
+				case <-readerCtx.Done():
+				}
+				return
+			}
+			select {
+			case results <- responsesReadResult{event: event}:
+			case <-readerCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return &responsesEventReader{
+		results:   results,
+		cancel:    cancel,
+		closeBody: closeBody,
+		closeDone: closeDone,
+		done:      done,
+	}
+}
+
+func (r *responsesEventReader) close() {
+	r.cancel()
+	r.closeBody()
+	timer := time.NewTimer(responsesReaderWait)
+	defer timer.Stop()
+	readerDone := r.done
+	bodyCloseDone := r.closeDone
+	for readerDone != nil || bodyCloseDone != nil {
+		select {
+		case <-readerDone:
+			readerDone = nil
+		case <-bodyCloseDone:
+			bodyCloseDone = nil
+		case <-timer.C:
+			return
+		}
+	}
+}
+
+type responsesIdleTimer struct {
+	timer *time.Timer
+	c     <-chan time.Time
+}
+
+func newResponsesIdleTimer(timeout time.Duration) *responsesIdleTimer {
+	if timeout == 0 {
+		return &responsesIdleTimer{}
+	}
+	timer := time.NewTimer(timeout)
+	return &responsesIdleTimer{timer: timer, c: timer.C}
+}
+
+func (t *responsesIdleTimer) reset(timeout time.Duration) {
+	if t.timer == nil {
+		return
+	}
+	if !t.timer.Stop() {
+		select {
+		case <-t.timer.C:
+		default:
+		}
+	}
+	t.timer.Reset(timeout)
+}
+
+func (t *responsesIdleTimer) stop() {
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+}
+
+func isResponsesTerminalEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.incomplete", "response.failed", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateResponsesPayloadType(eventType, payloadType string) error {
+	if payloadType != "" && payloadType != eventType {
+		return newStreamProtocolError(eventType, "event type does not match payload type", nil)
+	}
+	return nil
+}
+
+func trySendResponsesError(ctx context.Context, out chan<- provider.StreamChunk, err error) bool {
+	chunk := provider.StreamChunk{Type: provider.ChunkError, Error: err}
+	if ctx.Err() == nil {
+		return provider.TrySend(ctx, out, chunk)
+	}
+	select {
+	case out <- chunk:
+		return true
+	default:
+		return false
+	}
+}

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -113,6 +113,9 @@ func TestResponsesStreamIdleTimeoutErrorContract(t *testing.T) {
 	if idleErr.Idle != idle || !isResponsesIdleTimeout(chunk.Error) {
 		t.Fatalf("idle error = %#v", idleErr)
 	}
+	if idleErr.Error() != "openai responses stream idle for 25ms" || !idleErr.Temporary() {
+		t.Fatalf("idle error contract = %q, temporary = %v", idleErr.Error(), idleErr.Temporary())
+	}
 	var netErr net.Error
 	if !errors.As(chunk.Error, &netErr) || !netErr.Timeout() {
 		t.Fatalf("error does not satisfy transient net.Error timeout contract: %v", chunk.Error)
@@ -132,7 +135,6 @@ func TestResponsesStreamEventActivityResetsIdleTimeout(t *testing.T) {
 	}{
 		{name: "in progress", eventType: "response.in_progress", data: `{"response":{"id":"resp_1"}}`},
 		{name: "unknown valid event", eventType: "response.rate_limits.updated", data: `{"remaining":10}`},
-		{name: "malformed nonterminal event", eventType: "response.metadata", data: `{not-json}`},
 	}
 
 	for _, tt := range tests {
@@ -395,18 +397,109 @@ func TestResponsesStreamProtocolErrorContract(t *testing.T) {
 	drainChunks(t, out)
 }
 
-func TestResponsesStreamRejectsMismatchedTerminalPayloadType(t *testing.T) {
-	input := sseLine(
-		"response.completed",
-		`{"type":"response.failed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`,
-	)
+func TestResponsesStreamAcceptsDataOnlyEvents(t *testing.T) {
+	input := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-5\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+	out := make(chan provider.StreamChunk, 4)
+	streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
+
+	var text string
+	var gotFinish bool
+	for chunk := range out {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		if chunk.Type == provider.ChunkText {
+			text += chunk.Text
+		}
+		gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+	}
+	if text != "hello" || !gotFinish {
+		t.Fatalf("text = %q, finish = %v; want hello and finish", text, gotFinish)
+	}
+}
+
+func TestResponsesStreamRejectsMismatchedPayloadType(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		data      string
+	}{
+		{
+			name:      "nonterminal",
+			eventType: "response.output_text.delta",
+			data:      `{"type":"response.refusal.delta","delta":"no"}`,
+		},
+		{
+			name:      "terminal",
+			eventType: "response.completed",
+			data:      `{"type":"response.failed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := make(chan provider.StreamChunk, 4)
+			streamResponses(t.Context(), io.NopCloser(strings.NewReader(sseLine(tt.eventType, tt.data))), out)
+
+			chunk := receiveChunk(t, out)
+			var protocolErr *StreamProtocolError
+			if !errors.As(chunk.Error, &protocolErr) || protocolErr.EventType != tt.eventType {
+				t.Fatalf("error = %T %v, want payload mismatch for %q", chunk.Error, chunk.Error, tt.eventType)
+			}
+			if protocolErr.Reason != "event type does not match payload type" {
+				t.Fatalf("reason = %q", protocolErr.Reason)
+			}
+			if !strings.Contains(protocolErr.Error(), tt.eventType) {
+				t.Fatalf("error %q does not identify event type %q", protocolErr.Error(), tt.eventType)
+			}
+			drainChunks(t, out)
+		})
+	}
+}
+
+func TestResponsesIdleTimerReset(t *testing.T) {
+	disabled := newResponsesIdleTimer(0)
+	disabled.reset(time.Second)
+	disabled.stop()
+
+	timer := newResponsesIdleTimer(time.Hour)
+	t.Cleanup(timer.stop)
+	timer.reset(20 * time.Millisecond)
+	select {
+	case <-timer.c:
+	case <-time.After(time.Second):
+		t.Fatal("reset timer did not fire")
+	}
+}
+
+func TestResponsesStreamRejectsMalformedNonterminalEvent(t *testing.T) {
+	out := make(chan provider.StreamChunk, 4)
+	streamResponses(t.Context(), io.NopCloser(strings.NewReader(sseLine("response.output_text.delta", `{not-json}`))), out)
+
+	chunk := receiveChunk(t, out)
+	var protocolErr *StreamProtocolError
+	if chunk.Type != provider.ChunkError || !errors.As(chunk.Error, &protocolErr) {
+		t.Fatalf("chunk = %#v, want protocol error", chunk)
+	}
+	if protocolErr.EventType != "response.output_text.delta" || protocolErr.Reason != "event data is not valid JSON" {
+		t.Fatalf("protocol error = %#v", protocolErr)
+	}
+	drainChunks(t, out)
+}
+
+func TestResponsesStreamRejectsUnterminatedTerminalEvent(t *testing.T) {
+	input := "event: response.completed\ndata: {\"response\":{\"id\":\"resp_1\"}}"
 	out := make(chan provider.StreamChunk, 4)
 	streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
 
 	chunk := receiveChunk(t, out)
 	var protocolErr *StreamProtocolError
-	if !errors.As(chunk.Error, &protocolErr) || protocolErr.EventType != "response.completed" {
-		t.Fatalf("error = %T %v, want terminal payload mismatch", chunk.Error, chunk.Error)
+	if chunk.Type != provider.ChunkError || !errors.As(chunk.Error, &protocolErr) {
+		t.Fatalf("chunk = %#v, want protocol error", chunk)
+	}
+	if protocolErr.Reason != "stream ended before a terminal event" {
+		t.Fatalf("reason = %q", protocolErr.Reason)
 	}
 	drainChunks(t, out)
 }

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -488,6 +488,270 @@ func TestResponsesStreamRejectsMalformedNonterminalEvent(t *testing.T) {
 	drainChunks(t, out)
 }
 
+func TestResponsesStreamRejectsUntypedDataOnlyEvent(t *testing.T) {
+	for _, data := range []string{`{}`, `null`} {
+		t.Run(data, func(t *testing.T) {
+			reader, writer := io.Pipe()
+			t.Cleanup(func() {
+				_ = reader.Close()
+				_ = writer.Close()
+			})
+
+			out := make(chan provider.StreamChunk, 4)
+			go streamResponsesWithConfig(t.Context(), reader, out, responsesStreamConfig{
+				idleTimeout: 100 * time.Millisecond,
+			})
+			if _, err := io.WriteString(writer, "data: "+data+"\n\n"); err != nil {
+				t.Fatalf("write event: %v", err)
+			}
+
+			chunk := receiveChunk(t, out)
+			var protocolErr *StreamProtocolError
+			if chunk.Type != provider.ChunkError || !errors.As(chunk.Error, &protocolErr) {
+				t.Fatalf("chunk = %#v, want protocol error", chunk)
+			}
+			if protocolErr.EventType != "" || protocolErr.Reason != "event is missing type" {
+				t.Fatalf("protocol error = %#v", protocolErr)
+			}
+			if isResponsesIdleTimeout(chunk.Error) {
+				t.Fatalf("untyped event incorrectly counted as stream activity: %v", chunk.Error)
+			}
+			drainChunks(t, out)
+		})
+	}
+}
+
+func TestResponsesStreamRejectsInvalidRecognizedEventSchema(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventType  string
+		data       string
+		dataOnly   bool
+		wantReason string
+	}{
+		{
+			name:      "text delta",
+			eventType: "response.output_text.delta",
+			data:      `{"type":"response.output_text.delta","delta":123}`,
+			dataOnly:  true,
+		},
+		{
+			name:      "refusal delta",
+			eventType: "response.refusal.delta",
+			data:      `{"delta":123}`,
+		},
+		{
+			name:      "reasoning summary delta",
+			eventType: "response.reasoning_summary_text.delta",
+			data:      `{"summary_index":"first"}`,
+		},
+		{
+			name:      "output item added",
+			eventType: "response.output_item.added",
+			data:      `{"output_index":"first","item":{"type":"function_call"}}`,
+		},
+		{
+			name:      "tool call delta",
+			eventType: "response.function_call_arguments.delta",
+			data:      `{"type":"response.function_call_arguments.delta","output_index":0,"delta":123}`,
+		},
+		{
+			name:      "tool call done",
+			eventType: "response.function_call_arguments.done",
+			data:      `{"output_index":"first"}`,
+		},
+		{
+			name:      "output item done envelope",
+			eventType: "response.output_item.done",
+			data:      `{"output_index":"first","item":{"type":"message"}}`,
+		},
+		{
+			name:      "output item done item",
+			eventType: "response.output_item.done",
+			data:      `{"output_index":0,"item":123}`,
+		},
+		{
+			name:      "output item done item type",
+			eventType: "response.output_item.done",
+			data:      `{"output_index":0,"item":{"type":123}}`,
+		},
+		{
+			name:      "reasoning item",
+			eventType: "response.output_item.done",
+			data:      `{"output_index":0,"item":{"type":"reasoning","encrypted_content":123}}`,
+		},
+		{
+			name:       "text delta missing",
+			eventType:  "response.output_text.delta",
+			data:       `{}`,
+			wantReason: "event payload is missing required delta",
+		},
+		{
+			name:       "text event null payload",
+			eventType:  "response.output_text.delta",
+			data:       `null`,
+			wantReason: "event payload is missing required delta",
+		},
+		{
+			name:       "refusal delta null",
+			eventType:  "response.refusal.delta",
+			data:       `{"delta":null}`,
+			wantReason: "event payload is missing required delta",
+		},
+		{
+			name:       "reasoning item id null",
+			eventType:  "response.reasoning_summary_text.delta",
+			data:       `{"item_id":null,"summary_index":0,"delta":"thinking"}`,
+			wantReason: "event payload has null item_id",
+		},
+		{
+			name:       "reasoning summary index null",
+			eventType:  "response.reasoning_summary_text.delta",
+			data:       `{"item_id":"rs_1","summary_index":null,"delta":"thinking"}`,
+			wantReason: "event payload has null summary_index",
+		},
+		{
+			name:       "reasoning delta null",
+			eventType:  "response.reasoning_summary_text.delta",
+			data:       `{"item_id":"rs_1","summary_index":0,"delta":null}`,
+			wantReason: "event payload is missing required delta",
+		},
+		{
+			name:       "output item added index null",
+			eventType:  "response.output_item.added",
+			data:       `{"output_index":null,"item":{"type":"function_call"}}`,
+			wantReason: "event payload has null output_index",
+		},
+		{
+			name:       "output item added item null",
+			eventType:  "response.output_item.added",
+			data:       `{"output_index":0,"item":null}`,
+			wantReason: "event payload is missing required item",
+		},
+		{
+			name:       "output item added type null",
+			eventType:  "response.output_item.added",
+			data:       `{"output_index":0,"item":{"type":null}}`,
+			wantReason: "event payload is missing required item.type",
+		},
+		{
+			name:       "tool call delta index null",
+			eventType:  "response.function_call_arguments.delta",
+			data:       `{"output_index":null,"delta":"{"}`,
+			wantReason: "event payload has null output_index",
+		},
+		{
+			name:       "tool call delta null",
+			eventType:  "response.function_call_arguments.delta",
+			data:       `{"output_index":0,"delta":null}`,
+			wantReason: "event payload is missing required delta",
+		},
+		{
+			name:       "tool call done index null",
+			eventType:  "response.function_call_arguments.done",
+			data:       `{"output_index":null}`,
+			wantReason: "event payload has null output_index",
+		},
+		{
+			name:       "output item done index null",
+			eventType:  "response.output_item.done",
+			data:       `{"output_index":null}`,
+			wantReason: "event payload has null output_index",
+		},
+		{
+			name:       "output item done item null",
+			eventType:  "response.output_item.done",
+			data:       `{"output_index":0,"item":null}`,
+			wantReason: "event payload has null item",
+		},
+		{
+			name:       "output item done type null",
+			eventType:  "response.output_item.done",
+			data:       `{"output_index":0,"item":{"type":null}}`,
+			wantReason: "event payload is missing required item.type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := sseLine(tt.eventType, tt.data)
+			if tt.dataOnly {
+				input = "data: " + tt.data + "\n\n"
+			}
+			input += completedResponsesEvent
+
+			out := make(chan provider.StreamChunk, 4)
+			streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
+
+			chunk := receiveChunk(t, out)
+			var protocolErr *StreamProtocolError
+			if chunk.Type != provider.ChunkError || !errors.As(chunk.Error, &protocolErr) {
+				t.Fatalf("chunk = %#v, want protocol error", chunk)
+			}
+			wantReason := tt.wantReason
+			if wantReason == "" {
+				wantReason = "event payload does not match event schema"
+			}
+			if protocolErr.EventType != tt.eventType || protocolErr.Reason != wantReason {
+				t.Fatalf("protocol error = %#v", protocolErr)
+			}
+			if tt.wantReason == "" && errors.Unwrap(protocolErr) == nil {
+				t.Fatalf("protocol error does not preserve decoding cause: %#v", protocolErr)
+			}
+			drainChunks(t, out)
+		})
+	}
+}
+
+func TestResponsesStreamPreservesOptionalFieldCompatibility(t *testing.T) {
+	input := sseLine("response.output_text.delta", `{"delta":""}`) +
+		sseLine("response.reasoning_summary_text.delta", `{"delta":""}`) +
+		sseLine("response.function_call_arguments.delta", `{"delta":""}`) +
+		completedResponsesEvent
+	out := make(chan provider.StreamChunk, 8)
+	streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
+
+	var gotFinish bool
+	for chunk := range out {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+	}
+	if !gotFinish {
+		t.Fatal("stream did not finish after present empty delta fields")
+	}
+}
+
+func TestResponsesStreamPreservesReasoningItemFallbacks(t *testing.T) {
+	input := sseLine("response.output_item.added", `{"output_index":0,"item":{"type":"reasoning"}}`) +
+		sseLine("response.output_item.done", `{"output_index":0,"item":{"type":"reasoning","id":"rs_1","encrypted_content":"encrypted"}}`) +
+		completedResponsesEvent
+	out := make(chan provider.StreamChunk, 8)
+	streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
+
+	var reasoning *provider.StreamChunk
+	for chunk := range out {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		if chunk.Type == provider.ChunkReasoning {
+			copy := chunk
+			reasoning = &copy
+		}
+	}
+	if reasoning == nil {
+		t.Fatal("missing encrypted reasoning chunk")
+	}
+	if got := reasoning.Metadata["reasoningId"]; got != "rs_1:0" {
+		t.Fatalf("reasoningId = %#v, want rs_1:0", got)
+	}
+	openai, ok := reasoning.Metadata["openai"].(map[string]any)
+	if !ok || openai["itemId"] != "rs_1" || openai["encryptedContent"] != "encrypted" {
+		t.Fatalf("openai reasoning metadata = %#v", reasoning.Metadata["openai"])
+	}
+}
+
 func TestResponsesStreamRejectsUnterminatedTerminalEvent(t *testing.T) {
 	input := "event: response.completed\ndata: {\"response\":{\"id\":\"resp_1\"}}"
 	out := make(chan provider.StreamChunk, 4)

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -546,6 +546,11 @@ func TestResponsesStreamRejectsInvalidRecognizedEventSchema(t *testing.T) {
 			data:      `{"summary_index":"first"}`,
 		},
 		{
+			name:      "reasoning summary part added",
+			eventType: "response.reasoning_summary_part.added",
+			data:      `{"item_id":123,"output_index":0,"summary_index":0}`,
+		},
+		{
 			name:      "output item added",
 			eventType: "response.output_item.added",
 			data:      `{"output_index":"first","item":{"type":"function_call"}}`,
@@ -584,6 +589,16 @@ func TestResponsesStreamRejectsInvalidRecognizedEventSchema(t *testing.T) {
 			name:      "server-executed item",
 			eventType: "response.output_item.done",
 			data:      `{"output_index":0,"item":{"type":"web_search_call","score":1e1000}}`,
+		},
+		{
+			name:      "server-executed item id",
+			eventType: "response.output_item.done",
+			data:      `{"output_index":0,"item":{"type":"web_search_call","id":123}}`,
+		},
+		{
+			name:      "server-executed item name",
+			eventType: "response.output_item.done",
+			data:      `{"output_index":0,"item":{"type":"web_search_call","name":true}}`,
 		},
 		{
 			name:       "text delta missing",

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -601,6 +601,48 @@ func TestResponsesStreamRejectsInvalidRecognizedEventSchema(t *testing.T) {
 			data:      `{"output_index":0,"item":{"type":"web_search_call","name":true}}`,
 		},
 		{
+			name:       "reasoning part item id null",
+			eventType:  "response.reasoning_summary_part.added",
+			data:       `{"item_id":null,"output_index":0,"summary_index":0,"sequence_number":0,"part":{}}`,
+			wantReason: "event payload has null item_id",
+		},
+		{
+			name:       "reasoning part output index null",
+			eventType:  "response.reasoning_summary_part.added",
+			data:       `{"item_id":"rs_1","output_index":null,"summary_index":0,"sequence_number":0,"part":{}}`,
+			wantReason: "event payload has null output_index",
+		},
+		{
+			name:       "reasoning part summary index null",
+			eventType:  "response.reasoning_summary_part.added",
+			data:       `{"item_id":"rs_1","output_index":0,"summary_index":null,"sequence_number":0,"part":{}}`,
+			wantReason: "event payload has null summary_index",
+		},
+		{
+			name:       "reasoning part sequence number null",
+			eventType:  "response.reasoning_summary_part.added",
+			data:       `{"item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":null,"part":{}}`,
+			wantReason: "event payload has null sequence_number",
+		},
+		{
+			name:       "reasoning part null",
+			eventType:  "response.reasoning_summary_part.added",
+			data:       `{"item_id":"rs_1","output_index":0,"summary_index":0,"sequence_number":0,"part":null}`,
+			wantReason: "event payload has null part",
+		},
+		{
+			name:       "server-executed item id null",
+			eventType:  "response.output_item.done",
+			data:       `{"output_index":0,"item":{"type":"web_search_call","id":null}}`,
+			wantReason: "event payload has null item.id",
+		},
+		{
+			name:       "server-executed item name null",
+			eventType:  "response.output_item.done",
+			data:       `{"output_index":0,"item":{"type":"web_search_call","name":null}}`,
+			wantReason: "event payload has null item.name",
+		},
+		{
 			name:       "text delta missing",
 			eventType:  "response.output_text.delta",
 			data:       `{}`,
@@ -726,7 +768,9 @@ func TestResponsesStreamRejectsInvalidRecognizedEventSchema(t *testing.T) {
 func TestResponsesStreamPreservesOptionalFieldCompatibility(t *testing.T) {
 	input := sseLine("response.output_text.delta", `{"delta":""}`) +
 		sseLine("response.reasoning_summary_text.delta", `{"delta":""}`) +
+		sseLine("response.reasoning_summary_part.added", `{}`) +
 		sseLine("response.function_call_arguments.delta", `{"delta":""}`) +
+		sseLine("response.output_item.done", `{"item":{"type":"web_search_call"}}`) +
 		completedResponsesEvent
 	out := make(chan provider.StreamChunk, 8)
 	streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -581,6 +581,11 @@ func TestResponsesStreamRejectsInvalidRecognizedEventSchema(t *testing.T) {
 			data:      `{"output_index":0,"item":{"type":"reasoning","encrypted_content":123}}`,
 		},
 		{
+			name:      "server-executed item",
+			eventType: "response.output_item.done",
+			data:      `{"output_index":0,"item":{"type":"web_search_call","score":1e1000}}`,
+		},
+		{
 			name:       "text delta missing",
 			eventType:  "response.output_text.delta",
 			data:       `{}`,

--- a/provider/openai/responses_stream_test.go
+++ b/provider/openai/responses_stream_test.go
@@ -1,0 +1,652 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zendev-sh/goai"
+	"github.com/zendev-sh/goai/provider"
+)
+
+const completedResponsesEvent = "event: response.completed\ndata: {\"response\":{\"id\":\"resp_1\",\"model\":\"o3\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+
+func isResponsesIdleTimeout(err error) bool {
+	var target *StreamIdleTimeoutError
+	return errors.As(err, &target)
+}
+
+func isResponsesProtocolError(err error) bool {
+	var target *StreamProtocolError
+	return errors.As(err, &target)
+}
+
+type blockingReadCloser struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	readOnce    sync.Once
+	closeOnce   sync.Once
+	closeCount  atomic.Int32
+}
+
+type blockingCloseReadCloser struct {
+	readStarted  chan struct{}
+	closeStarted chan struct{}
+	releaseClose chan struct{}
+	releaseRead  chan struct{}
+	readDone     chan struct{}
+	readOnce     sync.Once
+	closeOnce    sync.Once
+}
+
+func newBlockingCloseReadCloser() *blockingCloseReadCloser {
+	return &blockingCloseReadCloser{
+		readStarted:  make(chan struct{}),
+		closeStarted: make(chan struct{}),
+		releaseClose: make(chan struct{}),
+		releaseRead:  make(chan struct{}),
+		readDone:     make(chan struct{}),
+	}
+}
+
+func (r *blockingCloseReadCloser) Read(_ []byte) (int, error) {
+	r.readOnce.Do(func() { close(r.readStarted) })
+	<-r.releaseRead
+	close(r.readDone)
+	return 0, io.ErrClosedPipe
+}
+
+func (r *blockingCloseReadCloser) Close() error {
+	r.closeOnce.Do(func() { close(r.closeStarted) })
+	<-r.releaseClose
+	close(r.releaseRead)
+	return nil
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (r *blockingReadCloser) Read(_ []byte) (int, error) {
+	r.readOnce.Do(func() { close(r.readStarted) })
+	<-r.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (r *blockingReadCloser) Close() error {
+	r.closeCount.Add(1)
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
+}
+
+func TestResponsesStreamIdleTimeoutErrorContract(t *testing.T) {
+	body := newBlockingReadCloser()
+	out := make(chan provider.StreamChunk, 4)
+	idle := 25 * time.Millisecond
+	go streamResponsesWithConfig(t.Context(), body, out, responsesStreamConfig{idleTimeout: idle})
+
+	select {
+	case <-body.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream reader did not start")
+	}
+
+	chunk := receiveChunk(t, out)
+	if chunk.Type != provider.ChunkError {
+		t.Fatalf("chunk type = %q, want %q", chunk.Type, provider.ChunkError)
+	}
+	var idleErr *StreamIdleTimeoutError
+	if !errors.As(chunk.Error, &idleErr) {
+		t.Fatalf("error = %T %v, want *StreamIdleTimeoutError", chunk.Error, chunk.Error)
+	}
+	if idleErr.Idle != idle || !isResponsesIdleTimeout(chunk.Error) {
+		t.Fatalf("idle error = %#v", idleErr)
+	}
+	var netErr net.Error
+	if !errors.As(chunk.Error, &netErr) || !netErr.Timeout() {
+		t.Fatalf("error does not satisfy transient net.Error timeout contract: %v", chunk.Error)
+	}
+
+	drainChunks(t, out)
+	if got := body.closeCount.Load(); got != 1 {
+		t.Fatalf("body Close calls = %d, want 1", got)
+	}
+}
+
+func TestResponsesStreamEventActivityResetsIdleTimeout(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		data      string
+	}{
+		{name: "in progress", eventType: "response.in_progress", data: `{"response":{"id":"resp_1"}}`},
+		{name: "unknown valid event", eventType: "response.rate_limits.updated", data: `{"remaining":10}`},
+		{name: "malformed nonterminal event", eventType: "response.metadata", data: `{not-json}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader, writer := io.Pipe()
+			out := make(chan provider.StreamChunk, 8)
+			go streamResponsesWithConfig(t.Context(), reader, out, responsesStreamConfig{
+				idleTimeout: 200 * time.Millisecond,
+			})
+
+			writerDone := make(chan struct{})
+			go func() {
+				defer close(writerDone)
+				defer func() { _ = writer.Close() }()
+				for range 5 {
+					time.Sleep(50 * time.Millisecond)
+					if _, err := io.WriteString(writer, sseLine(tt.eventType, tt.data)); err != nil {
+						return
+					}
+				}
+				time.Sleep(50 * time.Millisecond)
+				_, _ = io.WriteString(writer, completedResponsesEvent)
+			}()
+
+			var gotFinish, gotError bool
+			for chunk := range out {
+				gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+				gotError = gotError || chunk.Type == provider.ChunkError
+			}
+			<-writerDone
+			if !gotFinish || gotError {
+				t.Fatalf("finish = %v, error = %v", gotFinish, gotError)
+			}
+		})
+	}
+}
+
+func TestResponsesStreamOutputBackpressureDoesNotCauseIdleTimeout(t *testing.T) {
+	idle := 10 * time.Millisecond
+	input := sseLine("response.output_text.delta", `{"delta":"hello"}`) + completedResponsesEvent
+
+	for range 20 {
+		out := make(chan provider.StreamChunk)
+		go streamResponsesWithConfig(t.Context(), io.NopCloser(strings.NewReader(input)), out, responsesStreamConfig{
+			idleTimeout: idle,
+		})
+
+		// Keep projection blocked beyond the idle window while the reader queues
+		// the already-complete terminal event.
+		time.Sleep(3 * idle)
+
+		var gotFinish bool
+		for chunk := range out {
+			if isResponsesIdleTimeout(chunk.Error) {
+				t.Fatal("downstream backpressure was reported as provider inactivity")
+			}
+			if chunk.Type == provider.ChunkError {
+				t.Fatalf("unexpected stream error: %v", chunk.Error)
+			}
+			gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+		}
+		if !gotFinish {
+			t.Fatal("stream did not finish after downstream resumed")
+		}
+	}
+}
+
+func TestResponsesStreamCommentsDoNotResetIdleTimeout(t *testing.T) {
+	reader, writer := io.Pipe()
+	out := make(chan provider.StreamChunk, 4)
+	go streamResponsesWithConfig(t.Context(), reader, out, responsesStreamConfig{idleTimeout: 60 * time.Millisecond})
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		defer func() { _ = writer.Close() }()
+		for {
+			time.Sleep(15 * time.Millisecond)
+			if _, err := io.WriteString(writer, ": ping\n\n"); err != nil {
+				return
+			}
+		}
+	}()
+
+	chunk := receiveChunk(t, out)
+	if !isResponsesIdleTimeout(chunk.Error) {
+		t.Fatalf("error = %T %v, want idle timeout", chunk.Error, chunk.Error)
+	}
+	drainChunks(t, out)
+	<-writerDone
+}
+
+func TestResponsesStreamPartialEventDoesNotResetIdleTimeout(t *testing.T) {
+	reader, writer := io.Pipe()
+	out := make(chan provider.StreamChunk, 4)
+	go streamResponsesWithConfig(t.Context(), reader, out, responsesStreamConfig{idleTimeout: 40 * time.Millisecond})
+
+	if _, err := io.WriteString(writer, "event: response.in_progress\n"); err != nil {
+		t.Fatalf("write partial event: %v", err)
+	}
+	chunk := receiveChunk(t, out)
+	if !isResponsesIdleTimeout(chunk.Error) {
+		t.Fatalf("error = %T %v, want idle timeout", chunk.Error, chunk.Error)
+	}
+	drainChunks(t, out)
+	_ = writer.Close()
+}
+
+func TestResponsesStreamReasoningThenIdleTimeout(t *testing.T) {
+	reader, writer := io.Pipe()
+	out := make(chan provider.StreamChunk, 4)
+	go streamResponsesWithConfig(t.Context(), reader, out, responsesStreamConfig{idleTimeout: 40 * time.Millisecond})
+
+	input := sseLine("response.reasoning_summary_text.delta", `{"item_id":"rs_1","summary_index":0,"delta":"thinking"}`)
+	if _, err := io.WriteString(writer, input); err != nil {
+		t.Fatalf("write reasoning event: %v", err)
+	}
+	if chunk := receiveChunk(t, out); chunk.Type != provider.ChunkReasoning || chunk.Text != "thinking" {
+		t.Fatalf("reasoning chunk = %#v", chunk)
+	}
+	if chunk := receiveChunk(t, out); !isResponsesIdleTimeout(chunk.Error) {
+		t.Fatalf("error = %T %v, want idle timeout", chunk.Error, chunk.Error)
+	}
+	drainChunks(t, out)
+	_ = writer.Close()
+}
+
+func TestResponsesStreamZeroIdleTimeoutDisablesWatchdog(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	body := newBlockingReadCloser()
+	out := make(chan provider.StreamChunk, 4)
+	go streamResponsesWithConfig(ctx, body, out, responsesStreamConfig{})
+
+	select {
+	case chunk := <-out:
+		t.Fatalf("received chunk with disabled watchdog: %#v", chunk)
+	case <-time.After(50 * time.Millisecond):
+	}
+	cancel()
+
+	chunk := receiveChunk(t, out)
+	if !errors.Is(chunk.Error, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", chunk.Error)
+	}
+	drainChunks(t, out)
+}
+
+func TestResponsesStreamCallerCancellationIdentity(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	body := newBlockingReadCloser()
+	out := make(chan provider.StreamChunk, 4)
+	go streamResponsesWithConfig(ctx, body, out, responsesStreamConfig{idleTimeout: time.Second})
+
+	select {
+	case <-body.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream reader did not start")
+	}
+	cancel()
+
+	chunk := receiveChunk(t, out)
+	if !errors.Is(chunk.Error, context.Canceled) || isResponsesIdleTimeout(chunk.Error) {
+		t.Fatalf("error = %T %v, want context.Canceled", chunk.Error, chunk.Error)
+	}
+	drainChunks(t, out)
+}
+
+func TestResponsesStreamCallerDeadlineIdentity(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+	body := newBlockingReadCloser()
+	out := make(chan provider.StreamChunk, 4)
+	go streamResponsesWithConfig(ctx, body, out, responsesStreamConfig{idleTimeout: time.Second})
+
+	chunk := receiveChunk(t, out)
+	if !errors.Is(chunk.Error, context.DeadlineExceeded) || isResponsesIdleTimeout(chunk.Error) {
+		t.Fatalf("error = %T %v, want context.DeadlineExceeded", chunk.Error, chunk.Error)
+	}
+	drainChunks(t, out)
+}
+
+func TestResponsesStreamTerminalClosesBlockedBody(t *testing.T) {
+	reader, writer := io.Pipe()
+	body := &countingReadCloser{ReadCloser: reader}
+	out := make(chan provider.StreamChunk, 8)
+	go streamResponsesWithConfig(t.Context(), body, out, responsesStreamConfig{idleTimeout: time.Second})
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(writer, completedResponsesEvent)
+		writeDone <- err
+	}()
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write terminal event: %v", err)
+	}
+
+	var gotFinish bool
+	for chunk := range out {
+		gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+	}
+	if !gotFinish {
+		t.Fatal("terminal event did not emit finish chunk")
+	}
+	if got := body.closeCount.Load(); got != 1 {
+		t.Fatalf("body Close calls = %d, want 1", got)
+	}
+	if _, err := io.WriteString(writer, "still open"); err == nil {
+		t.Fatal("body remained open after terminal event")
+	}
+	_ = writer.Close()
+}
+
+func TestResponsesStreamBlockingBodyCloseDoesNotBlockOutput(t *testing.T) {
+	body := newBlockingCloseReadCloser()
+	out := make(chan provider.StreamChunk, 4)
+	go streamResponsesWithConfig(t.Context(), body, out, responsesStreamConfig{idleTimeout: 20 * time.Millisecond})
+
+	select {
+	case <-body.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stream reader did not start")
+	}
+
+	chunk := receiveChunk(t, out)
+	if !isResponsesIdleTimeout(chunk.Error) {
+		t.Fatalf("error = %T %v, want idle timeout", chunk.Error, chunk.Error)
+	}
+	select {
+	case <-body.closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("body Close did not start")
+	}
+
+	// Close remains blocked, but the coordinator must still finish after its
+	// bounded reader wait and close the output channel.
+	drainChunks(t, out)
+	close(body.releaseClose)
+	select {
+	case <-body.readDone:
+	case <-time.After(time.Second):
+		t.Fatal("stream reader did not exit after releasing body Close")
+	}
+}
+
+func TestResponsesStreamProtocolErrorContract(t *testing.T) {
+	out := make(chan provider.StreamChunk, 4)
+	streamResponses(t.Context(), io.NopCloser(strings.NewReader("event: response.created\ndata: {}\n\n")), out)
+
+	chunk := receiveChunk(t, out)
+	var protocolErr *StreamProtocolError
+	if !errors.As(chunk.Error, &protocolErr) || !isResponsesProtocolError(chunk.Error) {
+		t.Fatalf("error = %T %v, want *StreamProtocolError", chunk.Error, chunk.Error)
+	}
+	if protocolErr.Provider != responsesStreamProvider || protocolErr.API != responsesStreamAPI {
+		t.Fatalf("protocol error = %#v", protocolErr)
+	}
+	if strings.Contains(protocolErr.Error(), "response.created") {
+		t.Fatalf("premature EOF error unexpectedly includes event payload/type: %q", protocolErr.Error())
+	}
+	drainChunks(t, out)
+}
+
+func TestResponsesStreamRejectsMismatchedTerminalPayloadType(t *testing.T) {
+	input := sseLine(
+		"response.completed",
+		`{"type":"response.failed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`,
+	)
+	out := make(chan provider.StreamChunk, 4)
+	streamResponses(t.Context(), io.NopCloser(strings.NewReader(input)), out)
+
+	chunk := receiveChunk(t, out)
+	var protocolErr *StreamProtocolError
+	if !errors.As(chunk.Error, &protocolErr) || protocolErr.EventType != "response.completed" {
+		t.Fatalf("error = %T %v, want terminal payload mismatch", chunk.Error, chunk.Error)
+	}
+	drainChunks(t, out)
+}
+
+func TestResponsesStreamTerminalUsageCompatibility(t *testing.T) {
+	tests := []struct {
+		name         string
+		usage        string
+		wantFinish   bool
+		wantProtocol bool
+		wantInput    int
+		wantOutput   int
+	}{
+		{name: "usage omitted", wantFinish: true},
+		{name: "complete usage", usage: `,"usage":{"input_tokens":3,"output_tokens":2}`, wantFinish: true, wantInput: 3, wantOutput: 2},
+		{name: "empty usage", usage: `,"usage":{}`, wantProtocol: true},
+		{name: "missing input tokens", usage: `,"usage":{"output_tokens":2}`, wantProtocol: true},
+		{name: "missing output tokens", usage: `,"usage":{"input_tokens":3}`, wantProtocol: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := `{"response":{"id":"resp_1"` + tt.usage + `}}`
+			out := make(chan provider.StreamChunk, 4)
+			streamResponses(t.Context(), io.NopCloser(strings.NewReader(sseLine("response.completed", payload))), out)
+
+			var gotFinish bool
+			var gotProtocol bool
+			for chunk := range out {
+				gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+				var protocolErr *StreamProtocolError
+				gotProtocol = gotProtocol || errors.As(chunk.Error, &protocolErr)
+				if chunk.Type == provider.ChunkFinish && (chunk.Usage.InputTokens != tt.wantInput || chunk.Usage.OutputTokens != tt.wantOutput) {
+					t.Fatalf("finish usage = %#v, want %d input and %d output tokens", chunk.Usage, tt.wantInput, tt.wantOutput)
+				}
+			}
+			if gotFinish != tt.wantFinish || gotProtocol != tt.wantProtocol {
+				t.Fatalf("finish = %v, protocol error = %v; want finish = %v, protocol error = %v", gotFinish, gotProtocol, tt.wantFinish, tt.wantProtocol)
+			}
+		})
+	}
+}
+
+func TestResponsesStreamOptions(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		model := Chat("o3", WithAPIKey("key")).(*chatModel)
+		if got := model.opts.responsesStreamIdleTimeout; got != DefaultResponsesStreamIdleTimeout {
+			t.Fatalf("default idle timeout = %s, want %s", got, DefaultResponsesStreamIdleTimeout)
+		}
+	})
+
+	t.Run("override", func(t *testing.T) {
+		model := Chat(
+			"o3",
+			WithAPIKey("key"),
+			WithResponsesStreamIdleTimeout(3*time.Second),
+		).(*chatModel)
+		if got := model.opts.responsesStreamIdleTimeout; got != 3*time.Second {
+			t.Fatalf("idle timeout = %s, want 3s", got)
+		}
+	})
+
+	t.Run("done compatibility", func(t *testing.T) {
+		model := Chat(
+			"gpt-5",
+			WithAPIKey("key"),
+			WithResponsesStreamDoneCompatibility(true),
+		).(*chatModel)
+		if !model.opts.responsesStreamAllowDone {
+			t.Fatal("[DONE] compatibility option was not applied")
+		}
+	})
+
+	t.Run("negative rejected before request", func(t *testing.T) {
+		model := Chat(
+			"o3",
+			WithAPIKey("key"),
+			WithBaseURL("http://invalid.invalid"),
+			WithResponsesStreamIdleTimeout(-time.Second),
+		)
+		result, err := model.DoStream(t.Context(), provider.GenerateParams{})
+		if err == nil || result != nil {
+			t.Fatalf("DoStream() = (%v, %v), want nil result and configuration error", result, err)
+		}
+		if !strings.Contains(err.Error(), "must be non-negative") {
+			t.Fatalf("error = %q", err)
+		}
+	})
+
+	t.Run("chat completions unaffected", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		}))
+		defer server.Close()
+
+		model := Chat(
+			"gpt-4o",
+			WithAPIKey("key"),
+			WithBaseURL(server.URL),
+			WithResponsesStreamIdleTimeout(-time.Second),
+		)
+		result, err := model.DoStream(t.Context(), provider.GenerateParams{ProviderOptions: chatCompletionsOpts})
+		if err != nil {
+			t.Fatalf("DoStream() error = %v", err)
+		}
+		var gotFinish bool
+		for chunk := range result.Stream {
+			gotFinish = gotFinish || chunk.Type == provider.ChunkFinish
+		}
+		if !gotFinish {
+			t.Fatal("Chat Completions stream did not preserve [DONE] behavior")
+		}
+	})
+}
+
+func TestResponsesStreamErrorPropagatesThroughTextStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sseLine("response.created", `{"response":{"id":"resp_1"}}`))
+	}))
+	defer server.Close()
+
+	model := Chat("o3", WithAPIKey("key"), WithBaseURL(server.URL))
+	stream, err := goai.StreamText(t.Context(), model, goai.WithPrompt("hi"))
+	if err != nil {
+		t.Fatalf("StreamText() error = %v", err)
+	}
+	stream.Result()
+	var protocolErr *StreamProtocolError
+	if err := stream.Err(); !errors.As(err, &protocolErr) {
+		t.Fatalf("stream.Err() = %T %v, want *StreamProtocolError", err, err)
+	}
+}
+
+func TestResponsesStreamTerminalRaces(t *testing.T) {
+	t.Run("completion and cancellation", func(t *testing.T) {
+		for range 100 {
+			ctx, cancel := context.WithCancel(t.Context())
+			reader, writer := io.Pipe()
+			body := &countingReadCloser{ReadCloser: reader}
+			out := make(chan provider.StreamChunk, 8)
+			go streamResponsesWithConfig(ctx, body, out, responsesStreamConfig{idleTimeout: time.Second})
+
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Go(func() {
+				<-start
+				_, _ = io.WriteString(writer, completedResponsesEvent)
+			})
+			wg.Go(func() {
+				<-start
+				cancel()
+			})
+			close(start)
+
+			terminalOutcomes := countTerminalOutcomes(out)
+			wg.Wait()
+			_ = writer.Close()
+			if terminalOutcomes > 1 {
+				t.Fatalf("terminal outcomes = %d, want at most 1", terminalOutcomes)
+			}
+			if got := body.closeCount.Load(); got != 1 {
+				t.Fatalf("body Close calls = %d, want 1", got)
+			}
+		}
+	})
+
+	t.Run("completion and timeout", func(t *testing.T) {
+		for range 50 {
+			reader, writer := io.Pipe()
+			body := &countingReadCloser{ReadCloser: reader}
+			out := make(chan provider.StreamChunk, 8)
+			go streamResponsesWithConfig(t.Context(), body, out, responsesStreamConfig{idleTimeout: 2 * time.Millisecond})
+
+			writerDone := make(chan struct{})
+			go func() {
+				defer close(writerDone)
+				time.Sleep(2 * time.Millisecond)
+				_, _ = io.WriteString(writer, completedResponsesEvent)
+			}()
+			terminalOutcomes := countTerminalOutcomes(out)
+			<-writerDone
+			_ = writer.Close()
+			if terminalOutcomes != 1 {
+				t.Fatalf("terminal outcomes = %d, want 1", terminalOutcomes)
+			}
+			if got := body.closeCount.Load(); got != 1 {
+				t.Fatalf("body Close calls = %d, want 1", got)
+			}
+		}
+	})
+}
+
+type countingReadCloser struct {
+	io.ReadCloser
+	closeCount atomic.Int32
+}
+
+func (r *countingReadCloser) Close() error {
+	r.closeCount.Add(1)
+	return r.ReadCloser.Close()
+}
+
+func receiveChunk(t *testing.T, out <-chan provider.StreamChunk) provider.StreamChunk {
+	t.Helper()
+	select {
+	case chunk, ok := <-out:
+		if !ok {
+			t.Fatal("stream closed without a chunk")
+		}
+		return chunk
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream chunk")
+		return provider.StreamChunk{}
+	}
+}
+
+func drainChunks(t *testing.T, out <-chan provider.StreamChunk) {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case _, ok := <-out:
+			if !ok {
+				return
+			}
+		case <-timer.C:
+			t.Fatal("timed out waiting for stream close")
+		}
+	}
+}
+
+func countTerminalOutcomes(out <-chan provider.StreamChunk) int {
+	var count int
+	for chunk := range out {
+		if chunk.Type == provider.ChunkFinish || chunk.Type == provider.ChunkError {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Summary

Add OpenAI Responses stream idle timeout and protocol checks

## Changes

- Introduce `WithResponsesStreamIdleTimeout` and `WithResponsesStreamDoneCompatibility` options for OpenAI/Azure.
- Enforce 5-minute event-level idle watchdogs on Responses streams to detect stalled provider connections.
- Implement explicit protocol validation for Responses API terminal events, rejecting premature EOF or bare `[DONE]` sentinels by default.
- Add `StreamIdleTimeoutError` and `StreamProtocolError` for observability into stream failures.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] New tests added for new functionality
- [x] Examples updated if public API changed

## Related issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
