### PR TITLE
fix(anthropic): stream long-running DoGenerate requests

### DIFF
--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -102,6 +102,12 @@ type options struct {
 	// disables native structured output entirely. Platform adapters set this
 	// to their own documented compatibility set.
 	nativeOutputFormatModels []string
+
+	// autoStreaming enables DoGenerate to transparently issue stream:true and
+	// reassemble the response for long-running (thinking) requests. Enabled by
+	// default for the direct API; adapters whose streaming endpoint needs
+	// extra permissions (Bedrock's InvokeModelWithResponseStream) opt out.
+	autoStreaming bool
 }
 
 // WithAPIKey sets a static API key for authentication.
@@ -211,9 +217,20 @@ func WithNativeOutputFormatSupport(support NativeOutputFormatSupport) Option {
 	}
 }
 
+// WithAutoStreaming controls whether DoGenerate transparently issues stream:true
+// and reassembles the response for long-running (thinking) requests. Enabled by
+// default for the direct API. Adapters whose streaming endpoint needs extra
+// permissions (Bedrock's InvokeModelWithResponseStream) disable it so existing
+// deployments do not regress by default.
+func WithAutoStreaming(enabled bool) Option {
+	return func(o *options) {
+		o.autoStreaming = enabled
+	}
+}
+
 // Chat creates an Anthropic language model for the given model ID.
 func Chat(modelID string, opts ...Option) provider.LanguageModel {
-	o := options{baseURL: defaultBaseURL}
+	o := options{baseURL: defaultBaseURL, autoStreaming: true}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -344,7 +361,10 @@ func (m *chatModel) DoGenerate(ctx context.Context, params provider.GeneratePara
 	// into the same Message document a non-streaming call would have
 	// returned. Transport only — the result is indistinguishable to the
 	// caller. See useStreamingTransport.
-	streaming := m.useStreamingTransport(params)
+	streaming, err := m.useStreamingTransport(params)
+	if err != nil {
+		return nil, err
+	}
 	body := m.buildRequest(params, streaming)
 	toolBetas := collectToolBetas(params.Tools)
 	if hasRemoteRef(params.Messages) {
@@ -977,12 +997,20 @@ func modelIDMatches(id, base string) bool {
 // the guidance warns against.
 //
 // Callers can force the decision either way with
-// ProviderOptions["streamingTransport"] = true / false.
-func (m *chatModel) useStreamingTransport(params provider.GenerateParams) bool {
-	if v, ok := params.ProviderOptions["streamingTransport"].(bool); ok {
-		return v
+// ProviderOptions["streamingTransport"] = true / false. A non-boolean value
+// is rejected rather than silently ignored.
+func (m *chatModel) useStreamingTransport(params provider.GenerateParams) (bool, error) {
+	if v, ok := params.ProviderOptions["streamingTransport"]; ok {
+		b, isBool := v.(bool)
+		if !isBool {
+			return false, fmt.Errorf("anthropic: streamingTransport must be a boolean, got %T", v)
+		}
+		return b, nil
 	}
-	return m.willThink(params)
+	if !m.opts.autoStreaming {
+		return false, nil
+	}
+	return m.willThink(params), nil
 }
 
 // willThink reports whether a request is expected to produce thinking, and
@@ -1725,6 +1753,10 @@ func isServerToolResultBlock(t string) bool {
 // An "error" event is returned as-is: parseResponse already recognises the
 // {"type":"error"} envelope and converts it to an APIError or
 // ContextOverflowError, so error classification stays in one place too.
+// maxStreamedContentBlocks bounds the number of content blocks a reassembled
+// stream may contain, so a hostile index cannot force unbounded allocation.
+const maxStreamedContentBlocks = 500
+
 func accumulateStreamedMessage(ctx context.Context, body io.Reader) ([]byte, error) {
 	scanner := sse.NewScanner(body)
 
@@ -1735,55 +1767,92 @@ func accumulateStreamedMessage(ctx context.Context, body io.Reader) ([]byte, err
 	// only valid JSON once concatenated, so they are buffered until
 	// content_block_stop.
 	toolInput := map[int]*strings.Builder{}
+	// Lifecycle tracking: message_start must precede every other event,
+	// message_stop must terminate a well-formed stream, and every started
+	// content block must be stopped before the stream ends. Violations are
+	// protocol errors, never partial successes.
+	messageStarted := false
+	messageStopped := false
+	openBlocks := map[int]bool{}
 
 	blockAt := func(idx int) map[string]any {
-		if idx < 0 {
-			idx = 0
-		}
 		for len(content) <= idx {
 			content = append(content, map[string]any{})
 		}
 		return content[idx]
 	}
 
-	for data, ok := scanner.Next(); ok; data, ok = scanner.Next() {
+	for {
+		ev, ok := scanner.NextEvent()
+		if !ok {
+			break
+		}
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-
+		// Bedrock emits event:error with AWS exception payloads that carry no
+		// Anthropic "type" field. Surface it as a protocol error rather than
+		// letting it fall through to a partial success.
+		if ev.Type == "error" {
+			return nil, fmt.Errorf("anthropic: stream error event: %s", string(ev.Data))
+		}
 		var event map[string]any
-		if err := json.Unmarshal([]byte(data), &event); err != nil {
-			// Matches parseSSE: a frame we cannot parse is skipped rather
-			// than failing the whole response.
-			continue
+		if err := json.Unmarshal(ev.Data, &event); err != nil {
+			return nil, fmt.Errorf("anthropic: malformed stream event: %w", err)
 		}
 
 		switch eventType, _ := event["type"].(string); eventType {
 		case "message_start":
-			if msg, ok := event["message"].(map[string]any); ok {
-				message = msg
-				// content arrives as separate events; rebuild it from those
-				// rather than trusting the (empty) array in the envelope.
-				if existing, ok := msg["content"].([]any); ok {
-					for _, b := range existing {
-						if bm, ok := b.(map[string]any); ok {
-							content = append(content, bm)
-						}
+			if messageStarted {
+				return nil, fmt.Errorf("anthropic: duplicate message_start")
+			}
+			messageStarted = true
+			msg, ok := event["message"].(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("anthropic: message_start missing message")
+			}
+			message = msg
+			// content arrives as separate events; rebuild it from those rather
+			// than trusting the (usually empty) array in the envelope.
+			if existing, ok := msg["content"].([]any); ok {
+				for _, b := range existing {
+					if bm, ok := b.(map[string]any); ok {
+						content = append(content, bm)
+						openBlocks[len(content)-1] = true
 					}
 				}
 			}
 
 		case "content_block_start":
-			idx := eventIndex(event)
+			if !messageStarted {
+				return nil, fmt.Errorf("anthropic: content_block_start before message_start")
+			}
+			idx, err := streamEventIndex(event)
+			if err != nil {
+				return nil, err
+			}
+			if openBlocks[idx] {
+				return nil, fmt.Errorf("anthropic: duplicate content_block_start at index %d", idx)
+			}
 			block, _ := event["content_block"].(map[string]any)
 			if block == nil {
 				block = map[string]any{}
 			}
 			blockAt(idx)
 			content[idx] = block
+			openBlocks[idx] = true
 
 		case "content_block_delta":
-			idx := eventIndex(event)
+			if !messageStarted {
+				return nil, fmt.Errorf("anthropic: content_block_delta before message_start")
+			}
+			idx, err := streamEventIndex(event)
+			if err != nil {
+				return nil, err
+			}
+			if !openBlocks[idx] {
+				return nil, fmt.Errorf("anthropic: content_block_delta for unopened block %d", idx)
+			}
 			delta, _ := event["delta"].(map[string]any)
 			if delta == nil {
 				continue
@@ -1813,23 +1882,33 @@ func accumulateStreamedMessage(ctx context.Context, body io.Reader) ([]byte, err
 			}
 
 		case "content_block_stop":
-			idx := eventIndex(event)
+			if !messageStarted {
+				return nil, fmt.Errorf("anthropic: content_block_stop before message_start")
+			}
+			idx, err := streamEventIndex(event)
+			if err != nil {
+				return nil, err
+			}
+			if !openBlocks[idx] {
+				return nil, fmt.Errorf("anthropic: content_block_stop for unopened block %d", idx)
+			}
+			delete(openBlocks, idx)
 			sb := toolInput[idx]
+			delete(toolInput, idx)
 			if sb == nil {
 				continue
 			}
-			delete(toolInput, idx)
 			var input any
-			if err := json.Unmarshal([]byte(cmp.Or(sb.String(), "{}")), &input); err == nil {
-				blockAt(idx)["input"] = input
+			if err := json.Unmarshal([]byte(cmp.Or(sb.String(), "{}")), &input); err != nil {
+				// Fragments that never form valid JSON are a malformed stream;
+				// do not report a partial tool call as success.
+				return nil, fmt.Errorf("anthropic: unparseable tool input for block %d: %w", idx, err)
 			}
-			// A fragment set that does not parse leaves the block's original
-			// input in place, mirroring parseSSE's "{}" fallback rather than
-			// failing the response.
+			blockAt(idx)["input"] = input
 
 		case "message_delta":
-			if message == nil {
-				continue
+			if !messageStarted {
+				return nil, fmt.Errorf("anthropic: message_delta before message_start")
 			}
 			// stop_reason, stop_sequence and container all arrive inside
 			// delta, at the same position they occupy in a complete Message.
@@ -1855,23 +1934,32 @@ func accumulateStreamedMessage(ctx context.Context, body io.Reader) ([]byte, err
 				message["context_management"] = cm
 			}
 
+		case "message_stop":
+			if !messageStarted {
+				return nil, fmt.Errorf("anthropic: message_stop before message_start")
+			}
+			messageStopped = true
+
 		case "error":
-			return []byte(data), nil
+			// Anthropic error envelope; hand it to parseResponse unchanged so
+			// error classification stays in one place.
+			return ev.Data, nil
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("reading stream: %w", err)
 	}
-	if message == nil {
-		// No message_start: either an empty body or a stream that failed
-		// before the envelope arrived.
+	if !messageStarted {
 		return nil, &goai.APIError{Message: "anthropic: stream ended before message_start"}
 	}
+	if !messageStopped {
+		return nil, fmt.Errorf("anthropic: stream ended before message_stop")
+	}
+	if len(openBlocks) > 0 {
+		return nil, fmt.Errorf("anthropic: stream ended with %d unclosed content block(s)", len(openBlocks))
+	}
 
-	// A stream truncated after message_start still yields whatever content
-	// arrived; parseResponse maps the absent stop_reason to FinishOther,
-	// which is more useful to a caller than discarding the response.
 	message["content"] = content
 	out, err := json.Marshal(message)
 	if err != nil {
@@ -1880,15 +1968,23 @@ func accumulateStreamedMessage(ctx context.Context, body io.Reader) ([]byte, err
 	return out, nil
 }
 
-// eventIndex reads an SSE event's content block index. A missing or
-// non-numeric index is treated as 0, which is the only block a stream
-// omitting the field could be describing.
-func eventIndex(event map[string]any) int {
-	idx, _ := event["index"].(float64)
-	if idx < 0 {
-		return 0
+// streamEventIndex reads and validates an SSE event's content block index. A
+// missing index is treated as 0. Negative, fractional, overflowing, or
+// over-limit indexes are rejected as protocol errors so a hostile index cannot
+// force unbounded allocation.
+func streamEventIndex(event map[string]any) (int, error) {
+	v, ok := event["index"]
+	if !ok {
+		return 0, nil
 	}
-	return int(idx)
+	f, ok := v.(float64)
+	if !ok {
+		return 0, fmt.Errorf("anthropic: content block index is not a number: %T", v)
+	}
+	if f != float64(int(f)) || f < 0 || f > maxStreamedContentBlocks {
+		return 0, fmt.Errorf("anthropic: invalid content block index %v", f)
+	}
+	return int(f), nil
 }
 
 // appendStringField concatenates a streamed delta onto a content block field,

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -63,7 +63,7 @@ var anthropicProtectedKeys = map[string]bool{
 	"tools": true, "tool_choice": true,
 	// SDK-internal keys that are never sent on the wire.
 	"structuredOutputMode": true, "sendReasoning": true,
-	"cacheControl": true,
+	"cacheControl": true, "streamingTransport": true,
 }
 
 // Option configures the Anthropic provider.
@@ -340,7 +340,12 @@ func (m *chatModel) DoGenerate(ctx context.Context, params provider.GeneratePara
 			return nil, err
 		}
 	}
-	body := m.buildRequest(params, false)
+	// Long-running requests are issued with stream:true and reassembled
+	// into the same Message document a non-streaming call would have
+	// returned. Transport only — the result is indistinguishable to the
+	// caller. See useStreamingTransport.
+	streaming := m.useStreamingTransport(params)
+	body := m.buildRequest(params, streaming)
 	toolBetas := collectToolBetas(params.Tools)
 	if hasRemoteRef(params.Messages) {
 		toolBetas = append(toolBetas, filesBetaHeader)
@@ -352,7 +357,12 @@ func (m *chatModel) DoGenerate(ctx context.Context, params provider.GeneratePara
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	var respBody []byte
+	if streaming {
+		respBody, err = accumulateStreamedMessage(ctx, resp.Body)
+	} else {
+		respBody, err = io.ReadAll(resp.Body)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("reading response: %w", err)
 	}
@@ -945,6 +955,56 @@ func modelIDMatches(id, base string) bool {
 		return true
 	}
 	return false
+}
+
+// useStreamingTransport reports whether DoGenerate should issue its request
+// with stream:true and reassemble the streamed events into a complete
+// Message, instead of waiting on a single non-streaming response.
+//
+// Anthropic's guidance is to stream long-running requests. A non-streaming
+// call holds an HTTP response open with no bytes flowing until the model has
+// finished everything it intends to do, so a request that thinks for minutes
+// is exposed to idle-timeout enforcement — by the client, and by any proxy
+// or load balancer in between. Thinking is where that bites, and since the
+// 5.x generation thinks with no thinking parameter sent at all, it is the
+// common case rather than an opt-in one.
+//
+// This matters most in a tool loop. GenerateObject is the only structured-
+// output entry point that runs tools (StreamObject is single-step by
+// design), and it drives every step through DoGenerate — so before this,
+// native structured output plus tools plus a thinking model was reachable
+// only over the non-streaming transport, which is exactly the combination
+// the guidance warns against.
+//
+// Callers can force the decision either way with
+// ProviderOptions["streamingTransport"] = true / false.
+func (m *chatModel) useStreamingTransport(params provider.GenerateParams) bool {
+	if v, ok := params.ProviderOptions["streamingTransport"].(bool); ok {
+		return v
+	}
+	return m.willThink(params)
+}
+
+// willThink reports whether a request is expected to produce thinking, and
+// therefore to run long.
+//
+// Two ways that happens: the caller asked for it (a "thinking" or "effort"
+// provider option), or the model thinks by default with no thinking
+// parameter sent — true from the 5.x generation onward. Opus 4.7/4.8 support
+// adaptive thinking but only when it is requested, so they qualify via the
+// first branch only.
+func (m *chatModel) willThink(params provider.GenerateParams) bool {
+	if !supportsThinking(m.id) {
+		return false
+	}
+	if _, ok := params.ProviderOptions["thinking"]; ok {
+		return true
+	}
+	if _, ok := params.ProviderOptions["effort"]; ok {
+		return true
+	}
+	major, _, ok := anthropicModelVersion(m.id)
+	return ok && major >= 5
 }
 
 // injectNativeOutputFormat stores the structured-output schema in
@@ -1646,6 +1706,200 @@ var serverToolResultBlockTypes = map[string]bool{
 
 func isServerToolResultBlock(t string) bool {
 	return serverToolResultBlockTypes[t]
+}
+
+// accumulateStreamedMessage reads Anthropic's SSE event stream and
+// reassembles the single Message object those events describe, returning the
+// JSON bytes as though the request had been issued non-streaming.
+//
+// Rebuilding the wire document, rather than mapping events onto
+// provider.GenerateResult directly, is the deliberate part. parseResponse is
+// the one place that knows how to interpret a Message, and it reads several
+// things provider.StreamChunk has no field for: thinking-block signatures
+// (which must be replayed verbatim on the next turn), redacted_thinking
+// payloads, server tool result blocks, citations, and container /
+// context_management metadata. Reassembling the document keeps DoGenerate's
+// two transports identical in everything but transport; mapping events would
+// fork that logic and silently drop whatever a chunk cannot carry.
+//
+// An "error" event is returned as-is: parseResponse already recognises the
+// {"type":"error"} envelope and converts it to an APIError or
+// ContextOverflowError, so error classification stays in one place too.
+func accumulateStreamedMessage(ctx context.Context, body io.Reader) ([]byte, error) {
+	scanner := sse.NewScanner(body)
+
+	var message map[string]any
+	var content []map[string]any
+	// Anthropic sends tool input as a JSON string split across
+	// input_json_delta fragments, keyed by content block index. Fragments are
+	// only valid JSON once concatenated, so they are buffered until
+	// content_block_stop.
+	toolInput := map[int]*strings.Builder{}
+
+	blockAt := func(idx int) map[string]any {
+		if idx < 0 {
+			idx = 0
+		}
+		for len(content) <= idx {
+			content = append(content, map[string]any{})
+		}
+		return content[idx]
+	}
+
+	for data, ok := scanner.Next(); ok; data, ok = scanner.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		var event map[string]any
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			// Matches parseSSE: a frame we cannot parse is skipped rather
+			// than failing the whole response.
+			continue
+		}
+
+		switch eventType, _ := event["type"].(string); eventType {
+		case "message_start":
+			if msg, ok := event["message"].(map[string]any); ok {
+				message = msg
+				// content arrives as separate events; rebuild it from those
+				// rather than trusting the (empty) array in the envelope.
+				if existing, ok := msg["content"].([]any); ok {
+					for _, b := range existing {
+						if bm, ok := b.(map[string]any); ok {
+							content = append(content, bm)
+						}
+					}
+				}
+			}
+
+		case "content_block_start":
+			idx := eventIndex(event)
+			block, _ := event["content_block"].(map[string]any)
+			if block == nil {
+				block = map[string]any{}
+			}
+			blockAt(idx)
+			content[idx] = block
+
+		case "content_block_delta":
+			idx := eventIndex(event)
+			delta, _ := event["delta"].(map[string]any)
+			if delta == nil {
+				continue
+			}
+			block := blockAt(idx)
+			switch deltaType, _ := delta["type"].(string); deltaType {
+			case "text_delta":
+				appendStringField(block, "text", delta["text"])
+			case "thinking_delta":
+				appendStringField(block, "thinking", delta["thinking"])
+			case "signature_delta":
+				appendStringField(block, "signature", delta["signature"])
+			case "input_json_delta":
+				if fragment, ok := delta["partial_json"].(string); ok {
+					sb := toolInput[idx]
+					if sb == nil {
+						sb = &strings.Builder{}
+						toolInput[idx] = sb
+					}
+					sb.WriteString(fragment)
+				}
+			case "citations_delta":
+				if citation, ok := delta["citation"].(map[string]any); ok {
+					existing, _ := block["citations"].([]any)
+					block["citations"] = append(existing, citation)
+				}
+			}
+
+		case "content_block_stop":
+			idx := eventIndex(event)
+			sb := toolInput[idx]
+			if sb == nil {
+				continue
+			}
+			delete(toolInput, idx)
+			var input any
+			if err := json.Unmarshal([]byte(cmp.Or(sb.String(), "{}")), &input); err == nil {
+				blockAt(idx)["input"] = input
+			}
+			// A fragment set that does not parse leaves the block's original
+			// input in place, mirroring parseSSE's "{}" fallback rather than
+			// failing the response.
+
+		case "message_delta":
+			if message == nil {
+				continue
+			}
+			// stop_reason, stop_sequence and container all arrive inside
+			// delta, at the same position they occupy in a complete Message.
+			if delta, ok := event["delta"].(map[string]any); ok {
+				for k, v := range delta {
+					message[k] = v
+				}
+			}
+			// usage and context_management arrive at the event's top level.
+			if u, ok := event["usage"].(map[string]any); ok {
+				existing, _ := message["usage"].(map[string]any)
+				if existing == nil {
+					existing = map[string]any{}
+					message["usage"] = existing
+				}
+				// message_start's usage carries input-side counts; the delta
+				// supersedes the output-side ones it repeats.
+				for k, v := range u {
+					existing[k] = v
+				}
+			}
+			if cm, ok := event["context_management"]; ok {
+				message["context_management"] = cm
+			}
+
+		case "error":
+			return []byte(data), nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading stream: %w", err)
+	}
+	if message == nil {
+		// No message_start: either an empty body or a stream that failed
+		// before the envelope arrived.
+		return nil, &goai.APIError{Message: "anthropic: stream ended before message_start"}
+	}
+
+	// A stream truncated after message_start still yields whatever content
+	// arrived; parseResponse maps the absent stop_reason to FinishOther,
+	// which is more useful to a caller than discarding the response.
+	message["content"] = content
+	out, err := json.Marshal(message)
+	if err != nil {
+		return nil, fmt.Errorf("reassembling streamed message: %w", err)
+	}
+	return out, nil
+}
+
+// eventIndex reads an SSE event's content block index. A missing or
+// non-numeric index is treated as 0, which is the only block a stream
+// omitting the field could be describing.
+func eventIndex(event map[string]any) int {
+	idx, _ := event["index"].(float64)
+	if idx < 0 {
+		return 0
+	}
+	return int(idx)
+}
+
+// appendStringField concatenates a streamed delta onto a content block field,
+// creating it when the first fragment arrives.
+func appendStringField(block map[string]any, key string, value any) {
+	fragment, ok := value.(string)
+	if !ok {
+		return
+	}
+	existing, _ := block[key].(string)
+	block[key] = existing + fragment
 }
 
 func parseResponse(body []byte) (*provider.GenerateResult, error) {

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -4398,6 +4398,32 @@ func TestAccumulateStreamedMessage_Parity(t *testing.T) {
 			),
 			complete: `{"id":"msg_5","model":"claude-sonnet-5","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":3,"iterations":[{"type":"assistant","input_tokens":5,"output_tokens":3}]},"context_management":{"applied_edits":[{"type":"clear_tool_uses_20250919"}]}}`,
 		},
+		{
+			name: "citations arrive via citations_delta",
+			stream: sseFrames(
+				`{"type":"message_start","message":{"id":"msg_6","model":"claude-sonnet-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":5}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"See source."}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"web","cited_text":"src","url":"https://example.com","title":"Example"}}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+				`{"type":"message_stop"}`,
+			),
+			complete: `{"id":"msg_6","model":"claude-sonnet-5","type":"message","role":"assistant","content":[{"type":"text","text":"See source.","citations":[{"type":"web","cited_text":"src","url":"https://example.com","title":"Example"}]}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":4}}`,
+		},
+		{
+			name: "server tool use and its result block",
+			stream: sseFrames(
+				`{"type":"message_start","message":{"id":"msg_7","model":"claude-sonnet-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":5}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"toolu_web","name":"web_search","input":{}}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"toolu_web","content":[{"type":"text","text":"result"}]}}`,
+				`{"type":"content_block_stop","index":1}`,
+				`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":4}}`,
+				`{"type":"message_stop"}`,
+			),
+			complete: `{"id":"msg_7","model":"claude-sonnet-5","type":"message","role":"assistant","content":[{"type":"server_tool_use","id":"toolu_web","name":"web_search","input":{}},{"type":"web_search_tool_result","tool_use_id":"toolu_web","content":[{"type":"text","text":"result"}]}],"stop_reason":"tool_use","usage":{"input_tokens":5,"output_tokens":4}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -4456,28 +4482,43 @@ func TestAccumulateStreamedMessage_NoMessageStart(t *testing.T) {
 }
 
 func TestAccumulateStreamedMessage_TruncatedStream(t *testing.T) {
-	// A stream cut off mid-message still yields the content that arrived;
-	// discarding it would lose a partial answer the caller can use.
+	// A stream cut off before message_stop is a protocol error: reporting the
+	// partial text as a complete generation would hide a truncated response.
 	stream := sseFrames(
 		`{"type":"message_start","message":{"id":"msg_t","model":"claude-sonnet-5","type":"message","content":[],"usage":{"input_tokens":9}}}`,
 		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
 		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`,
 	)
 
-	body, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
-	if err != nil {
-		t.Fatalf("accumulateStreamedMessage: %v", err)
+	_, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err == nil {
+		t.Fatal("expected a protocol error for a stream truncated before message_stop")
 	}
-	result, err := parseResponse(body)
-	if err != nil {
-		t.Fatalf("parseResponse: %v", err)
-	}
-	if result.Text != "partial" {
-		t.Errorf("Text = %q, want %q", result.Text, "partial")
+	if !strings.Contains(err.Error(), "message_stop") {
+		t.Errorf("error = %q, want it to mention message_stop", err.Error())
 	}
 }
 
-func TestAccumulateStreamedMessage_MalformedFrameSkipped(t *testing.T) {
+func TestAccumulateStreamedMessage_UnclosedBlock(t *testing.T) {
+	// A stream that stops after starting a content block but never stops it is
+	// malformed even if message_stop arrives.
+	stream := sseFrames(
+		`{"type":"message_start","message":{"id":"msg_b","model":"claude-sonnet-5","type":"message","content":[],"usage":{"input_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`,
+		`{"type":"message_stop"}`,
+	)
+	_, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err == nil {
+		t.Fatal("expected a protocol error for an unclosed content block")
+	}
+	if !strings.Contains(err.Error(), "unclosed") {
+		t.Errorf("error = %q, want it to mention an unclosed block", err.Error())
+	}
+}
+
+func TestAccumulateStreamedMessage_MalformedFrame(t *testing.T) {
+	// A frame that is not valid JSON is a protocol error, not a frame to skip.
 	stream := sseFrames(
 		`{"type":"message_start","message":{"id":"msg_m","model":"claude-sonnet-5","type":"message","content":[],"usage":{"input_tokens":1}}}`,
 		`not json at all`,
@@ -4488,22 +4529,18 @@ func TestAccumulateStreamedMessage_MalformedFrameSkipped(t *testing.T) {
 		`{"type":"message_stop"}`,
 	)
 
-	body, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
-	if err != nil {
-		t.Fatalf("accumulateStreamedMessage: %v", err)
+	_, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err == nil {
+		t.Fatal("expected a protocol error for a malformed stream frame")
 	}
-	result, err := parseResponse(body)
-	if err != nil {
-		t.Fatalf("parseResponse: %v", err)
-	}
-	if result.Text != "fine" {
-		t.Errorf("Text = %q, want %q", result.Text, "fine")
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("error = %q, want it to mention a malformed frame", err.Error())
 	}
 }
 
-func TestAccumulateStreamedMessage_UnparseableToolInputKeepsBlock(t *testing.T) {
-	// Fragments that never form valid JSON must not discard the tool call
-	// itself; the block's original input stands.
+func TestAccumulateStreamedMessage_UnparseableToolInput(t *testing.T) {
+	// Fragments that never form valid JSON are a malformed stream and must not
+	// be reported as a successful tool call with {} input.
 	stream := sseFrames(
 		`{"type":"message_start","message":{"id":"msg_u","model":"claude-sonnet-5","type":"message","content":[],"usage":{"input_tokens":1}}}`,
 		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_9","name":"read","input":{}}}`,
@@ -4513,19 +4550,28 @@ func TestAccumulateStreamedMessage_UnparseableToolInputKeepsBlock(t *testing.T) 
 		`{"type":"message_stop"}`,
 	)
 
-	body, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
-	if err != nil {
-		t.Fatalf("accumulateStreamedMessage: %v", err)
+	_, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err == nil {
+		t.Fatal("expected a protocol error for unparseable tool input")
 	}
-	result, err := parseResponse(body)
-	if err != nil {
-		t.Fatalf("parseResponse: %v", err)
+	if !strings.Contains(err.Error(), "tool input") {
+		t.Errorf("error = %q, want it to mention tool input", err.Error())
 	}
-	if len(result.ToolCalls) != 1 {
-		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
-	}
-	if result.ToolCalls[0].Name != "read" {
-		t.Errorf("tool name = %q, want read", result.ToolCalls[0].Name)
+}
+
+func TestAccumulateStreamedMessage_BoundedIndex(t *testing.T) {
+	// A hostile or corrupted index must be rejected, not trigger unbounded
+	// allocation.
+	for _, idx := range []string{"1000000000", "-1", "0.5"} {
+		stream := sseFrames(
+			`{"type":"message_start","message":{"id":"msg_i","model":"claude-sonnet-5","type":"message","content":[]}}`,
+			`{"type":"content_block_start","index":`+idx+`,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_stop","index":`+idx+`}`,
+			`{"type":"message_stop"}`,
+		)
+		if _, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream)); err == nil {
+			t.Errorf("expected a protocol error for content block index %s", idx)
+		}
 	}
 }
 
@@ -4585,6 +4631,7 @@ func TestUseStreamingTransport_ExplicitOverride(t *testing.T) {
 		modelID string
 		opts    map[string]any
 		want    bool
+		wantErr bool
 	}{
 		{
 			name:    "explicit false beats thinks-by-default",
@@ -4599,21 +4646,52 @@ func TestUseStreamingTransport_ExplicitOverride(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "non-bool value falls through to willThink",
+			name:    "non-bool value is rejected",
 			modelID: "claude-sonnet-5",
 			opts:    map[string]any{"streamingTransport": "yes"},
-			want:    true,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &chatModel{id: tt.modelID}
-			got := m.useStreamingTransport(provider.GenerateParams{ProviderOptions: tt.opts})
+			got, err := m.useStreamingTransport(provider.GenerateParams{ProviderOptions: tt.opts})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error for a non-boolean streamingTransport, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("useStreamingTransport: %v", err)
+			}
 			if got != tt.want {
 				t.Errorf("useStreamingTransport = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestUseStreamingTransport_ProviderAware(t *testing.T) {
+	// Auto-streaming is disabled for adapters that opt out (e.g. Bedrock,
+	// whose streaming endpoint needs a different IAM permission), even for a
+	// model that thinks by default.
+	m := &chatModel{id: "claude-sonnet-5", opts: options{autoStreaming: false}}
+	got, err := m.useStreamingTransport(provider.GenerateParams{})
+	if err != nil {
+		t.Fatalf("useStreamingTransport: %v", err)
+	}
+	if got {
+		t.Error("auto-streaming must be disabled when the adapter opts out")
+	}
+	// An explicit override still wins.
+	got, err = m.useStreamingTransport(provider.GenerateParams{ProviderOptions: map[string]any{"streamingTransport": true}})
+	if err != nil {
+		t.Fatalf("useStreamingTransport: %v", err)
+	}
+	if !got {
+		t.Error("explicit streamingTransport=true must win over the adapter opt-out")
 	}
 }
 

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -4302,5 +4303,408 @@ func TestTransformNativeOutputSchema_PropertyNameCollision(t *testing.T) {
 	// A malformed name-keyed value must not panic.
 	if _, err := transformNativeOutputSchema(map[string]any{"properties": "not-a-map"}); err == nil {
 		t.Error("expected an error for a non-object properties value")
+	}
+}
+
+// sseFrames joins event JSON documents into an SSE body.
+func sseFrames(events ...string) string {
+	var b strings.Builder
+	for _, e := range events {
+		b.WriteString("data: " + e + "\n\n")
+	}
+	return b.String()
+}
+
+// TestAccumulateStreamedMessage_Parity is the load-bearing test for the
+// streaming transport: the same Message delivered as an event stream and as a
+// single non-streaming response must parse to identical results. If this
+// holds, DoGenerate's two transports are interchangeable by construction and
+// no field can be silently lost in reassembly.
+//
+// Tool inputs in the complete fixtures are written in Go's canonical
+// marshalling form (keys sorted, no whitespace) because the streamed side is
+// re-marshalled from a decoded map; a semantically equal but differently
+// formatted fixture would fail on json.RawMessage byte comparison.
+func TestAccumulateStreamedMessage_Parity(t *testing.T) {
+	tests := []struct {
+		name     string
+		stream   string
+		complete string
+	}{
+		{
+			name: "text only",
+			stream: sseFrames(
+				`{"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":15,"cache_read_input_tokens":5}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":8}}`,
+				`{"type":"message_stop"}`,
+			),
+			complete: `{"id":"msg_1","model":"claude-sonnet-5","type":"message","role":"assistant","content":[{"type":"text","text":"Hello world"}],"stop_reason":"end_turn","usage":{"input_tokens":15,"cache_read_input_tokens":5,"output_tokens":8}}`,
+		},
+		{
+			name: "thinking block with signature is preserved verbatim",
+			stream: sseFrames(
+				`{"type":"message_start","message":{"id":"msg_2","model":"claude-opus-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":20}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me "}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"consider."}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EqQBCgIY"}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"AhgCIkAw"}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+				`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer."}}`,
+				`{"type":"content_block_stop","index":1}`,
+				`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":30,"output_tokens_details":{"thinking_tokens":22}}}`,
+				`{"type":"message_stop"}`,
+			),
+			complete: `{"id":"msg_2","model":"claude-opus-5","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"Let me consider.","signature":"EqQBCgIYAhgCIkAw"},{"type":"text","text":"Answer."}],"stop_reason":"end_turn","usage":{"input_tokens":20,"output_tokens":30,"output_tokens_details":{"thinking_tokens":22}}}`,
+		},
+		{
+			name: "tool_use input reassembled from fragments",
+			stream: sseFrames(
+				`{"type":"message_start","message":{"id":"msg_3","model":"claude-sonnet-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":30}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"read","input":{}}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\""}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"a.go\"}"}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":12}}`,
+				`{"type":"message_stop"}`,
+			),
+			complete: `{"id":"msg_3","model":"claude-sonnet-5","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"read","input":{"path":"a.go"}}],"stop_reason":"tool_use","usage":{"input_tokens":30,"output_tokens":12}}`,
+		},
+		{
+			name: "redacted_thinking arrives complete in content_block_start",
+			stream: sseFrames(
+				`{"type":"message_start","message":{"id":"msg_4","model":"claude-opus-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":10}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"EncryptedPayload"}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+				`{"type":"message_stop"}`,
+			),
+			complete: `{"id":"msg_4","model":"claude-opus-5","type":"message","role":"assistant","content":[{"type":"redacted_thinking","data":"EncryptedPayload"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":4}}`,
+		},
+		{
+			name: "usage iterations and context_management",
+			stream: sseFrames(
+				`{"type":"message_start","message":{"id":"msg_5","model":"claude-sonnet-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":5}}}`,
+				`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+				`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+				`{"type":"content_block_stop","index":0}`,
+				`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3,"iterations":[{"type":"assistant","input_tokens":5,"output_tokens":3}]},"context_management":{"applied_edits":[{"type":"clear_tool_uses_20250919"}]}}`,
+				`{"type":"message_stop"}`,
+			),
+			complete: `{"id":"msg_5","model":"claude-sonnet-5","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":3,"iterations":[{"type":"assistant","input_tokens":5,"output_tokens":3}]},"context_management":{"applied_edits":[{"type":"clear_tool_uses_20250919"}]}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accumulated, err := accumulateStreamedMessage(t.Context(), strings.NewReader(tt.stream))
+			if err != nil {
+				t.Fatalf("accumulateStreamedMessage: %v", err)
+			}
+
+			gotStreamed, err := parseResponse(accumulated)
+			if err != nil {
+				t.Fatalf("parseResponse(streamed): %v", err)
+			}
+			gotComplete, err := parseResponse([]byte(tt.complete))
+			if err != nil {
+				t.Fatalf("parseResponse(complete): %v", err)
+			}
+
+			if !reflect.DeepEqual(gotStreamed, gotComplete) {
+				t.Errorf("streamed and non-streaming results differ\nstreamed: %#v\ncomplete: %#v\nreassembled JSON: %s",
+					gotStreamed, gotComplete, accumulated)
+			}
+		})
+	}
+}
+
+func TestAccumulateStreamedMessage_ErrorEvent(t *testing.T) {
+	stream := sseFrames(
+		`{"type":"message_start","message":{"id":"msg_e","model":"claude-sonnet-5","content":[]}}`,
+		`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+	)
+
+	body, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("accumulateStreamedMessage: %v", err)
+	}
+
+	// The error envelope is handed to parseResponse unchanged so that error
+	// classification stays in one place.
+	if _, err = parseResponse(body); err == nil {
+		t.Fatal("expected parseResponse to report the streamed error event")
+	}
+	var apiErr *goai.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *goai.APIError, got %T: %v", err, err)
+	}
+	if !strings.Contains(apiErr.Message, "Overloaded") {
+		t.Errorf("error message = %q, want it to mention Overloaded", apiErr.Message)
+	}
+}
+
+func TestAccumulateStreamedMessage_NoMessageStart(t *testing.T) {
+	if _, err := accumulateStreamedMessage(t.Context(), strings.NewReader("")); err == nil {
+		t.Fatal("expected an error when the stream carries no message_start")
+	}
+}
+
+func TestAccumulateStreamedMessage_TruncatedStream(t *testing.T) {
+	// A stream cut off mid-message still yields the content that arrived;
+	// discarding it would lose a partial answer the caller can use.
+	stream := sseFrames(
+		`{"type":"message_start","message":{"id":"msg_t","model":"claude-sonnet-5","type":"message","content":[],"usage":{"input_tokens":9}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`,
+	)
+
+	body, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("accumulateStreamedMessage: %v", err)
+	}
+	result, err := parseResponse(body)
+	if err != nil {
+		t.Fatalf("parseResponse: %v", err)
+	}
+	if result.Text != "partial" {
+		t.Errorf("Text = %q, want %q", result.Text, "partial")
+	}
+}
+
+func TestAccumulateStreamedMessage_MalformedFrameSkipped(t *testing.T) {
+	stream := sseFrames(
+		`{"type":"message_start","message":{"id":"msg_m","model":"claude-sonnet-5","type":"message","content":[],"usage":{"input_tokens":1}}}`,
+		`not json at all`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"fine"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	body, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("accumulateStreamedMessage: %v", err)
+	}
+	result, err := parseResponse(body)
+	if err != nil {
+		t.Fatalf("parseResponse: %v", err)
+	}
+	if result.Text != "fine" {
+		t.Errorf("Text = %q, want %q", result.Text, "fine")
+	}
+}
+
+func TestAccumulateStreamedMessage_UnparseableToolInputKeepsBlock(t *testing.T) {
+	// Fragments that never form valid JSON must not discard the tool call
+	// itself; the block's original input stands.
+	stream := sseFrames(
+		`{"type":"message_start","message":{"id":"msg_u","model":"claude-sonnet-5","type":"message","content":[],"usage":{"input_tokens":1}}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_9","name":"read","input":{}}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":2}}`,
+		`{"type":"message_stop"}`,
+	)
+
+	body, err := accumulateStreamedMessage(t.Context(), strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("accumulateStreamedMessage: %v", err)
+	}
+	result, err := parseResponse(body)
+	if err != nil {
+		t.Fatalf("parseResponse: %v", err)
+	}
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(result.ToolCalls))
+	}
+	if result.ToolCalls[0].Name != "read" {
+		t.Errorf("tool name = %q, want read", result.ToolCalls[0].Name)
+	}
+}
+
+func TestWillThink(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		opts    map[string]any
+		want    bool
+	}{
+		{name: "5.x thinks with no parameter at all", modelID: "claude-sonnet-5", want: true},
+		{name: "opus 5 thinks by default", modelID: "claude-opus-5", want: true},
+		{name: "fable 5 thinks by default", modelID: "claude-fable-5", want: true},
+		{name: "4.8 only on request", modelID: "claude-opus-4-8", want: false},
+		{
+			name:    "4.8 with explicit thinking",
+			modelID: "claude-opus-4-8",
+			opts:    map[string]any{"thinking": map[string]any{"type": "adaptive"}},
+			want:    true,
+		},
+		{
+			name:    "4.7 with effort",
+			modelID: "claude-opus-4-7",
+			opts:    map[string]any{"effort": "medium"},
+			want:    true,
+		},
+		{
+			name:    "4.6 with budget_tokens thinking",
+			modelID: "claude-sonnet-4-6",
+			opts:    map[string]any{"thinking": map[string]any{"type": "enabled", "budgetTokens": 4000}},
+			want:    true,
+		},
+		{name: "4.6 without thinking", modelID: "claude-sonnet-4-6", want: false},
+		{
+			name:    "model that cannot think ignores the option",
+			modelID: "claude-3-5-sonnet-20241022",
+			opts:    map[string]any{"thinking": map[string]any{"type": "enabled"}},
+			want:    false,
+		},
+		{name: "bedrock-prefixed 5.x still detected", modelID: "us.anthropic.claude-sonnet-5", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &chatModel{id: tt.modelID}
+			got := m.willThink(provider.GenerateParams{ProviderOptions: tt.opts})
+			if got != tt.want {
+				t.Errorf("willThink(%q) = %v, want %v", tt.modelID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUseStreamingTransport_ExplicitOverride(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		opts    map[string]any
+		want    bool
+	}{
+		{
+			name:    "explicit false beats thinks-by-default",
+			modelID: "claude-sonnet-5",
+			opts:    map[string]any{"streamingTransport": false},
+			want:    false,
+		},
+		{
+			name:    "explicit true beats a non-thinking model",
+			modelID: "claude-sonnet-4-6",
+			opts:    map[string]any{"streamingTransport": true},
+			want:    true,
+		},
+		{
+			name:    "non-bool value falls through to willThink",
+			modelID: "claude-sonnet-5",
+			opts:    map[string]any{"streamingTransport": "yes"},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &chatModel{id: tt.modelID}
+			got := m.useStreamingTransport(provider.GenerateParams{ProviderOptions: tt.opts})
+			if got != tt.want {
+				t.Errorf("useStreamingTransport = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDoGenerate_UsesStreamingTransportForThinkingModels is the end-to-end
+// check: a thinking model's DoGenerate must request stream:true, consume SSE,
+// and still return a normal GenerateResult — including the thinking signature
+// that provider.StreamChunk cannot carry.
+func TestDoGenerate_UsesStreamingTransportForThinkingModels(t *testing.T) {
+	var gotStream any
+	var gotStreamingTransportOnWire bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStream = body["stream"]
+		_, gotStreamingTransportOnWire = body["streamingTransport"]
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, sseFrames(
+			`{"type":"message_start","message":{"id":"msg_e2e","model":"claude-sonnet-5","type":"message","role":"assistant","content":[],"usage":{"input_tokens":11}}}`,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"SigABC"}}`,
+			`{"type":"content_block_stop","index":0}`,
+			`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"done"}}`,
+			`{"type":"content_block_stop","index":1}`,
+			`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":7}}`,
+			`{"type":"message_stop"}`,
+		))
+	}))
+	defer server.Close()
+
+	model := Chat("claude-sonnet-5", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	if gotStream != true {
+		t.Errorf("request stream = %v, want true", gotStream)
+	}
+	if gotStreamingTransportOnWire {
+		t.Error("streamingTransport leaked onto the wire; it is an SDK-internal key")
+	}
+	if result.Text != "done" {
+		t.Errorf("Text = %q, want %q", result.Text, "done")
+	}
+	if result.Reasoning != "hmm" {
+		t.Errorf("Reasoning = %q, want %q", result.Reasoning, "hmm")
+	}
+	if result.Usage.OutputTokens != 7 {
+		t.Errorf("OutputTokens = %d, want 7", result.Usage.OutputTokens)
+	}
+	// The signature is the field a chunk-based reassembly would have dropped.
+	if !strings.Contains(fmt.Sprint(result.ProviderMetadata), "SigABC") {
+		t.Errorf("thinking signature missing from ProviderMetadata: %v", result.ProviderMetadata)
+	}
+}
+
+func TestDoGenerate_NonThinkingModelStaysNonStreaming(t *testing.T) {
+	var gotStream any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStream = body["stream"]
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg_ns","model":"claude-sonnet-4-6","type":"message","role":"assistant","content":[{"type":"text","text":"plain"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}`)
+	}))
+	defer server.Close()
+
+	model := Chat("claude-sonnet-4-6", WithAPIKey("test-key"), WithBaseURL(server.URL))
+	result, err := model.DoGenerate(t.Context(), provider.GenerateParams{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: []provider.Part{{Type: provider.PartText, Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	if gotStream != false {
+		t.Errorf("request stream = %v, want false for a non-thinking model", gotStream)
+	}
+	if result.Text != "plain" {
+		t.Errorf("Text = %q, want %q", result.Text, "plain")
 	}
 }

--- a/provider/bedrock/anthropic.go
+++ b/provider/bedrock/anthropic.go
@@ -84,6 +84,10 @@ func AnthropicChat(modelID string, opts ...Option) provider.LanguageModel {
 		// Bedrock documents a narrower structured-output set than the direct
 		// Claude API (Opus 4.6, Sonnet 4.6, Sonnet 4.5, Opus 4.5, Haiku 4.5).
 		anthropic.WithNativeOutputFormatSupport(anthropic.NativeOutputFormatBedrock),
+		// Auto-streaming switches DoGenerate to InvokeModelWithResponseStream,
+		// which needs a different IAM permission than InvokeModel. Keep it
+		// opt-in so existing deployments do not regress by default.
+		anthropic.WithAutoStreaming(false),
 	}
 	// Provide a placeholder token source so the anthropic provider's auth
 	// resolution is satisfied. The transport below replaces the request's


### PR DESCRIPTION
## Summary

`DoGenerate` now issues `stream:true` and reassembles the SSE events into the `Message` document a non-streaming call would have returned, whenever the request is expected to think: a `thinking` or `effort` provider option, or a model from the 5.x generation (which thinks with no `thinking` parameter sent at all). Callers can force the decision either way via `ProviderOptions["streamingTransport"]`.

Reassembles the wire document rather than mapping SSE events directly onto `provider.GenerateResult`, because `parseResponse` is the one place that knows how to interpret a `Message`, and it reads several things `provider.StreamChunk` has no field for: thinking-block signatures (which must be replayed verbatim on the next turn), `redacted_thinking` payloads, server tool result blocks, citations, and `container`/`context_management` metadata. `doHTTP` already derives streaming from `body["stream"]`, so Bedrock's and Vertex's URL builders pick the streaming endpoint with no further change.

**Depends on #164** — this branch is stacked on `fix/anthropic-capability-version-detection` (uses its `anthropicModelVersion`/`supportsThinking` helpers), so the diff below currently includes that PR's commit too and will collapse to just this change once #164 merges.

## Changes

- `useStreamingTransport` / `willThink`: transport-selection predicates.
- `accumulateStreamedMessage`: rebuilds the Message wire document from SSE (text, thinking+signature, fragmented tool-input, `redacted_thinking`, usage/`context_management`), tolerating truncated or malformed frames.
- `anthropicProtectedKeys` gains `streamingTransport` (SDK-internal, never sent on the wire).

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (pre-existing `errcheck` findings in `anthropic_test.go`, unrelated to this change)
- [x] New tests added for new functionality — parity test asserting the same `Message` delivered as SSE and as a single response parses identically, plus error/truncation/malformed-frame handling and `willThink`/transport-override coverage
- [ ] Examples updated if public API changed — no public API change

## Related issues

Closes #163