### PR TITLE
fix(anthropic): derive model capabilities from version, not literal lists

### DIFF
--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -18,6 +18,8 @@ import (
 	"maps"
 	"net/http"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -200,11 +202,54 @@ type chatModel struct {
 
 func (m *chatModel) ModelID() string { return m.id }
 
-// supportsThinking returns true for Anthropic models that support extended thinking.
+// anthropicModelVersionPattern matches the generation numbers in a
+// current-naming Anthropic model id ("claude-<family>-<major>[-<minor>]").
+//
+// Deliberately unanchored: Bedrock reuses this provider via
+// bedrock.AnthropicChat with a prefixed id ("anthropic.claude-opus-5",
+// "us.anthropic.claude-sonnet-4-6"), and Vertex appends an "@date" suffix
+// ("claude-opus-4-5@20251101"). Legacy family-last ids ("claude-3-7-sonnet",
+// "claude-3-5-sonnet-20241022") do not match and are reported as unversioned.
+var anthropicModelVersionPattern = regexp.MustCompile(`claude-(?:opus|sonnet|haiku|fable|mythos)-(\d+)(?:-(\d+))?`)
+
+// anthropicModelVersion extracts the major and minor generation numbers from a
+// current-naming Anthropic model id. ok is false when the id carries no
+// parseable version, in which case callers should fall back to legacy handling.
+//
+// A trailing numeric segment is only treated as a minor version when it is one
+// or two digits; longer runs are release dates, not versions, so
+// "claude-sonnet-4-20250514" reports major 4 with no minor rather than minor
+// 20250514.
+func anthropicModelVersion(modelID string) (major, minor int, ok bool) {
+	m := anthropicModelVersionPattern.FindStringSubmatch(strings.ToLower(modelID))
+	if m == nil {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	if len(m[2]) > 0 && len(m[2]) <= 2 {
+		// Cannot fail: the pattern matched one or two ASCII digits.
+		minor, _ = strconv.Atoi(m[2])
+	}
+	return major, minor, true
+}
+
+// supportsThinking returns true for Anthropic models that support extended
+// thinking: every model from the Claude 4 generation onward, plus the legacy
+// claude-3-7-sonnet.
+//
+// Version-derived rather than a literal model list, which had gone stale for
+// the 5.x generation (claude-opus-5, claude-sonnet-5, claude-fable-5) and for
+// claude-haiku-4-5, all of which support thinking but matched none of the
+// previous substrings.
 func supportsThinking(modelID string) bool {
-	return strings.Contains(modelID, "claude-3-7-sonnet") ||
-		strings.Contains(modelID, "claude-sonnet-4") ||
-		strings.Contains(modelID, "claude-opus-4")
+	if strings.Contains(modelID, "claude-3-7-sonnet") {
+		return true
+	}
+	major, _, ok := anthropicModelVersion(modelID)
+	return ok && major >= 4
 }
 
 // hasRemoteRef returns true if any message part contains a RemoteRef.
@@ -772,15 +817,28 @@ func (m *chatModel) useNativeOutputFormat(params provider.GenerateParams) bool {
 	}
 }
 
-// supportsNativeOutputFormat returns true for models that support native output_format.
-// Matches Vercel: claude-sonnet-4-6, claude-opus-4-6, claude-sonnet-4-5, claude-opus-4-5, claude-opus-4-1.
+// supportsNativeOutputFormat returns true for models that support native
+// structured output (output_config.format): the Claude 4.1 release and
+// everything after it.
+//
+// Version-derived rather than a literal model list. The previous list
+// (claude-sonnet-4-6, claude-opus-4-6, claude-sonnet-4-5, claude-opus-4-5,
+// claude-opus-4-1) had gone stale for every model shipped since: opus-4-7,
+// opus-4-8, haiku-4-5, and the whole 5.x generation (opus-5, sonnet-5,
+// fable-5) all support it but matched none of those substrings, so
+// structuredOutputMode "auto" silently fell back to the tool_choice-forcing
+// tool trick — which the Messages API rejects when thinking is enabled.
 func (m *chatModel) supportsNativeOutputFormat() bool {
-	id := m.id
-	return strings.Contains(id, "claude-sonnet-4-6") ||
-		strings.Contains(id, "claude-opus-4-6") ||
-		strings.Contains(id, "claude-sonnet-4-5") ||
-		strings.Contains(id, "claude-opus-4-5") ||
-		strings.Contains(id, "claude-opus-4-1")
+	major, minor, ok := anthropicModelVersion(m.id)
+	if !ok {
+		return false
+	}
+	if major >= 5 {
+		return true
+	}
+	// Within the 4.x generation, 4.0 (which appears either bare or with a
+	// release-date suffix, so minor is 0) predates structured output.
+	return major == 4 && minor >= 1
 }
 
 // injectNativeOutputFormat stores the structured-output schema in
@@ -802,6 +860,7 @@ func injectNativeOutputFormat(params provider.GenerateParams) provider.GenerateP
 		if err := json.Unmarshal(p.ResponseFormat.Schema, &schema); err != nil {
 			return params // schema invalid, fall back to tool trick
 		}
+		schema = stripNativeOutputKeywords(schema)
 	}
 	p.ProviderOptions["output_format"] = map[string]any{
 		"type":   "json_schema",
@@ -810,6 +869,105 @@ func injectNativeOutputFormat(params provider.GenerateParams) provider.GenerateP
 	// Clear ResponseFormat so the tool trick is not also applied.
 	p.ResponseFormat = nil
 	return p
+}
+
+// nativeOutputUnsupportedKeywords lists the JSON Schema validation keywords
+// that Anthropic's native structured-output validator rejects outright, e.g.
+//
+//	output_config.format.schema: For 'number' type, properties maximum,
+//	minimum are not supported
+//
+// Per Anthropic's structured-output schema limitations these are the numeric
+// constraints, the string-length constraints, and the more complex array
+// constraints. Basic types, enum/const, anyOf/allOf, $ref/$defs, string
+// formats, and additionalProperties:false are all supported and are left
+// alone.
+//
+// Only the native output_config.format path needs this. The tool-trick path
+// sends the same schema as a tool's input_schema, where these keywords are
+// advisory (no strict:true) and therefore harmless — so a caller who stays on
+// the tool trick keeps full validation.
+var nativeOutputUnsupportedKeywords = map[string]bool{
+	"minimum":          true,
+	"maximum":          true,
+	"exclusiveMinimum": true,
+	"exclusiveMaximum": true,
+	"multipleOf":       true,
+	"minLength":        true,
+	"maxLength":        true,
+	"minItems":         true,
+	"maxItems":         true,
+	"uniqueItems":      true,
+}
+
+// schemaNameKeyedKeywords lists the keywords whose value is a map keyed by
+// *names* — data-model property names or definition names — rather than a
+// schema object. The keys inside them are caller-chosen identifiers, so they
+// must never be filtered as validation keywords: a response field legitimately
+// named "minimum" is not the numeric `minimum` constraint.
+var schemaNameKeyedKeywords = map[string]bool{
+	"properties":        true,
+	"patternProperties": true,
+	"dependentSchemas":  true,
+	"$defs":             true,
+	"definitions":       true,
+}
+
+// stripNativeOutputKeywords walks an arbitrary schema value and removes every
+// keyword in nativeOutputUnsupportedKeywords wherever it appears in keyword
+// position, so a schema carrying constraints Anthropic does not support is
+// still usable with native structured output instead of failing the request.
+//
+// Filtering is position-aware. Inside a schemaNameKeyedKeywords map the keys
+// are data-model names, so only their values are sanitised; deleting them
+// would silently drop caller fields from the requested shape and could leave
+// `required` referencing a property that no longer exists. (The sibling
+// sanitiser in internal/gemini instead reconciles `required` against
+// `properties` after the fact; not deleting the properties in the first place
+// makes that unnecessary here.)
+//
+// The function does not mutate its input: new maps/slices are allocated for
+// every container so callers can safely reuse the original schema.
+func stripNativeOutputKeywords(obj any) any {
+	switch v := obj.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(v))
+		for k, val := range v {
+			if nativeOutputUnsupportedKeywords[k] {
+				continue
+			}
+			if schemaNameKeyedKeywords[k] {
+				result[k] = stripNameKeyedMap(val)
+				continue
+			}
+			result[k] = stripNativeOutputKeywords(val)
+		}
+		return result
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = stripNativeOutputKeywords(item)
+		}
+		return out
+	default:
+		return obj
+	}
+}
+
+// stripNameKeyedMap sanitises the values of a name-keyed map (the value of
+// "properties", "$defs", and friends) while preserving every key verbatim.
+// A non-map value is handed back to the ordinary walk, so a malformed schema
+// is passed through rather than mangled here.
+func stripNameKeyedMap(obj any) any {
+	m, ok := obj.(map[string]any)
+	if !ok {
+		return stripNativeOutputKeywords(obj)
+	}
+	result := make(map[string]any, len(m))
+	for name, sub := range m {
+		result[name] = stripNativeOutputKeywords(sub)
+	}
+	return result
 }
 
 const responseFormatToolName = "json_response"

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -94,6 +95,13 @@ type options struct {
 	bodyTransformer BodyTransformer
 	errorProvider   string // provider name for error parsing (default "anthropic")
 	skipEnvResolve  bool   // skip ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL env resolution
+
+	// nativeOutputFormatModels restricts the model IDs for which native
+	// structured output (output_config.format) is enabled in "auto" mode.
+	// nil selects the direct-Anthropic documented list; an empty slice
+	// disables native structured output entirely. Platform adapters set this
+	// to their own documented compatibility set.
+	nativeOutputFormatModels []string
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -166,6 +174,40 @@ func WithErrorProvider(name string) Option {
 func WithSkipEnvResolve() Option {
 	return func(o *options) {
 		o.skipEnvResolve = true
+	}
+}
+
+// NativeOutputFormatSupport selects which documented model set enables native
+// structured output (output_config.format) in "auto" mode for a platform.
+type NativeOutputFormatSupport int
+
+const (
+	// NativeOutputFormatDirect is the default: the full documented Claude API
+	// compatibility set. Used by the direct API and platforms (Vertex, Azure)
+	// that expose the same set.
+	NativeOutputFormatDirect NativeOutputFormatSupport = iota
+	// NativeOutputFormatBedrock is the narrower documented Amazon Bedrock set.
+	NativeOutputFormatBedrock
+	// NativeOutputFormatDisabled disables native structured output entirely;
+	// the platform does not document support for the field.
+	NativeOutputFormatDisabled
+)
+
+// WithNativeOutputFormatSupport restricts which models enable native
+// structured output (output_config.format) in "auto" mode. Platform adapters
+// whose documented compatibility differs from the direct Claude API set this
+// explicitly (e.g. bedrock.WithNativeOutputFormatSupport(Bedrock),
+// minimax.WithNativeOutputFormatSupport(Disabled)).
+func WithNativeOutputFormatSupport(support NativeOutputFormatSupport) Option {
+	return func(o *options) {
+		switch support {
+		case NativeOutputFormatBedrock:
+			o.nativeOutputFormatModels = bedrockNativeOutputFormatModels
+		case NativeOutputFormatDisabled:
+			o.nativeOutputFormatModels = []string{}
+		default:
+			o.nativeOutputFormatModels = nil
+		}
 	}
 }
 
@@ -245,7 +287,9 @@ func anthropicModelVersion(modelID string) (major, minor int, ok bool) {
 // claude-haiku-4-5, all of which support thinking but matched none of the
 // previous substrings.
 func supportsThinking(modelID string) bool {
-	if strings.Contains(modelID, "claude-3-7-sonnet") {
+	// Legacy and non-versioned aliases that support thinking but carry no
+	// parseable generation number.
+	if strings.Contains(modelID, "claude-3-7-sonnet") || strings.Contains(modelID, "claude-mythos-preview") {
 		return true
 	}
 	major, _, ok := anthropicModelVersion(modelID)
@@ -290,7 +334,11 @@ func (m *chatModel) DoGenerate(ctx context.Context, params provider.GeneratePara
 	if rfMode {
 		params = injectResponseFormatTool(params)
 	} else if useOutputFormat {
-		params = injectNativeOutputFormat(params)
+		var err error
+		params, err = injectNativeOutputFormat(params)
+		if err != nil {
+			return nil, err
+		}
 	}
 	body := m.buildRequest(params, false)
 	toolBetas := collectToolBetas(params.Tools)
@@ -326,7 +374,11 @@ func (m *chatModel) DoStream(ctx context.Context, params provider.GenerateParams
 	if rfMode {
 		params = injectResponseFormatTool(params)
 	} else if useOutputFormat {
-		params = injectNativeOutputFormat(params)
+		var err error
+		params, err = injectNativeOutputFormat(params)
+		if err != nil {
+			return nil, err
+		}
 	}
 	body := m.buildRequest(params, true)
 	toolBetas := collectToolBetas(params.Tools)
@@ -817,34 +869,91 @@ func (m *chatModel) useNativeOutputFormat(params provider.GenerateParams) bool {
 	}
 }
 
-// supportsNativeOutputFormat returns true for models that support native
-// structured output (output_config.format): the Claude 4.1 release and
-// everything after it.
+// directNativeOutputFormatModels is the documented Claude API compatibility set
+// for native structured output (output_config.format), kept explicit so a
+// future model name is not enabled before the platform documentation
+// guarantees it. Release-date aliases (e.g. claude-opus-4-5-20251101) match via
+// modelIDMatches.
 //
-// Version-derived rather than a literal model list. The previous list
-// (claude-sonnet-4-6, claude-opus-4-6, claude-sonnet-4-5, claude-opus-4-5,
-// claude-opus-4-1) had gone stale for every model shipped since: opus-4-7,
-// opus-4-8, haiku-4-5, and the whole 5.x generation (opus-5, sonnet-5,
-// fable-5) all support it but matched none of those substrings, so
-// structuredOutputMode "auto" silently fell back to the tool_choice-forcing
-// tool trick — which the Messages API rejects when thinking is enabled.
+// Source: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#compatibility
+var directNativeOutputFormatModels = []string{
+	"claude-fable-5", "claude-mythos-5", "claude-mythos-preview",
+	"claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
+	"claude-sonnet-5", "claude-sonnet-4-6", "claude-sonnet-4-5",
+	"claude-opus-4-5", "claude-haiku-4-5",
+}
+
+// bedrockNativeOutputFormatModels is the documented Amazon Bedrock subset.
+// Source: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#compatibility
+var bedrockNativeOutputFormatModels = []string{
+	"claude-opus-4-6", "claude-sonnet-4-6", "claude-sonnet-4-5",
+	"claude-opus-4-5", "claude-haiku-4-5",
+}
+
+// supportsNativeOutputFormat reports whether the model supports native
+// structured output. It consults the adapter-provided compatibility list when
+// set (Bedrock, Vertex, Azure, MiniMax), otherwise the direct-Anthropic list.
 func (m *chatModel) supportsNativeOutputFormat() bool {
-	major, minor, ok := anthropicModelVersion(m.id)
-	if !ok {
+	models := m.opts.nativeOutputFormatModels
+	if models == nil {
+		models = directNativeOutputFormatModels
+	}
+	return modelMatchesAny(m.id, models)
+}
+
+// modelMatchesAny reports whether modelID matches any base model name in
+// models, allowing documented release-date, @date, and -v suffixed aliases but
+// rejecting unknown future numeric families.
+func modelMatchesAny(modelID string, models []string) bool {
+	id := strings.ToLower(modelID)
+	for _, base := range models {
+		if modelIDMatches(id, base) {
+			return true
+		}
+	}
+	return false
+}
+
+func modelIDMatches(id, base string) bool {
+	idx := strings.Index(id, base)
+	if idx < 0 {
 		return false
 	}
-	if major >= 5 {
+	// The base must be a whole token: preceded by a separator ('.' for Bedrock
+	// prefixes like "anthropic.claude-opus-5") or the start of the string.
+	if idx > 0 {
+		prev := id[idx-1]
+		if prev != '.' && prev != '-' && prev != '/' && prev != ':' {
+			return false
+		}
+	}
+	suffix := id[idx+len(base):]
+	if suffix == "" {
 		return true
 	}
-	// Within the 4.x generation, 4.0 (which appears either bare or with a
-	// release-date suffix, so minor is 0) predates structured output.
-	return major == 4 && minor >= 1
+	// Vertex @date suffix or Bedrock -v versioned suffix.
+	if strings.HasPrefix(suffix, "@") || strings.HasPrefix(suffix, "-v") {
+		return true
+	}
+	// Release-date alias: claude-opus-4-5-20251101.
+	if len(suffix) == 9 && suffix[0] == '-' {
+		for i := 1; i < len(suffix); i++ {
+			if suffix[i] < '0' || suffix[i] > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // injectNativeOutputFormat stores the structured-output schema in
 // ProviderOptions["output_format"]; buildRequest nests it under
-// output_config.format on the wire.
-func injectNativeOutputFormat(params provider.GenerateParams) provider.GenerateParams {
+// output_config.format on the wire. It returns an error when the response
+// format schema is invalid or cannot be expressed for native structured
+// output, so the caller surfaces it rather than silently dropping the
+// requested output mode.
+func injectNativeOutputFormat(params provider.GenerateParams) (provider.GenerateParams, error) {
 	p := params
 	// Copy the map to avoid mutating the caller's ProviderOptions.
 	newOpts := maps.Clone(p.ProviderOptions)
@@ -853,14 +962,18 @@ func injectNativeOutputFormat(params provider.GenerateParams) provider.GenerateP
 	}
 	p.ProviderOptions = newOpts
 	if p.ResponseFormat == nil {
-		return params
+		return params, nil
 	}
 	var schema any
 	if len(p.ResponseFormat.Schema) > 0 {
 		if err := json.Unmarshal(p.ResponseFormat.Schema, &schema); err != nil {
-			return params // schema invalid, fall back to tool trick
+			return params, fmt.Errorf("anthropic: invalid response format schema: %w", err)
 		}
-		schema = stripNativeOutputKeywords(schema)
+		var err error
+		schema, err = transformNativeOutputSchema(schema)
+		if err != nil {
+			return params, fmt.Errorf("anthropic: invalid response format schema: %w", err)
+		}
 	}
 	p.ProviderOptions["output_format"] = map[string]any{
 		"type":   "json_schema",
@@ -868,106 +981,202 @@ func injectNativeOutputFormat(params provider.GenerateParams) provider.GenerateP
 	}
 	// Clear ResponseFormat so the tool trick is not also applied.
 	p.ResponseFormat = nil
-	return p
+	return p, nil
 }
 
-// nativeOutputUnsupportedKeywords lists the JSON Schema validation keywords
-// that Anthropic's native structured-output validator rejects outright, e.g.
-//
-//	output_config.format.schema: For 'number' type, properties maximum,
-//	minimum are not supported
-//
-// Per Anthropic's structured-output schema limitations these are the numeric
-// constraints, the string-length constraints, and the more complex array
-// constraints. Basic types, enum/const, anyOf/allOf, $ref/$defs, string
-// formats, and additionalProperties:false are all supported and are left
-// alone.
-//
-// Only the native output_config.format path needs this. The tool-trick path
-// sends the same schema as a tool's input_schema, where these keywords are
-// advisory (no strict:true) and therefore harmless — so a caller who stays on
-// the tool trick keeps full validation.
-var nativeOutputUnsupportedKeywords = map[string]bool{
-	"minimum":          true,
-	"maximum":          true,
-	"exclusiveMinimum": true,
-	"exclusiveMaximum": true,
-	"multipleOf":       true,
-	"minLength":        true,
-	"maxLength":        true,
-	"minItems":         true,
-	"maxItems":         true,
-	"uniqueItems":      true,
+// supportedNativeFormats lists the string formats Anthropic's native
+// structured-output validator accepts; any other format value is filtered out
+// (and recorded in the description).
+var supportedNativeFormats = map[string]bool{
+	"date-time": true, "time": true, "date": true, "duration": true,
+	"email": true, "hostname": true, "ipv4": true, "ipv6": true,
+	"uuid": true, "uri": true,
 }
 
-// schemaNameKeyedKeywords lists the keywords whose value is a map keyed by
-// *names* — data-model property names or definition names — rather than a
-// schema object. The keys inside them are caller-chosen identifiers, so they
-// must never be filtered as validation keywords: a response field legitimately
-// named "minimum" is not the numeric `minimum` constraint.
-var schemaNameKeyedKeywords = map[string]bool{
-	"properties":        true,
-	"patternProperties": true,
-	"dependentSchemas":  true,
-	"$defs":             true,
-	"definitions":       true,
-}
+// transformNativeOutputSchema mirrors Anthropic's documented SDK schema
+// transformation for native structured output: keep only the keywords the
+// validator supports for the schema's effective type, preserve unsupported
+// constraints in the description, and recurse only into actual subschemas.
+// Literal values (enum members, const, default) are cloned verbatim, never
+// walked as schemas. The input is never mutated.
+//
+// Source: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works
+func transformNativeOutputSchema(obj any) (any, error) {
+	m, ok := obj.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema must be an object")
+	}
+	remaining := maps.Clone(m)
+	out := make(map[string]any, len(m)+1)
 
-// stripNativeOutputKeywords walks an arbitrary schema value and removes every
-// keyword in nativeOutputUnsupportedKeywords wherever it appears in keyword
-// position, so a schema carrying constraints Anthropic does not support is
-// still usable with native structured output instead of failing the request.
-//
-// Filtering is position-aware. Inside a schemaNameKeyedKeywords map the keys
-// are data-model names, so only their values are sanitised; deleting them
-// would silently drop caller fields from the requested shape and could leave
-// `required` referencing a property that no longer exists. (The sibling
-// sanitiser in internal/gemini instead reconciles `required` against
-// `properties` after the fact; not deleting the properties in the first place
-// makes that unnecessary here.)
-//
-// The function does not mutate its input: new maps/slices are allocated for
-// every container so callers can safely reuse the original schema.
-func stripNativeOutputKeywords(obj any) any {
-	switch v := obj.(type) {
-	case map[string]any:
-		result := make(map[string]any, len(v))
-		for k, val := range v {
-			if nativeOutputUnsupportedKeywords[k] {
-				continue
-			}
-			if schemaNameKeyedKeywords[k] {
-				result[k] = stripNameKeyedMap(val)
-				continue
-			}
-			result[k] = stripNativeOutputKeywords(val)
+	if defs, ok := remaining["$defs"]; ok {
+		transformed, err := transformSchemaMap(defs)
+		if err != nil {
+			return nil, fmt.Errorf("$defs: %w", err)
 		}
-		return result
+		out["$defs"] = transformed
+		delete(remaining, "$defs")
+	}
+	if ref, ok := remaining["$ref"]; ok {
+		out["$ref"] = cloneJSONValue(ref)
+		return out, nil
+	}
+
+	typeName, _ := remaining["type"].(string)
+	delete(remaining, "type")
+	var composition string
+	for _, keyword := range []string{"anyOf", "oneOf", "allOf"} {
+		if _, ok := remaining[keyword].([]any); ok {
+			composition = keyword
+			break
+		}
+	}
+	if composition != "" {
+		transformed, err := transformSchemaList(remaining[composition])
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", composition, err)
+		}
+		if composition == "oneOf" {
+			// Anthropic does not support oneOf; express it as anyOf.
+			out["anyOf"] = transformed
+		} else {
+			out[composition] = transformed
+		}
+		delete(remaining, composition)
+	} else if typeName != "" {
+		out["type"] = typeName
+	} else {
+		return nil, fmt.Errorf("schema must have type, anyOf, oneOf, or allOf")
+	}
+
+	// Literal/annotation keywords are carried verbatim (never recursed).
+	for _, keyword := range []string{"enum", "const", "description", "title"} {
+		if value, ok := remaining[keyword]; ok {
+			out[keyword] = cloneJSONValue(value)
+			delete(remaining, keyword)
+		}
+	}
+
+	switch typeName {
+	case "object":
+		if properties, ok := remaining["properties"]; ok {
+			transformed, err := transformSchemaMap(properties)
+			if err != nil {
+				return nil, fmt.Errorf("properties: %w", err)
+			}
+			out["properties"] = transformed
+		} else {
+			out["properties"] = map[string]any{}
+		}
+		delete(remaining, "properties")
+		// Anthropic requires additionalProperties:false on objects.
+		delete(remaining, "additionalProperties")
+		out["additionalProperties"] = false
+		if required, ok := remaining["required"]; ok {
+			out["required"] = cloneJSONValue(required)
+			delete(remaining, "required")
+		}
+	case "array":
+		if items, ok := remaining["items"]; ok {
+			transformed, err := transformNativeOutputSchema(items)
+			if err != nil {
+				return nil, fmt.Errorf("items: %w", err)
+			}
+			out["items"] = transformed
+			delete(remaining, "items")
+		}
+		// Anthropic accepts minItems only as 0 or 1; anything else is
+		// unsupported and falls through to the description.
+		if minItems, ok := remaining["minItems"].(float64); ok && (minItems == 0 || minItems == 1) {
+			out["minItems"] = minItems
+			delete(remaining, "minItems")
+		}
+	case "string":
+		if format, ok := remaining["format"].(string); ok && supportedNativeFormats[format] {
+			out["format"] = format
+			delete(remaining, "format")
+		}
+	case "integer", "number", "boolean", "null", "":
+	default:
+		return nil, fmt.Errorf("unsupported schema type %q", typeName)
+	}
+
+	// Anything left (pattern, patternProperties, dependentSchemas, unsupported
+	// constraints, etc.) is not expressible as a native constraint; record it
+	// in the description so it is not silently dropped.
+	if len(remaining) > 0 {
+		extra := formatUnsupportedSchemaKeywords(remaining)
+		if description, _ := out["description"].(string); description != "" {
+			out["description"] = description + "\n\n" + extra
+		} else {
+			out["description"] = extra
+		}
+	}
+	return out, nil
+}
+
+func transformSchemaMap(value any) (any, error) {
+	m, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("must be an object")
+	}
+	out := make(map[string]any, len(m))
+	for name, schema := range m {
+		transformed, err := transformNativeOutputSchema(schema)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		out[name] = transformed
+	}
+	return out, nil
+}
+
+func transformSchemaList(value any) (any, error) {
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("must be an array")
+	}
+	out := make([]any, len(items))
+	for i, schema := range items {
+		transformed, err := transformNativeOutputSchema(schema)
+		if err != nil {
+			return nil, fmt.Errorf("item %d: %w", i, err)
+		}
+		out[i] = transformed
+	}
+	return out, nil
+}
+
+func formatUnsupportedSchemaKeywords(values map[string]any) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s: %v", key, values[key]))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+func cloneJSONValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, item := range v {
+			out[k] = cloneJSONValue(item)
+		}
+		return out
 	case []any:
 		out := make([]any, len(v))
 		for i, item := range v {
-			out[i] = stripNativeOutputKeywords(item)
+			out[i] = cloneJSONValue(item)
 		}
 		return out
 	default:
-		return obj
+		return value
 	}
-}
-
-// stripNameKeyedMap sanitises the values of a name-keyed map (the value of
-// "properties", "$defs", and friends) while preserving every key verbatim.
-// A non-map value is handed back to the ordinary walk, so a malformed schema
-// is passed through rather than mangled here.
-func stripNameKeyedMap(obj any) any {
-	m, ok := obj.(map[string]any)
-	if !ok {
-		return stripNativeOutputKeywords(obj)
-	}
-	result := make(map[string]any, len(m))
-	for name, sub := range m {
-		result[name] = stripNativeOutputKeywords(sub)
-	}
-	return result
 }
 
 const responseFormatToolName = "json_response"

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -784,7 +784,11 @@ func TestBuildRequest_NativeOutputFormat(t *testing.T) {
 	if !m.useNativeOutputFormat(params) {
 		t.Fatal("useNativeOutputFormat = false, want true for structuredOutputMode=outputFormat")
 	}
-	params = injectNativeOutputFormat(params)
+	var err error
+	params, err = injectNativeOutputFormat(params)
+	if err != nil {
+		t.Fatalf("injectNativeOutputFormat: %v", err)
+	}
 	body := m.buildRequest(params, false)
 
 	// The deprecated top-level field must not be present.
@@ -2561,7 +2565,10 @@ func TestInjectNativeOutputFormat_NilProviderOptions(t *testing.T) {
 			Schema: json.RawMessage(`{"type":"object"}`),
 		},
 	}
-	result := injectNativeOutputFormat(params)
+	result, err := injectNativeOutputFormat(params)
+	if err != nil {
+		t.Fatalf("injectNativeOutputFormat: %v", err)
+	}
 	if result.ProviderOptions == nil {
 		t.Fatal("expected ProviderOptions to be initialized")
 	}
@@ -2578,7 +2585,8 @@ func TestInjectNativeOutputFormat_NilProviderOptions(t *testing.T) {
 	}
 }
 
-// injectNativeOutputFormat with invalid schema bytes (covers unmarshal error fallback).
+// injectNativeOutputFormat with invalid schema bytes must surface an error
+// rather than silently dropping the requested output mode.
 func TestInjectNativeOutputFormat_InvalidSchema(t *testing.T) {
 	params := provider.GenerateParams{
 		ResponseFormat: &provider.ResponseFormat{
@@ -2586,8 +2594,11 @@ func TestInjectNativeOutputFormat_InvalidSchema(t *testing.T) {
 		},
 		ProviderOptions: map[string]any{"existing": "value"},
 	}
-	result := injectNativeOutputFormat(params)
-	// Should return original params unchanged (fall back to tool trick).
+	result, err := injectNativeOutputFormat(params)
+	if err == nil {
+		t.Fatal("expected an error for an invalid schema, got nil")
+	}
+	// ResponseFormat must not be cleared and output_format must not be set.
 	if result.ResponseFormat == nil {
 		t.Error("ResponseFormat should NOT be cleared when schema is invalid")
 	}
@@ -3241,7 +3252,10 @@ func TestInjectNativeOutputFormat_NilResponseFormat(t *testing.T) {
 	params := provider.GenerateParams{
 		ProviderOptions: map[string]any{"existing": "value"},
 	}
-	result := injectNativeOutputFormat(params)
+	result, err := injectNativeOutputFormat(params)
+	if err != nil {
+		t.Fatalf("injectNativeOutputFormat: %v", err)
+	}
 	// Should return the original params (not the copy with cloned ProviderOptions).
 	if result.ProviderOptions["existing"] != "value" {
 		t.Error("should preserve original ProviderOptions")
@@ -3958,14 +3972,12 @@ func TestSupportsNativeOutputFormat(t *testing.T) {
 		id   string
 		want bool
 	}{
-		// Previously matched by the literal list -- must not regress.
+		// Documented direct-Claude API compatibility set.
 		{"claude-sonnet-4-6", true},
 		{"claude-sonnet-4-6-20260310", true},
 		{"claude-opus-4-6", true},
 		{"claude-sonnet-4-5", true},
 		{"claude-opus-4-5", true},
-		{"claude-opus-4-1", true},
-		// Previously false despite supporting structured output.
 		{"claude-opus-4-7", true},
 		{"claude-opus-4-8", true},
 		{"claude-haiku-4-5-20251001", true},
@@ -3973,8 +3985,16 @@ func TestSupportsNativeOutputFormat(t *testing.T) {
 		{"claude-sonnet-5", true},
 		{"claude-fable-5", true},
 		{"claude-mythos-5", true},
-		{"anthropic.claude-opus-5", true},
+		{"claude-mythos-preview", true},
+		// Release-date and platform aliases.
 		{"claude-opus-4-5@20251101", true},
+		{"anthropic.claude-opus-5", true},
+		{"us.anthropic.claude-sonnet-4-6", true},
+		// Not on the documented list, despite a version >= 4.1.
+		{"claude-opus-4-1", false},
+		{"claude-opus-4-1-20250101", false},
+		{"claude-opus-4-9", false},
+		{"claude-opus-6", false},
 		// The 4.0 release predates structured output, bare or dated.
 		{"claude-sonnet-4-20250514", false},
 		{"claude-opus-4-20250514", false},
@@ -3993,7 +4013,46 @@ func TestSupportsNativeOutputFormat(t *testing.T) {
 	}
 }
 
-func TestStripNativeOutputKeywords(t *testing.T) {
+func TestSupportsNativeOutputFormat_Bedrock(t *testing.T) {
+	bedrock := &chatModel{id: "x", opts: options{nativeOutputFormatModels: bedrockNativeOutputFormatModels}}
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		// Documented Bedrock subset.
+		{"claude-opus-4-6", true},
+		{"anthropic.claude-opus-4-6", true},
+		{"claude-sonnet-4-6", true},
+		{"us.anthropic.claude-sonnet-4-6", true},
+		{"claude-sonnet-4-5", true},
+		{"claude-opus-4-5", true},
+		{"claude-haiku-4-5", true},
+		// Not in the Bedrock subset even though the direct API supports them.
+		{"claude-opus-5", false},
+		{"claude-sonnet-5", false},
+		{"claude-fable-5", false},
+		{"claude-mythos-preview", false},
+		{"claude-opus-4-7", false},
+		{"claude-opus-4-8", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			bedrock.id = tc.id
+			if got := bedrock.supportsNativeOutputFormat(); got != tc.want {
+				t.Errorf("bedrock supportsNativeOutputFormat(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSupportsNativeOutputFormat_Disabled(t *testing.T) {
+	m := &chatModel{id: "claude-opus-5", opts: options{nativeOutputFormatModels: []string{}}}
+	if m.supportsNativeOutputFormat() {
+		t.Error("native structured output must be disabled when the adapter opts out")
+	}
+}
+
+func TestTransformNativeOutputSchema(t *testing.T) {
 	in := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -4021,29 +4080,14 @@ func TestStripNativeOutputKeywords(t *testing.T) {
 		},
 	}
 
-	got, ok := stripNativeOutputKeywords(in).(map[string]any)
+	gotVal, err := transformNativeOutputSchema(in)
+	if err != nil {
+		t.Fatalf("transformNativeOutputSchema: %v", err)
+	}
+	got, ok := gotVal.(map[string]any)
 	if !ok {
-		t.Fatalf("stripNativeOutputKeywords returned %T, want map", got)
+		t.Fatalf("transformNativeOutputSchema returned %T, want map", gotVal)
 	}
-
-	// Every unsupported keyword must be gone, at every depth.
-	var walk func(any)
-	walk = func(node any) {
-		switch n := node.(type) {
-		case map[string]any:
-			for k, v := range n {
-				if nativeOutputUnsupportedKeywords[k] {
-					t.Errorf("unsupported keyword %q survived sanitisation", k)
-				}
-				walk(v)
-			}
-		case []any:
-			for _, v := range n {
-				walk(v)
-			}
-		}
-	}
-	walk(got)
 
 	// Supported constructs must survive untouched.
 	props := got["properties"].(map[string]any)
@@ -4065,12 +4109,74 @@ func TestStripNativeOutputKeywords(t *testing.T) {
 	if anyOf := props["either"].(map[string]any)["anyOf"].([]any); len(anyOf) != 2 {
 		t.Errorf("anyOf must survive: %#v", anyOf)
 	}
+	// minItems 0/1 is supported and must be preserved, not dropped.
+	if tags := props["tags"].(map[string]any); tags["minItems"] != float64(1) {
+		t.Errorf("minItems:1 must survive: %#v", tags)
+	}
+
+	// Unsupported constraints must not appear as schema keys, but must be
+	// recorded in a description rather than silently dropped.
+	collected := collectDescriptions(got)
+	for _, kw := range []string{"minimum", "maximum", "minLength", "uniqueItems", "multipleOf", "maxLength"} {
+		if keyPresent(got, kw) {
+			t.Errorf("unsupported keyword %q survived as a schema key", kw)
+		}
+		if !strings.Contains(collected, kw) {
+			t.Errorf("unsupported keyword %q not recorded in a description", kw)
+		}
+	}
 
 	// Input must not be mutated.
 	origConf := in["properties"].(map[string]any)["confidence"].(map[string]any)
 	if _, stillThere := origConf["minimum"]; !stillThere {
-		t.Error("stripNativeOutputKeywords mutated its input")
+		t.Error("transformNativeOutputSchema mutated its input")
 	}
+}
+
+// keyPresent reports whether the keyword appears as a schema key anywhere.
+func keyPresent(node any, keyword string) bool {
+	switch n := node.(type) {
+	case map[string]any:
+		if _, ok := n[keyword]; ok {
+			return true
+		}
+		for _, v := range n {
+			if keyPresent(v, keyword) {
+				return true
+			}
+		}
+	case []any:
+		for _, v := range n {
+			if keyPresent(v, keyword) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// collectDescriptions concatenates every "description" value in the schema.
+func collectDescriptions(node any) string {
+	var sb strings.Builder
+	var walk func(any)
+	walk = func(n any) {
+		switch v := n.(type) {
+		case map[string]any:
+			if d, ok := v["description"].(string); ok {
+				sb.WriteString(d)
+				sb.WriteString("\n")
+			}
+			for _, sub := range v {
+				walk(sub)
+			}
+		case []any:
+			for _, sub := range v {
+				walk(sub)
+			}
+		}
+	}
+	walk(node)
+	return sb.String()
 }
 
 func TestBuildRequest_NativeOutputFormat_SanitisesSchema(t *testing.T) {
@@ -4086,34 +4192,49 @@ func TestBuildRequest_NativeOutputFormat_SanitisesSchema(t *testing.T) {
 		ProviderOptions: map[string]any{"structuredOutputMode": "outputFormat"},
 	}
 
-	params = injectNativeOutputFormat(params)
+	var err error
+	params, err = injectNativeOutputFormat(params)
+	if err != nil {
+		t.Fatalf("injectNativeOutputFormat: %v", err)
+	}
 	body := m.buildRequest(params, false)
 
 	raw, err := json.Marshal(body["output_config"])
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, kw := range []string{"minimum", "maximum"} {
-		if strings.Contains(string(raw), `"`+kw+`"`) {
+	// The unsupported numeric constraints must not appear as schema keys.
+	for _, kw := range []string{`"minimum":`, `"maximum":`} {
+		if strings.Contains(string(raw), kw) {
 			t.Errorf("output_config still carries %q: %s", kw, raw)
 		}
 	}
-	// The schema itself must still be there and still be usable.
+	// The schema body and format type must still be present.
 	if !strings.Contains(string(raw), `"confidence"`) {
-		t.Errorf("sanitisation dropped the schema body: %s", raw)
+		t.Errorf("transformation dropped the schema body: %s", raw)
 	}
 	if !strings.Contains(string(raw), `"json_schema"`) {
 		t.Errorf("output_config.format.type lost: %s", raw)
 	}
 }
 
-// TestStripNativeOutputKeywords_PropertyNameCollision covers the case the
+func TestInjectNativeOutputFormat_InvalidSchema_Errors(t *testing.T) {
+	params := provider.GenerateParams{
+		ResponseFormat:  &provider.ResponseFormat{Schema: json.RawMessage(`{not json`)},
+		ProviderOptions: map[string]any{"structuredOutputMode": "outputFormat"},
+	}
+	if _, err := injectNativeOutputFormat(params); err == nil {
+		t.Error("expected an error for an invalid response format schema, got nil")
+	}
+}
+
+// TestTransformNativeOutputSchema_PropertyNameCollision covers the case the
 // first version of the sanitiser got wrong: a data-model field whose name
 // happens to match a constraint keyword must survive, because keys inside
 // "properties"/"$defs"/etc. are caller-chosen names, not validation keywords.
 // Deleting them silently changed the requested shape and could leave
 // "required" pointing at a property that no longer existed.
-func TestStripNativeOutputKeywords_PropertyNameCollision(t *testing.T) {
+func TestTransformNativeOutputSchema_PropertyNameCollision(t *testing.T) {
 	in := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -4133,7 +4254,11 @@ func TestStripNativeOutputKeywords_PropertyNameCollision(t *testing.T) {
 		},
 	}
 
-	got := stripNativeOutputKeywords(in).(map[string]any)
+	gotVal, err := transformNativeOutputSchema(in)
+	if err != nil {
+		t.Fatalf("transformNativeOutputSchema: %v", err)
+	}
+	got := gotVal.(map[string]any)
 
 	// Every property name survives.
 	props := got["properties"].(map[string]any)
@@ -4145,9 +4270,6 @@ func TestStripNativeOutputKeywords_PropertyNameCollision(t *testing.T) {
 	if _, ok := got["$defs"].(map[string]any)["multipleOf"]; !ok {
 		t.Error(`$defs entry "multipleOf" was deleted`)
 	}
-	if _, ok := got["patternProperties"].(map[string]any)["^minItems$"]; !ok {
-		t.Error(`patternProperties entry "^minItems$" was deleted`)
-	}
 
 	// required stays satisfiable: every name in it still exists in properties.
 	for _, r := range got["required"].([]any) {
@@ -4156,21 +4278,29 @@ func TestStripNativeOutputKeywords_PropertyNameCollision(t *testing.T) {
 		}
 	}
 
-	// Constraints in genuine keyword position are still stripped, including
-	// those nested inside the colliding properties and $defs.
-	if _, ok := props["minimum"].(map[string]any)["minimum"]; ok {
-		t.Error("constraint in keyword position inside a colliding property survived")
-	}
-	if _, ok := props["minLength"].(map[string]any)["minLength"]; ok {
-		t.Error("minLength constraint inside property named minLength survived")
+	// Constraints in genuine keyword position (siblings of "type") are not
+	// carried as keys; they are folded into a description. Note the property
+	// NAMES above legitimately collide with these keywords, so the check is
+	// scoped to each property's own schema, not the whole tree.
+	for _, name := range []string{"minimum", "maximum", "minLength"} {
+		if _, ok := props[name].(map[string]any)[name]; ok {
+			t.Errorf("constraint %q in keyword position inside property %q survived as a schema key", name, name)
+		}
 	}
 	if _, ok := got["$defs"].(map[string]any)["multipleOf"].(map[string]any)["maxLength"]; ok {
-		t.Error("maxLength constraint inside a $defs entry survived")
+		t.Error("maxLength constraint inside a $defs entry survived as a schema key")
 	}
-	if _, ok := got["patternProperties"].(map[string]any)["^minItems$"].(map[string]any)["minLength"]; ok {
-		t.Error("minLength constraint inside a patternProperties entry survived")
+	// patternProperties is not a supported construct; it is recorded in the
+	// description rather than preserved as a key.
+	if _, ok := got["patternProperties"]; ok {
+		t.Error("patternProperties must not survive as a schema key")
+	}
+	if !strings.Contains(collectDescriptions(got), "patternProperties") {
+		t.Error("patternProperties not recorded in a description")
 	}
 
 	// A malformed name-keyed value must not panic.
-	stripNativeOutputKeywords(map[string]any{"properties": "not-a-map"})
+	if _, err := transformNativeOutputSchema(map[string]any{"properties": "not-a-map"}); err == nil {
+		t.Error("expected an error for a non-object properties value")
+	}
 }

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -3872,3 +3872,305 @@ func TestDoGenerate_CacheTTLOnWire(t *testing.T) {
 		t.Errorf("anthropic-beta = %q, want %q (1h TTL is GA)", betaHeader, betaFeatures)
 	}
 }
+
+func TestAnthropicModelVersion(t *testing.T) {
+	cases := []struct {
+		id    string
+		major int
+		minor int
+		ok    bool
+	}{
+		// Current naming, with and without a release-date suffix.
+		{"claude-opus-4-7", 4, 7, true},
+		{"claude-opus-4-7-20260101", 4, 7, true},
+		{"claude-sonnet-4-6-20260310", 4, 6, true},
+		{"claude-haiku-4-5-20251001", 4, 5, true},
+		{"claude-opus-5", 5, 0, true},
+		{"claude-fable-5", 5, 0, true},
+		{"claude-mythos-5", 5, 0, true},
+		{"claude-opus-5-1", 5, 1, true},
+		// Multi-digit minor versions.
+		{"claude-sonnet-4-10", 4, 10, true},
+		// A trailing 8-digit run is a release date, not a minor version.
+		{"claude-sonnet-4-20250514", 4, 0, true},
+		{"claude-opus-4-20250514", 4, 0, true},
+		// Bedrock reuses this provider with a prefixed id.
+		{"anthropic.claude-opus-5", 5, 0, true},
+		{"us.anthropic.claude-sonnet-4-6", 4, 6, true},
+		// Vertex appends an @date suffix.
+		{"claude-opus-4-5@20251101", 4, 5, true},
+		// Legacy family-last naming carries no parseable version.
+		{"claude-3-7-sonnet", 0, 0, false},
+		{"claude-3-5-sonnet-20241022", 0, 0, false},
+		{"anthropic.claude-3-5-sonnet-20241022-v2:0", 0, 0, false},
+		{"not-a-claude-model", 0, 0, false},
+		{"", 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			major, minor, ok := anthropicModelVersion(tc.id)
+			if ok != tc.ok || major != tc.major || minor != tc.minor {
+				t.Errorf("anthropicModelVersion(%q) = (%d, %d, %v), want (%d, %d, %v)",
+					tc.id, major, minor, ok, tc.major, tc.minor, tc.ok)
+			}
+		})
+	}
+}
+
+func TestSupportsThinking(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		// Previously matched by the literal list -- must not regress.
+		{"claude-3-7-sonnet", true},
+		{"claude-3-7-sonnet-20250219", true},
+		{"claude-sonnet-4-20250514", true},
+		{"claude-opus-4-20250514", true},
+		{"claude-sonnet-4-6", true},
+		{"claude-opus-4-6", true},
+		{"claude-opus-4-5", true},
+		// Previously false despite supporting thinking.
+		{"claude-haiku-4-5-20251001", true},
+		{"claude-opus-4-7", true},
+		{"claude-opus-4-8", true},
+		{"claude-opus-5", true},
+		{"claude-sonnet-5", true},
+		{"claude-fable-5", true},
+		{"claude-mythos-5", true},
+		{"anthropic.claude-opus-5", true},
+		// Pre-4 models have no thinking support.
+		{"claude-3-5-sonnet-20241022", false},
+		{"claude-3-haiku-20240307", false},
+		{"not-a-claude-model", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			if got := supportsThinking(tc.id); got != tc.want {
+				t.Errorf("supportsThinking(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSupportsNativeOutputFormat(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		// Previously matched by the literal list -- must not regress.
+		{"claude-sonnet-4-6", true},
+		{"claude-sonnet-4-6-20260310", true},
+		{"claude-opus-4-6", true},
+		{"claude-sonnet-4-5", true},
+		{"claude-opus-4-5", true},
+		{"claude-opus-4-1", true},
+		// Previously false despite supporting structured output.
+		{"claude-opus-4-7", true},
+		{"claude-opus-4-8", true},
+		{"claude-haiku-4-5-20251001", true},
+		{"claude-opus-5", true},
+		{"claude-sonnet-5", true},
+		{"claude-fable-5", true},
+		{"claude-mythos-5", true},
+		{"anthropic.claude-opus-5", true},
+		{"claude-opus-4-5@20251101", true},
+		// The 4.0 release predates structured output, bare or dated.
+		{"claude-sonnet-4-20250514", false},
+		{"claude-opus-4-20250514", false},
+		// Legacy family-last naming.
+		{"claude-3-5-sonnet-20241022", false},
+		{"claude-3-7-sonnet", false},
+		{"not-a-claude-model", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			m := &chatModel{id: tc.id}
+			if got := m.supportsNativeOutputFormat(); got != tc.want {
+				t.Errorf("supportsNativeOutputFormat(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripNativeOutputKeywords(t *testing.T) {
+	in := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"confidence"},
+		"properties": map[string]any{
+			"confidence": map[string]any{
+				"type": "number", "minimum": 0.0, "maximum": 1.0,
+			},
+			"scenario": map[string]any{
+				"type": "string", "minLength": 1.0, "format": "uuid",
+			},
+			"severity": map[string]any{
+				"type": "string", "enum": []any{"high", "low"},
+			},
+			"tags": map[string]any{
+				"type": "array", "minItems": 1.0, "uniqueItems": true,
+				"items": map[string]any{"type": "string", "maxLength": 8.0},
+			},
+			"either": map[string]any{
+				"anyOf": []any{
+					map[string]any{"type": "integer", "multipleOf": 2.0},
+					map[string]any{"type": "null"},
+				},
+			},
+		},
+	}
+
+	got, ok := stripNativeOutputKeywords(in).(map[string]any)
+	if !ok {
+		t.Fatalf("stripNativeOutputKeywords returned %T, want map", got)
+	}
+
+	// Every unsupported keyword must be gone, at every depth.
+	var walk func(any)
+	walk = func(node any) {
+		switch n := node.(type) {
+		case map[string]any:
+			for k, v := range n {
+				if nativeOutputUnsupportedKeywords[k] {
+					t.Errorf("unsupported keyword %q survived sanitisation", k)
+				}
+				walk(v)
+			}
+		case []any:
+			for _, v := range n {
+				walk(v)
+			}
+		}
+	}
+	walk(got)
+
+	// Supported constructs must survive untouched.
+	props := got["properties"].(map[string]any)
+	if props["confidence"].(map[string]any)["type"] != "number" {
+		t.Errorf("confidence type lost: %#v", props["confidence"])
+	}
+	if props["scenario"].(map[string]any)["format"] != "uuid" {
+		t.Errorf("string format must survive: %#v", props["scenario"])
+	}
+	if enum := props["severity"].(map[string]any)["enum"].([]any); len(enum) != 2 {
+		t.Errorf("enum must survive: %#v", enum)
+	}
+	if got["additionalProperties"] != false {
+		t.Errorf("additionalProperties:false must survive: %#v", got["additionalProperties"])
+	}
+	if req := got["required"].([]any); len(req) != 1 || req[0] != "confidence" {
+		t.Errorf("required must survive: %#v", req)
+	}
+	if anyOf := props["either"].(map[string]any)["anyOf"].([]any); len(anyOf) != 2 {
+		t.Errorf("anyOf must survive: %#v", anyOf)
+	}
+
+	// Input must not be mutated.
+	origConf := in["properties"].(map[string]any)["confidence"].(map[string]any)
+	if _, stillThere := origConf["minimum"]; !stillThere {
+		t.Error("stripNativeOutputKeywords mutated its input")
+	}
+}
+
+func TestBuildRequest_NativeOutputFormat_SanitisesSchema(t *testing.T) {
+	m := &chatModel{id: "claude-opus-5", opts: options{baseURL: defaultBaseURL}}
+
+	// A constrained schema of exactly the shape the API rejects.
+	schema := json.RawMessage(`{"type":"object","additionalProperties":false,` +
+		`"properties":{"confidence":{"type":"number","minimum":0,"maximum":1}},` +
+		`"required":["confidence"]}`)
+	params := provider.GenerateParams{
+		Messages:        []provider.Message{{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}}},
+		ResponseFormat:  &provider.ResponseFormat{Schema: schema},
+		ProviderOptions: map[string]any{"structuredOutputMode": "outputFormat"},
+	}
+
+	params = injectNativeOutputFormat(params)
+	body := m.buildRequest(params, false)
+
+	raw, err := json.Marshal(body["output_config"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kw := range []string{"minimum", "maximum"} {
+		if strings.Contains(string(raw), `"`+kw+`"`) {
+			t.Errorf("output_config still carries %q: %s", kw, raw)
+		}
+	}
+	// The schema itself must still be there and still be usable.
+	if !strings.Contains(string(raw), `"confidence"`) {
+		t.Errorf("sanitisation dropped the schema body: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"json_schema"`) {
+		t.Errorf("output_config.format.type lost: %s", raw)
+	}
+}
+
+// TestStripNativeOutputKeywords_PropertyNameCollision covers the case the
+// first version of the sanitiser got wrong: a data-model field whose name
+// happens to match a constraint keyword must survive, because keys inside
+// "properties"/"$defs"/etc. are caller-chosen names, not validation keywords.
+// Deleting them silently changed the requested shape and could leave
+// "required" pointing at a property that no longer existed.
+func TestStripNativeOutputKeywords_PropertyNameCollision(t *testing.T) {
+	in := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"minimum", "maximum", "uniqueItems"},
+		"properties": map[string]any{
+			// Field names colliding with every stripped keyword.
+			"minimum":     map[string]any{"type": "number", "minimum": 0.0},
+			"maximum":     map[string]any{"type": "number", "maximum": 1.0},
+			"uniqueItems": map[string]any{"type": "boolean"},
+			"minLength":   map[string]any{"type": "integer", "minLength": 3.0},
+		},
+		"$defs": map[string]any{
+			"multipleOf": map[string]any{"type": "string", "maxLength": 4.0},
+		},
+		"patternProperties": map[string]any{
+			"^minItems$": map[string]any{"type": "string", "minLength": 1.0},
+		},
+	}
+
+	got := stripNativeOutputKeywords(in).(map[string]any)
+
+	// Every property name survives.
+	props := got["properties"].(map[string]any)
+	for _, name := range []string{"minimum", "maximum", "uniqueItems", "minLength"} {
+		if _, ok := props[name]; !ok {
+			t.Errorf("property %q was deleted; keys inside properties are names, not keywords", name)
+		}
+	}
+	if _, ok := got["$defs"].(map[string]any)["multipleOf"]; !ok {
+		t.Error(`$defs entry "multipleOf" was deleted`)
+	}
+	if _, ok := got["patternProperties"].(map[string]any)["^minItems$"]; !ok {
+		t.Error(`patternProperties entry "^minItems$" was deleted`)
+	}
+
+	// required stays satisfiable: every name in it still exists in properties.
+	for _, r := range got["required"].([]any) {
+		if _, ok := props[r.(string)]; !ok {
+			t.Errorf("required references %q which is no longer in properties", r)
+		}
+	}
+
+	// Constraints in genuine keyword position are still stripped, including
+	// those nested inside the colliding properties and $defs.
+	if _, ok := props["minimum"].(map[string]any)["minimum"]; ok {
+		t.Error("constraint in keyword position inside a colliding property survived")
+	}
+	if _, ok := props["minLength"].(map[string]any)["minLength"]; ok {
+		t.Error("minLength constraint inside property named minLength survived")
+	}
+	if _, ok := got["$defs"].(map[string]any)["multipleOf"].(map[string]any)["maxLength"]; ok {
+		t.Error("maxLength constraint inside a $defs entry survived")
+	}
+	if _, ok := got["patternProperties"].(map[string]any)["^minItems$"].(map[string]any)["minLength"]; ok {
+		t.Error("minLength constraint inside a patternProperties entry survived")
+	}
+
+	// A malformed name-keyed value must not panic.
+	stripNativeOutputKeywords(map[string]any{"properties": "not-a-map"})
+}

--- a/provider/bedrock/anthropic.go
+++ b/provider/bedrock/anthropic.go
@@ -81,6 +81,9 @@ func AnthropicChat(modelID string, opts ...Option) provider.LanguageModel {
 		anthropic.WithErrorProvider("bedrock-anthropic"),
 		anthropic.WithHTTPClient(signing),
 		anthropic.WithSkipEnvResolve(),
+		// Bedrock documents a narrower structured-output set than the direct
+		// Claude API (Opus 4.6, Sonnet 4.6, Sonnet 4.5, Opus 4.5, Haiku 4.5).
+		anthropic.WithNativeOutputFormatSupport(anthropic.NativeOutputFormatBedrock),
 	}
 	// Provide a placeholder token source so the anthropic provider's auth
 	// resolution is satisfied. The transport below replaces the request's

--- a/provider/minimax/minimax.go
+++ b/provider/minimax/minimax.go
@@ -100,6 +100,10 @@ func Chat(modelID string, opts ...Option) provider.LanguageModel {
 	if len(o.headers) > 0 {
 		anthropicOpts = append(anthropicOpts, anthropic.WithHeaders(o.headers))
 	}
+	// MiniMax does not document support for Anthropic's native
+	// output_config.format, so native structured output stays disabled and the
+	// tool-trick path is used instead.
+	anthropicOpts = append(anthropicOpts, anthropic.WithNativeOutputFormatSupport(anthropic.NativeOutputFormatDisabled))
 
 	return &chatModel{
 		inner: anthropic.Chat(modelID, anthropicOpts...),


### PR DESCRIPTION
## Summary

Replaces `supportsThinking`'s and `supportsNativeOutputFormat`'s hardcoded model-id substring lists with a shared `anthropicModelVersion` helper that parses major/minor generation out of the id, expressing each capability as a version range (thinking: Claude 4+ plus legacy `claude-3-7-sonnet`; native structured output: 4.1+). Also sanitises schemas on the native path, since native `output_config.format` rejects several JSON Schema keywords (`minimum`, `maximum`, etc.) that the tool-trick's advisory `input_schema` tolerates — widening the capability check alone would trade one breakage for another.

## Changes

- `anthropicModelVersion`: unanchored version parser, handling Bedrock (`anthropic.claude-opus-5`, `us.anthropic.claude-sonnet-4-6`) and Vertex (`@date` suffix) id shapes, and distinguishing a minor version from a release-date suffix (`claude-sonnet-4-20250514` is 4.0, not minor `20250514`).
- `stripNativeOutputKeywords` / `stripNameKeyedMap`: recursive, non-mutating schema sanitiser applied only on the native output path.
- Legacy family-last ids (`claude-3-5-sonnet-20241022`) remain unversioned, preserving current behaviour.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (pre-existing `errcheck` findings in `anthropic_test.go:3417/3445/3478` predate this change, unrelated to it)
- [x] New tests added for new functionality (version parser table, both predicates, sanitiser keyword removal/survival/non-mutation, buildRequest-level constrained-schema assertion)
- [ ] Examples updated if public API changed — no public API change

## Related issues

Closes #162