### PR TITLE
Prevent closure capture of request in stream goroutines

### DIFF
--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -293,11 +293,13 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	if err != nil {
 		return nil, err
 	}
+	// Keep resp.Request and its serialized request body out of the stream closure.
+	responseBody := resp.Body
 
 	out := make(chan provider.StreamChunk, 64)
 	go func() {
 		var closeOnce sync.Once
-		closeBody := func() { closeOnce.Do(func() { _ = resp.Body.Close() }) }
+		closeBody := func() { closeOnce.Do(func() { _ = responseBody.Close() }) }
 		defer closeBody()
 		// Close body on context cancellation to unblock scanner.Scan().
 		// Without this, the goroutine leaks if the server stalls mid-stream.
@@ -310,7 +312,7 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
-		parseSSE(ctx, resp.Body, out, rfMode)
+		parseSSE(ctx, responseBody, out, rfMode)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/cohere/cohere.go
+++ b/provider/cohere/cohere.go
@@ -167,11 +167,13 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	if err != nil {
 		return nil, err
 	}
+	// Keep resp.Request and its serialized request body out of the stream closure.
+	responseBody := resp.Body
 
 	out := make(chan provider.StreamChunk, 64)
 	go func() {
 		var closeOnce sync.Once
-		closeBody := func() { closeOnce.Do(func() { _ = resp.Body.Close() }) }
+		closeBody := func() { closeOnce.Do(func() { _ = responseBody.Close() }) }
 		defer closeBody()
 		// Close body on context cancellation to unblock parseChatStream.
 		// Without this, the goroutine leaks if the server stalls mid-stream.
@@ -184,7 +186,7 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			case <-done:
 			}
 		}()
-		parseChatStream(ctx, resp.Body, out)
+		parseChatStream(ctx, responseBody, out)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -257,11 +257,13 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	if err != nil {
 		return nil, err
 	}
+	// Keep resp.Request and its serialized request body out of the stream closure.
+	responseBody := resp.Body
 
 	out := make(chan provider.StreamChunk, 64)
 	go func() {
 		var closeOnce sync.Once
-		closeBody := func() { closeOnce.Do(func() { _ = resp.Body.Close() }) }
+		closeBody := func() { closeOnce.Do(func() { _ = responseBody.Close() }) }
 		defer closeBody()
 		// Close body on context cancellation to unblock scanner.Scan().
 		// Without this, the goroutine leaks if the server stalls mid-stream.
@@ -274,7 +276,7 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 			}
 		}()
 		defer close(done)
-		parseSSE(ctx, resp.Body, out)
+		parseSSE(ctx, responseBody, out)
 	}()
 
 	return &provider.StreamResult{Stream: out}, nil

--- a/provider/ollama/ollama.go
+++ b/provider/ollama/ollama.go
@@ -333,18 +333,20 @@ func (m *Model) DoStream(ctx context.Context, params provider.GenerateParams) (*
 	if err != nil {
 		return nil, err
 	}
+	// Keep resp.Request and its serialized request body out of the stream closure.
+	responseBody := resp.Body
 
 	ch := make(chan provider.StreamChunk, streamBufSize)
 
 	go func() {
 		defer close(ch)
-		defer func() { _ = resp.Body.Close() }()
+		defer func() { _ = responseBody.Close() }()
 
 		var lastResp ollamaChatResponse
 
 		// Read NDJSON with sse.Scanner: no 64 KiB per-line limit (unlike
 		// bufio.Scanner) while still bounding each line to sse.MaxLineSize.
-		scanner := sse.NewScanner(resp.Body)
+		scanner := sse.NewScanner(responseBody)
 		for {
 			line, ok := scanner.NextLine()
 			if !ok {

--- a/provider/openai/openai.go
+++ b/provider/openai/openai.go
@@ -205,10 +205,12 @@ func (m *chatModel) doStreamResponses(ctx context.Context, params provider.Gener
 	if err != nil {
 		return nil, err
 	}
+	// Keep resp.Request and its serialized request body out of the stream closure.
+	responseBody := resp.Body
 
 	out := make(chan provider.StreamChunk, 64)
 	go func() {
-		streamResponsesWithConfig(ctx, resp.Body, out, responsesStreamConfig{
+		streamResponsesWithConfig(ctx, responseBody, out, responsesStreamConfig{
 			idleTimeout: m.opts.responsesStreamIdleTimeout,
 			allowDone:   m.opts.responsesStreamAllowDone,
 		})

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -387,16 +387,18 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	if err != nil {
 		return nil, err
 	}
+	// Keep resp.Request and its serialized request body out of the stream closure.
+	responseBody := resp.Body
 
 	out := make(chan provider.StreamChunk, 64)
-	scanner := sse.NewScanner(resp.Body)
+	scanner := sse.NewScanner(responseBody)
 	go func() {
-		defer func() { _ = resp.Body.Close() }()
+		defer func() { _ = responseBody.Close() }()
 		done := make(chan struct{})
 		go func() {
 			select {
 			case <-ctx.Done():
-				_ = resp.Body.Close()
+				_ = responseBody.Close()
 			case <-done:
 			}
 		}()

--- a/provider/vertex/vertex.go
+++ b/provider/vertex/vertex.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/zendev-sh/goai"
 	"github.com/zendev-sh/goai/internal/gemini"
@@ -393,12 +394,16 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	out := make(chan provider.StreamChunk, 64)
 	scanner := sse.NewScanner(responseBody)
 	go func() {
-		defer func() { _ = responseBody.Close() }()
+		// Guard against closing the body twice: the cancellation goroutine and
+		// the stream defer both close it. sync.Once makes the second call a no-op.
+		var closeOnce sync.Once
+		closeBody := func() { closeOnce.Do(func() { _ = responseBody.Close() }) }
+		defer closeBody()
 		done := make(chan struct{})
 		go func() {
 			select {
 			case <-ctx.Done():
-				_ = responseBody.Close()
+				closeBody()
 			case <-done:
 			}
 		}()

--- a/provider/vertex/vertex_test.go
+++ b/provider/vertex/vertex_test.go
@@ -9,9 +9,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zendev-sh/goai/provider"
 )
+
+type vertexRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f vertexRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 func TestChat_Stream(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +52,50 @@ func TestChat_Stream(t *testing.T) {
 	}
 	if len(texts) != 1 || texts[0] != "Hello" {
 		t.Errorf("texts = %v, want [Hello]", texts)
+	}
+}
+
+func TestChat_Stream_ContextCancelClosesResponseBody(t *testing.T) {
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	client := &http.Client{Transport: vertexRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       reader,
+		}, nil
+	})}
+	model := Chat("gemini-2.5-pro",
+		WithTokenSource(provider.StaticToken("test-token")),
+		WithBaseURL("http://vertex.test"),
+		WithHTTPClient(client))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	result, err := model.DoStream(ctx, provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case _, ok := <-result.Stream:
+			if !ok {
+				return
+			}
+		case <-timer.C:
+			t.Fatal("stream did not close after context cancellation")
+		}
 	}
 }
 

--- a/provider/vertex/vertex_test.go
+++ b/provider/vertex/vertex_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -14,9 +15,23 @@ import (
 	"github.com/zendev-sh/goai/provider"
 )
 
-type vertexRoundTripFunc func(*http.Request) (*http.Response, error)
+type requestTrackingTransport struct {
+	responseBody     io.ReadCloser
+	requestCollected chan struct{}
+}
 
-func (f vertexRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func (t *requestTrackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	runtime.AddCleanup(req, func(collected chan struct{}) {
+		close(collected)
+	}, t.requestCollected)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       t.responseBody,
+		Request:    req,
+	}, nil
+}
 
 func TestChat_Stream(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -55,26 +70,25 @@ func TestChat_Stream(t *testing.T) {
 	}
 }
 
-func TestChat_Stream_ContextCancelClosesResponseBody(t *testing.T) {
+func TestChat_Stream_DoesNotRetainRequestGraph(t *testing.T) {
 	reader, writer := io.Pipe()
 	t.Cleanup(func() {
 		_ = reader.Close()
 		_ = writer.Close()
 	})
 
-	client := &http.Client{Transport: vertexRoundTripFunc(func(*http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     make(http.Header),
-			Body:       reader,
-		}, nil
-	})}
+	requestCollected := make(chan struct{})
+	client := &http.Client{Transport: &requestTrackingTransport{
+		responseBody:     reader,
+		requestCollected: requestCollected,
+	}}
 	model := Chat("gemini-2.5-pro",
 		WithTokenSource(provider.StaticToken("test-token")),
 		WithBaseURL("http://vertex.test"),
 		WithHTTPClient(client))
 
 	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
 	result, err := model.DoStream(ctx, provider.GenerateParams{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
@@ -84,17 +98,30 @@ func TestChat_Stream_ContextCancelClosesResponseBody(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cancel()
-	timer := time.NewTimer(time.Second)
+	// The pipe keeps the stream active. The request and its serialized body
+	// should nevertheless be unreachable once DoStream returns.
+	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
 	for {
+		runtime.GC()
 		select {
-		case _, ok := <-result.Stream:
-			if !ok {
-				return
+		case <-requestCollected:
+			cancel()
+			for {
+				select {
+				case _, ok := <-result.Stream:
+					if !ok {
+						return
+					}
+				case <-timer.C:
+					t.Fatal("stream did not close after context cancellation")
+				}
 			}
 		case <-timer.C:
-			t.Fatal("stream did not close after context cancellation")
+			t.Fatal("active stream retained its response/request graph")
+		case <-ticker.C:
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Extract `resp.Body` into a local variable before creating the stream goroutine to avoid retaining the response/request graph while the stream remains active.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] New tests added for new functionality
- [x] Examples updated if public API changed

## Related issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
